### PR TITLE
Implement warm editorial redesign and sample data loaders

### DIFF
--- a/docs/mockups/data-console-mockup.svg
+++ b/docs/mockups/data-console-mockup.svg
@@ -1,0 +1,178 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" fill="none">
+  <defs>
+    <linearGradient id="bgConsole" x1="0" y1="0" x2="1400" y2="880" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#09111A"/>
+      <stop offset="1" stop-color="#0E1723"/>
+    </linearGradient>
+    <pattern id="grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M24 0H0V24" stroke="#223142" stroke-width="1"/>
+    </pattern>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#3B82F6" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1400" height="880" fill="url(#bgConsole)"/>
+  <rect width="1400" height="880" fill="url(#grid)" opacity="0.5"/>
+
+  <text x="58" y="62" fill="#E8F0FF" font-size="30" font-family="Space Grotesk, Arial" font-weight="700">HabitFlow - Data Console</text>
+  <text x="58" y="90" fill="#93A7C2" font-size="15" font-family="Instrument Sans, Arial">Concept direction: denser panels, stronger grids, neon accents, analytics-first posture</text>
+
+  <rect x="48" y="120" width="1304" height="720" rx="20" fill="#0A131E" stroke="#223246" stroke-width="2"/>
+
+  <!-- Top status bar -->
+  <rect x="68" y="140" width="1264" height="58" rx="14" fill="#0E1A28" stroke="#223246"/>
+  <text x="92" y="175" fill="#DBEAFE" font-size="20" font-family="Space Grotesk, Arial" font-weight="700">HABITFLOW / OPS VIEW</text>
+  <rect x="1108" y="154" width="94" height="30" rx="10" fill="#102338" stroke="#2A4665"/>
+  <text x="1138" y="173" fill="#8AB4FF" font-size="12" font-family="Instrument Sans, Arial" font-weight="700">LIVE</text>
+  <rect x="1212" y="154" width="96" height="30" rx="10" fill="#11261C" stroke="#214F3A"/>
+  <text x="1235" y="173" fill="#6EE7B7" font-size="12" font-family="Instrument Sans, Arial" font-weight="700">SYNC OK</text>
+
+  <!-- Left nav rail -->
+  <rect x="68" y="214" width="220" height="606" rx="14" fill="#0D1826" stroke="#223246"/>
+  <g font-family="Instrument Sans, Arial" font-size="13" font-weight="600">
+    <text x="92" y="248" fill="#7E96B6">ROUTES</text>
+    <rect x="84" y="264" width="188" height="36" rx="10" fill="#102238" stroke="#2A4665"/>
+    <rect x="90" y="272" width="3" height="20" rx="1.5" fill="#3B82F6"/>
+    <text x="106" y="286" fill="#EAF2FF">Today</text>
+    <text x="106" y="330" fill="#A8B7CE">Week Grid</text>
+    <text x="106" y="374" fill="#A8B7CE">Month Grid</text>
+    <text x="106" y="418" fill="#A8B7CE">Habits Table</text>
+    <text x="106" y="462" fill="#A8B7CE">Stats</text>
+    <text x="106" y="506" fill="#A8B7CE">Settings</text>
+  </g>
+
+  <rect x="84" y="566" width="188" height="112" rx="12" fill="#0B1420" stroke="#223246"/>
+  <text x="98" y="592" fill="#8EA4BF" font-size="11" font-family="Instrument Sans, Arial">SHORTCUTS</text>
+  <text x="98" y="618" fill="#D8E6FF" font-size="13" font-family="Instrument Sans, Arial">Cmd + K  command palette</text>
+  <text x="98" y="642" fill="#D8E6FF" font-size="13" font-family="Instrument Sans, Arial">1-9      toggle habits</text>
+  <text x="98" y="666" fill="#D8E6FF" font-size="13" font-family="Instrument Sans, Arial">Left/Right move weeks</text>
+
+  <rect x="84" y="764" width="188" height="40" rx="10" fill="#102238" stroke="#2A4665" filter="url(#glow)"/>
+  <text x="145" y="789" fill="#EAF2FF" font-size="13" font-family="Instrument Sans, Arial" font-weight="700">New Habit</text>
+
+  <!-- Main panels -->
+  <rect x="304" y="214" width="700" height="268" rx="14" fill="#0D1826" stroke="#223246"/>
+  <text x="328" y="246" fill="#8EA4BF" font-size="11" font-family="Instrument Sans, Arial">TODAY / THROUGHPUT</text>
+  <text x="328" y="278" fill="#EAF2FF" font-size="28" font-family="Space Grotesk, Arial" font-weight="700">4 / 6 completed</text>
+  <text x="328" y="300" fill="#9BB0C9" font-size="13" font-family="Instrument Sans, Arial">Realtime checklist with keyboard-first controls and stronger telemetry framing</text>
+
+  <!-- KPI row -->
+  <g font-family="Instrument Sans, Arial">
+    <rect x="328" y="320" width="150" height="64" rx="10" fill="#0A131E" stroke="#223246"/>
+    <rect x="490" y="320" width="150" height="64" rx="10" fill="#0A131E" stroke="#223246"/>
+    <rect x="652" y="320" width="150" height="64" rx="10" fill="#0A131E" stroke="#223246"/>
+    <rect x="814" y="320" width="166" height="64" rx="10" fill="#0A131E" stroke="#223246"/>
+    <text x="342" y="342" fill="#7E96B6" font-size="10">COMPLETION</text>
+    <text x="342" y="368" fill="#60A5FA" font-size="24" font-weight="700">67%</text>
+    <text x="504" y="342" fill="#7E96B6" font-size="10">STREAKING</text>
+    <text x="504" y="368" fill="#F59E0B" font-size="24" font-weight="700">2</text>
+    <text x="666" y="342" fill="#7E96B6" font-size="10">FOCUS AREAS</text>
+    <text x="666" y="368" fill="#34D399" font-size="24" font-weight="700">3</text>
+    <text x="828" y="342" fill="#7E96B6" font-size="10">OPEN ITEMS</text>
+    <text x="828" y="368" fill="#FCA5A5" font-size="24" font-weight="700">2</text>
+  </g>
+
+  <!-- Trend panel in hero -->
+  <rect x="328" y="400" width="652" height="64" rx="10" fill="#0A131E" stroke="#223246"/>
+  <polyline points="346,450 390,438 434,444 478,420 522,430 566,398 610,414 654,390 698,402 742,370 786,384 830,360 874,374 918,352 962,366"
+            fill="none" stroke="#3B82F6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="346,456 390,448 434,452 478,434 522,440 566,422 610,430 654,416 698,422 742,404 786,412 830,398 874,406 918,392 962,396"
+            fill="none" stroke="#38BDF8" stroke-width="1.2" opacity="0.6"/>
+  <line x1="346" y1="458" x2="962" y2="458" stroke="#223246"/>
+
+  <!-- Right stack -->
+  <rect x="1020" y="214" width="312" height="182" rx="14" fill="#0D1826" stroke="#223246"/>
+  <text x="1044" y="246" fill="#8EA4BF" font-size="11" font-family="Instrument Sans, Arial">ALERTS / ANOMALIES</text>
+  <rect x="1044" y="264" width="264" height="34" rx="9" fill="#101C2B" stroke="#24354A"/>
+  <text x="1060" y="285" fill="#DCE8FF" font-size="12" font-family="Instrument Sans, Arial">Read 20 minutes lagging by 2 days</text>
+  <rect x="1044" y="306" width="264" height="34" rx="9" fill="#101C2B" stroke="#24354A"/>
+  <text x="1060" y="327" fill="#DCE8FF" font-size="12" font-family="Instrument Sans, Arial">Sleep target improving (+14%)</text>
+  <rect x="1044" y="348" width="264" height="28" rx="9" fill="#11261C" stroke="#214F3A"/>
+  <text x="1060" y="366" fill="#6EE7B7" font-size="11" font-family="Instrument Sans, Arial">No sync issues detected</text>
+
+  <rect x="1020" y="412" width="312" height="408" rx="14" fill="#0D1826" stroke="#223246"/>
+  <text x="1044" y="444" fill="#8EA4BF" font-size="11" font-family="Instrument Sans, Arial">WEEK GRID / DENSE MODE</text>
+
+  <!-- Mini week table -->
+  <g>
+    <rect x="1044" y="460" width="264" height="338" rx="10" fill="#0A131E" stroke="#223246"/>
+    <g font-family="Instrument Sans, Arial" font-size="10">
+      <text x="1084" y="478" fill="#8EA4BF">M</text>
+      <text x="1120" y="478" fill="#8EA4BF">T</text>
+      <text x="1156" y="478" fill="#8EA4BF">W</text>
+      <text x="1192" y="478" fill="#8EA4BF">T</text>
+      <text x="1228" y="478" fill="#8EA4BF">F</text>
+      <text x="1264" y="478" fill="#8EA4BF">S</text>
+      <text x="1292" y="478" fill="#8EA4BF">S</text>
+    </g>
+    <g>
+      <rect x="1054" y="490" width="90" height="28" rx="7" fill="#0F1D2C"/>
+      <text x="1062" y="508" fill="#CFE0FF" font-size="11" font-family="Instrument Sans, Arial">Walk</text>
+      <rect x="1150" y="490" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1186" y="490" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1222" y="490" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1258" y="490" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1294" y="490" width="4" height="20" rx="2" fill="#34D399"/>
+    </g>
+    <g>
+      <rect x="1054" y="526" width="90" height="28" rx="7" fill="#0F1D2C"/>
+      <text x="1062" y="544" fill="#CFE0FF" font-size="11" font-family="Instrument Sans, Arial">Read</text>
+      <rect x="1150" y="526" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1186" y="526" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1222" y="526" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1258" y="526" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1294" y="526" width="4" height="20" rx="2" fill="#F59E0B"/>
+    </g>
+    <g>
+      <rect x="1054" y="562" width="90" height="28" rx="7" fill="#0F1D2C"/>
+      <text x="1062" y="580" fill="#CFE0FF" font-size="11" font-family="Instrument Sans, Arial">Journal</text>
+      <rect x="1150" y="562" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1186" y="562" width="20" height="20" rx="6" fill="#1F2F42"/>
+      <rect x="1222" y="562" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1258" y="562" width="20" height="20" rx="6" fill="#3B82F6"/>
+      <rect x="1294" y="562" width="4" height="20" rx="2" fill="#F472B6"/>
+    </g>
+    <g>
+      <rect x="1054" y="610" width="244" height="172" rx="8" fill="#09111A" stroke="#223246"/>
+      <text x="1066" y="632" fill="#8EA4BF" font-size="10" font-family="Instrument Sans, Arial">Legend</text>
+      <rect x="1066" y="644" width="10" height="10" rx="2" fill="#3B82F6"/><text x="1084" y="653" fill="#DCE8FF" font-size="10" font-family="Instrument Sans, Arial">Completed</text>
+      <rect x="1160" y="644" width="10" height="10" rx="2" fill="#1F2F42"/><text x="1178" y="653" fill="#DCE8FF" font-size="10" font-family="Instrument Sans, Arial">Scheduled</text>
+      <rect x="1250" y="644" width="10" height="10" rx="2" fill="none" stroke="#6A7C97"/><text x="1268" y="653" fill="#DCE8FF" font-size="10" font-family="Instrument Sans, Arial">Future</text>
+      <text x="1066" y="684" fill="#8EA4BF" font-size="10" font-family="Instrument Sans, Arial">This direction makes analytics and planning feel like a command center.</text>
+    </g>
+  </g>
+
+  <!-- Bottom panel: habits table -->
+  <rect x="304" y="498" width="700" height="322" rx="14" fill="#0D1826" stroke="#223246"/>
+  <text x="328" y="530" fill="#8EA4BF" font-size="11" font-family="Instrument Sans, Arial">HABITS / TABLE VIEW</text>
+  <rect x="328" y="546" width="652" height="42" rx="10" fill="#0A131E" stroke="#223246"/>
+  <text x="346" y="571" fill="#A7BAD4" font-size="12" font-family="Instrument Sans, Arial">Search habits...</text>
+  <rect x="838" y="554" width="132" height="26" rx="8" fill="#102238" stroke="#2A4665"/>
+  <text x="880" y="571" fill="#AFC9F8" font-size="11" font-family="Instrument Sans, Arial">Filter: Health</text>
+
+  <g font-family="Instrument Sans, Arial" font-size="12">
+    <rect x="328" y="602" width="652" height="44" rx="10" fill="#0A131E" stroke="#1F3144"/>
+    <rect x="328" y="650" width="652" height="44" rx="10" fill="#09111A" stroke="#1A2B3D"/>
+    <rect x="328" y="698" width="652" height="44" rx="10" fill="#0A131E" stroke="#1F3144"/>
+    <rect x="328" y="746" width="652" height="44" rx="10" fill="#09111A" stroke="#1A2B3D"/>
+    <text x="348" y="629" fill="#E4EEFF">Morning walk</text>
+    <text x="348" y="677" fill="#E4EEFF">Read 20 minutes</text>
+    <text x="348" y="725" fill="#E4EEFF">Journal</text>
+    <text x="348" y="773" fill="#E4EEFF">Stretching</text>
+    <text x="520" y="629" fill="#9DB1CB">Daily</text>
+    <text x="520" y="677" fill="#9DB1CB">Daily</text>
+    <text x="520" y="725" fill="#9DB1CB">Mon/Wed/Fri</text>
+    <text x="520" y="773" fill="#9DB1CB">Daily</text>
+    <text x="690" y="629" fill="#60A5FA">86%</text>
+    <text x="690" y="677" fill="#60A5FA">72%</text>
+    <text x="690" y="725" fill="#60A5FA">54%</text>
+    <text x="690" y="773" fill="#60A5FA">78%</text>
+    <text x="826" y="629" fill="#F59E0B">12d</text>
+    <text x="826" y="677" fill="#F59E0B">5d</text>
+    <text x="826" y="725" fill="#F59E0B">3d</text>
+    <text x="826" y="773" fill="#F59E0B">8d</text>
+    <rect x="904" y="613" width="64" height="20" rx="6" fill="#11261C" stroke="#214F3A"/>
+    <text x="924" y="627" fill="#6EE7B7" font-size="10">ACTIVE</text>
+  </g>
+</svg>

--- a/docs/mockups/minimal-calm-mockup.svg
+++ b/docs/mockups/minimal-calm-mockup.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" fill="none">
+  <defs>
+    <linearGradient id="bgCalm" x1="0" y1="0" x2="1400" y2="880" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FAFBF8"/>
+      <stop offset="1" stop-color="#F1F3EC"/>
+    </linearGradient>
+    <radialGradient id="mist" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1080 140) rotate(10) scale(420 220)">
+      <stop stop-color="#D7E8D9" stop-opacity="0.55"/>
+      <stop offset="1" stop-color="#D7E8D9" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1400" height="880" fill="url(#bgCalm)"/>
+  <rect width="1400" height="880" fill="url(#mist)"/>
+
+  <text x="58" y="62" fill="#1F2A20" font-size="30" font-family="Space Grotesk, Arial" font-weight="700">HabitFlow - Minimal Calm</text>
+  <text x="58" y="90" fill="#647065" font-size="15" font-family="Instrument Sans, Arial">Concept direction: quiet whitespace, subtle borders, one restrained accent, fast daily completion flow</text>
+
+  <rect x="56" y="124" width="1288" height="708" rx="28" fill="#FBFCF9" stroke="#DFE5DA"/>
+
+  <!-- Header strip -->
+  <text x="92" y="178" fill="#748173" font-size="11" font-family="Instrument Sans, Arial" letter-spacing="2">DAILY FOCUS</text>
+  <text x="92" y="218" fill="#1D251E" font-size="38" font-family="Space Grotesk, Arial" font-weight="700">Today</text>
+  <text x="92" y="244" fill="#556055" font-size="15" font-family="Instrument Sans, Arial">Wednesday, February 25 - calm mode for quick completion</text>
+  <rect x="1148" y="174" width="140" height="38" rx="19" fill="#1F6B3B"/>
+  <text x="1191" y="198" fill="white" font-size="13" font-family="Instrument Sans, Arial" font-weight="700">New Habit</text>
+
+  <line x1="88" y1="270" x2="1312" y2="270" stroke="#E1E7DE"/>
+
+  <!-- Left content -->
+  <rect x="92" y="300" width="760" height="148" rx="18" fill="#FFFFFF" stroke="#E2E8E0"/>
+  <text x="116" y="330" fill="#6B766A" font-size="11" font-family="Instrument Sans, Arial" letter-spacing="1.5">TODAY</text>
+  <text x="116" y="367" fill="#1E2620" font-size="30" font-family="Space Grotesk, Arial" font-weight="700">4 of 6 habits done</text>
+  <text x="116" y="392" fill="#576258" font-size="14" font-family="Instrument Sans, Arial">Keep momentum. Finish two more before evening.</text>
+  <rect x="116" y="412" width="612" height="8" rx="4" fill="#E8EEE6"/>
+  <rect x="116" y="412" width="408" height="8" rx="4" fill="#1F6B3B"/>
+  <text x="742" y="418" fill="#1F6B3B" font-size="12" font-family="Instrument Sans, Arial" font-weight="700">67%</text>
+
+  <!-- Checklist -->
+  <rect x="92" y="470" width="760" height="310" rx="18" fill="#FFFFFF" stroke="#E2E8E0"/>
+  <text x="116" y="504" fill="#1F2721" font-size="16" font-family="Space Grotesk, Arial" font-weight="700">Checklist</text>
+  <text x="116" y="524" fill="#6A766C" font-size="12" font-family="Instrument Sans, Arial">Tap to complete. Open habit for detail.</text>
+  <text x="758" y="504" fill="#5D685E" font-size="12" font-family="Instrument Sans, Arial">Manage habits</text>
+
+  <g font-family="Instrument Sans, Arial">
+    <line x1="116" y1="544" x2="828" y2="544" stroke="#EDF1EB"/>
+    <line x1="116" y1="600" x2="828" y2="600" stroke="#EDF1EB"/>
+    <line x1="116" y1="656" x2="828" y2="656" stroke="#EDF1EB"/>
+    <line x1="116" y1="712" x2="828" y2="712" stroke="#EDF1EB"/>
+
+    <circle cx="130" cy="572" r="10" fill="#1F6B3B"/>
+    <path d="M125 572l3 3 7-8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="130" cy="628" r="10" fill="white" stroke="#C9D3C8"/>
+    <circle cx="130" cy="684" r="10" fill="white" stroke="#C9D3C8"/>
+    <circle cx="130" cy="740" r="10" fill="white" stroke="#C9D3C8"/>
+
+    <text x="154" y="576" fill="#5E675F" font-size="14" text-decoration="line-through">Morning walk</text>
+    <text x="154" y="632" fill="#1F2721" font-size="14" font-weight="600">Read 20 minutes</text>
+    <text x="154" y="688" fill="#1F2721" font-size="14" font-weight="600">Journal</text>
+    <text x="154" y="744" fill="#1F2721" font-size="14" font-weight="600">Stretching</text>
+
+    <text x="708" y="576" fill="#7A847A" font-size="12">Health</text>
+    <text x="708" y="632" fill="#7A847A" font-size="12">Learning</text>
+    <text x="708" y="688" fill="#7A847A" font-size="12">Mindset</text>
+    <text x="708" y="744" fill="#7A847A" font-size="12">Mobility</text>
+  </g>
+
+  <!-- Right rail -->
+  <rect x="876" y="300" width="436" height="226" rx="18" fill="#FFFFFF" stroke="#E2E8E0"/>
+  <text x="900" y="334" fill="#1E2620" font-size="16" font-family="Space Grotesk, Arial" font-weight="700">Weekly rhythm</text>
+  <text x="900" y="354" fill="#677368" font-size="12" font-family="Instrument Sans, Arial">Low noise analytics for quick review</text>
+
+  <!-- Calm chart -->
+  <line x1="900" y1="484" x2="1278" y2="484" stroke="#EEF2EC"/>
+  <line x1="900" y1="444" x2="1278" y2="444" stroke="#F4F7F3"/>
+  <line x1="900" y1="404" x2="1278" y2="404" stroke="#F4F7F3"/>
+  <polyline points="916,470 964,456 1012,462 1060,434 1108,442 1156,418 1204,426 1252,392"
+            fill="none" stroke="#1F6B3B" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="1252" cy="392" r="4" fill="#1F6B3B"/>
+  <text x="1220" y="384" fill="#1F6B3B" font-size="11" font-family="Instrument Sans, Arial">today</text>
+
+  <rect x="876" y="544" width="436" height="236" rx="18" fill="#FFFFFF" stroke="#E2E8E0"/>
+  <text x="900" y="578" fill="#1E2620" font-size="16" font-family="Space Grotesk, Arial" font-weight="700">Habits list (minimal variant)</text>
+  <text x="900" y="598" fill="#677368" font-size="12" font-family="Instrument Sans, Arial">Rows feel lighter, with status shown through spacing and color restraint</text>
+
+  <g font-family="Instrument Sans, Arial">
+    <rect x="900" y="620" width="388" height="34" rx="10" fill="#F8FAF7" stroke="#E7ECE4"/>
+    <text x="916" y="642" fill="#7A857B" font-size="12">Search habits...</text>
+
+    <rect x="900" y="666" width="388" height="38" rx="12" fill="#FFFFFF" stroke="#ECF0EA"/>
+    <rect x="904" y="676" width="3" height="18" rx="1.5" fill="#1F6B3B"/>
+    <text x="918" y="689" fill="#1F2721" font-size="13" font-weight="600">Morning walk</text>
+    <text x="1166" y="689" fill="#6E796F" font-size="12">12 day streak</text>
+
+    <rect x="900" y="710" width="388" height="38" rx="12" fill="#FFFFFF" stroke="#ECF0EA"/>
+    <rect x="904" y="720" width="3" height="18" rx="1.5" fill="#8BAA92"/>
+    <text x="918" y="733" fill="#1F2721" font-size="13" font-weight="600">Read 20 minutes</text>
+    <text x="1178" y="733" fill="#6E796F" font-size="12">5 day</text>
+  </g>
+
+  <!-- Mobile preview chip -->
+  <rect x="1078" y="104" width="232" height="154" rx="22" fill="#FFFFFF" stroke="#E2E8E0"/>
+  <text x="1100" y="130" fill="#647065" font-size="10" font-family="Instrument Sans, Arial" letter-spacing="1.5">MOBILE PREVIEW</text>
+  <rect x="1092" y="142" width="204" height="96" rx="16" fill="#FAFBF8" stroke="#E8EDE6"/>
+  <rect x="1100" y="204" width="188" height="24" rx="12" fill="#FFFFFF" stroke="#E4EAE1"/>
+  <circle cx="1132" cy="216" r="6" fill="#1F6B3B"/>
+  <circle cx="1178" cy="216" r="6" fill="#CBD6CC"/>
+  <circle cx="1224" cy="216" r="6" fill="#CBD6CC"/>
+  <circle cx="1270" cy="216" r="6" fill="#CBD6CC"/>
+  <text x="1098" y="162" fill="#1E2620" font-size="12" font-family="Space Grotesk, Arial" font-weight="700">Today</text>
+  <text x="1098" y="182" fill="#6A766C" font-size="11" font-family="Instrument Sans, Arial">4 of 6 done</text>
+</svg>

--- a/docs/mockups/warm-editorial-mockup.svg
+++ b/docs/mockups/warm-editorial-mockup.svg
@@ -1,0 +1,145 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" fill="none">
+  <defs>
+    <linearGradient id="bgWarm" x1="0" y1="0" x2="1400" y2="880" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F7F1E7"/>
+      <stop offset="1" stop-color="#EDE1CF"/>
+    </linearGradient>
+    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(220 120) rotate(25) scale(360 220)">
+      <stop stop-color="#8ED4FF" stop-opacity="0.36"/>
+      <stop offset="1" stop-color="#8ED4FF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 110) rotate(-20) scale(280 200)">
+      <stop stop-color="#FDBA74" stop-opacity="0.34"/>
+      <stop offset="1" stop-color="#FDBA74" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="shadowSoft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="#5A4936" flood-opacity="0.14"/>
+    </filter>
+  </defs>
+
+  <rect width="1400" height="880" fill="url(#bgWarm)"/>
+  <rect width="1400" height="880" fill="url(#glowA)"/>
+  <rect width="1400" height="880" fill="url(#glowB)"/>
+
+  <text x="58" y="62" fill="#2C241C" font-size="30" font-family="Space Grotesk, Arial" font-weight="700">HabitFlow - Warm Editorial</text>
+  <text x="58" y="90" fill="#6E6255" font-size="15" font-family="Instrument Sans, Arial">Concept direction: warm surfaces, tactile cards, softer gradients, expressive hierarchy</text>
+
+  <rect x="48" y="120" width="1304" height="720" rx="28" fill="#F4EADB" stroke="#D5C6B1" stroke-width="2"/>
+
+  <!-- Sidebar -->
+  <rect x="70" y="142" width="256" height="676" rx="22" fill="#FBF6EE" stroke="#D8CBB8"/>
+  <rect x="86" y="158" width="224" height="72" rx="18" fill="#FFFDF9" stroke="#E0D4C2"/>
+  <rect x="102" y="174" width="40" height="40" rx="12" fill="#2563EB"/>
+  <text x="114" y="201" fill="white" font-size="16" font-family="Arial" font-weight="700">HF</text>
+  <text x="154" y="190" fill="#241D17" font-size="17" font-family="Space Grotesk, Arial" font-weight="700">HabitFlow</text>
+  <text x="154" y="210" fill="#7D7265" font-size="12" font-family="Instrument Sans, Arial">Build momentum every day</text>
+
+  <!-- Nav items -->
+  <g font-family="Instrument Sans, Arial" font-size="14" font-weight="600">
+    <rect x="86" y="252" width="224" height="44" rx="14" fill="#FFFDF8" stroke="#DCCFBD"/>
+    <rect x="86" y="262" width="4" height="24" rx="2" fill="#2563EB"/>
+    <text x="110" y="280" fill="#231D17">Today</text>
+    <text x="110" y="330" fill="#6A6055">Week</text>
+    <text x="110" y="380" fill="#6A6055">Month</text>
+    <text x="110" y="430" fill="#6A6055">Habits</text>
+    <text x="110" y="480" fill="#6A6055">Stats</text>
+    <text x="110" y="530" fill="#6A6055">Settings</text>
+    <circle cx="98" cy="276" r="6" fill="#BFD8FF"/>
+    <circle cx="98" cy="326" r="6" fill="#D2EBDD"/>
+    <circle cx="98" cy="376" r="6" fill="#CDEFFD"/>
+    <circle cx="98" cy="426" r="6" fill="#C6F0DB"/>
+    <circle cx="98" cy="476" r="6" fill="#E7D3FA"/>
+    <circle cx="98" cy="526" r="6" fill="#FFDDBE"/>
+  </g>
+
+  <rect x="86" y="730" width="224" height="48" rx="16" fill="#2563EB" filter="url(#shadowSoft)"/>
+  <text x="157" y="760" fill="white" font-size="14" font-family="Instrument Sans, Arial" font-weight="700">New Habit</text>
+
+  <!-- Main canvas -->
+  <rect x="346" y="142" width="984" height="676" rx="22" fill="rgba(255,255,255,0.34)" stroke="#D8CBB8"/>
+
+  <!-- Header -->
+  <rect x="370" y="166" width="936" height="112" rx="20" fill="rgba(255,255,255,0.72)" stroke="#D8CBB8"/>
+  <text x="394" y="195" fill="#8A7E70" font-size="11" font-family="Instrument Sans, Arial" letter-spacing="2">DAILY FOCUS</text>
+  <text x="394" y="230" fill="#211A15" font-size="34" font-family="Space Grotesk, Arial" font-weight="700">Today</text>
+  <text x="394" y="254" fill="#62584E" font-size="15" font-family="Instrument Sans, Arial">Good morning - Wednesday, February 25</text>
+  <rect x="1120" y="190" width="162" height="44" rx="14" fill="#FFFDF9" stroke="#D9CCBA"/>
+  <text x="1168" y="218" fill="#2B251F" font-size="14" font-family="Instrument Sans, Arial" font-weight="600">Quick Add</text>
+
+  <!-- Hero / momentum -->
+  <rect x="370" y="296" width="616" height="220" rx="22" fill="#FFFDF8" stroke="#D9CCBA" filter="url(#shadowSoft)"/>
+  <text x="394" y="326" fill="#8A7E70" font-size="11" font-family="Instrument Sans, Arial" letter-spacing="2">TODAY'S MOMENTUM</text>
+  <text x="394" y="365" fill="#211A15" font-size="28" font-family="Space Grotesk, Arial" font-weight="700">4 of 6 habits complete</text>
+  <text x="394" y="390" fill="#655B50" font-size="14" font-family="Instrument Sans, Arial">2 left today. Small steps compound quickly.</text>
+  <rect x="394" y="420" width="540" height="14" rx="7" fill="#ECE3D6"/>
+  <rect x="394" y="420" width="360" height="14" rx="7" fill="#2563EB"/>
+  <rect x="394" y="454" width="124" height="28" rx="14" fill="#E7F0FF" stroke="#BCD2FF"/>
+  <text x="426" y="472" fill="#1E4FC8" font-size="12" font-family="Instrument Sans, Arial" font-weight="700">67% complete</text>
+  <rect x="528" y="454" width="108" height="28" rx="14" fill="#F6EFE3" stroke="#DED0BC"/>
+  <text x="558" y="472" fill="#675C50" font-size="12" font-family="Instrument Sans, Arial" font-weight="700">2 streaking</text>
+
+  <!-- Progress ring -->
+  <circle cx="894" cy="406" r="58" fill="#F8F1E7" stroke="#E2D6C6" stroke-width="8"/>
+  <circle cx="894" cy="406" r="58" fill="none" stroke="#2563EB" stroke-width="8" stroke-linecap="round"
+          stroke-dasharray="243 364" transform="rotate(-90 894 406)"/>
+  <text x="874" y="413" fill="#211A15" font-size="24" font-family="Space Grotesk, Arial" font-weight="700">67</text>
+  <text x="885" y="431" fill="#7A6E61" font-size="11" font-family="Instrument Sans, Arial">score</text>
+
+  <!-- Checklist -->
+  <rect x="370" y="536" width="616" height="258" rx="22" fill="rgba(255,255,255,0.8)" stroke="#D9CCBA"/>
+  <text x="394" y="566" fill="#241D17" font-size="15" font-family="Space Grotesk, Arial" font-weight="700">Today's Checklist</text>
+  <text x="394" y="586" fill="#7B7064" font-size="12" font-family="Instrument Sans, Arial">6 scheduled habits</text>
+  <text x="893" y="572" fill="#6F6458" font-size="12" font-family="Instrument Sans, Arial">Manage</text>
+
+  <!-- rows -->
+  <g font-family="Instrument Sans, Arial">
+    <rect x="386" y="602" width="584" height="40" rx="10" fill="#FFFDF9"/>
+    <rect x="386" y="646" width="584" height="40" rx="10" fill="#FBF6EE"/>
+    <rect x="386" y="690" width="584" height="40" rx="10" fill="#FFFDF9"/>
+    <rect x="386" y="734" width="584" height="40" rx="10" fill="#FBF6EE"/>
+    <rect x="394" y="610" width="3" height="24" rx="2" fill="#10B981"/>
+    <rect x="394" y="654" width="3" height="24" rx="2" fill="#F59E0B"/>
+    <rect x="394" y="698" width="3" height="24" rx="2" fill="#EC4899"/>
+    <rect x="394" y="742" width="3" height="24" rx="2" fill="#06B6D4"/>
+    <circle cx="414" cy="622" r="9" fill="#10B981"/>
+    <circle cx="414" cy="666" r="9" fill="#EFE4D4" stroke="#D6C8B5"/>
+    <circle cx="414" cy="710" r="9" fill="#EFE4D4" stroke="#D6C8B5"/>
+    <circle cx="414" cy="754" r="9" fill="#EFE4D4" stroke="#D6C8B5"/>
+    <text x="438" y="626" fill="#211A15" font-size="13" font-weight="600">Morning walk</text>
+    <text x="438" y="670" fill="#211A15" font-size="13" font-weight="600">Read 20 minutes</text>
+    <text x="438" y="714" fill="#211A15" font-size="13" font-weight="600">Journal</text>
+    <text x="438" y="758" fill="#211A15" font-size="13" font-weight="600">Stretching</text>
+    <rect x="770" y="610" width="68" height="22" rx="11" fill="#F6EFE3" stroke="#DED0BC"/>
+    <text x="790" y="625" fill="#6B5F54" font-size="11">Health</text>
+    <rect x="852" y="610" width="52" height="22" rx="11" fill="#FFF3D6" stroke="#F3D38E"/>
+    <text x="872" y="625" fill="#B26B00" font-size="11">3</text>
+  </g>
+
+  <!-- Right column -->
+  <rect x="1004" y="296" width="302" height="168" rx="20" fill="#FFFDF8" stroke="#D9CCBA"/>
+  <text x="1028" y="326" fill="#6D6257" font-size="11" font-family="Instrument Sans, Arial" letter-spacing="2">HABITS SNAPSHOT</text>
+  <text x="1028" y="360" fill="#231C16" font-size="15" font-family="Space Grotesk, Arial" font-weight="700">Active 12</text>
+  <text x="1028" y="384" fill="#231C16" font-size="15" font-family="Space Grotesk, Arial" font-weight="700">Categories 5</text>
+  <text x="1028" y="408" fill="#231C16" font-size="15" font-family="Space Grotesk, Arial" font-weight="700">Hot streaks 4</text>
+  <rect x="1160" y="338" width="118" height="8" rx="4" fill="#E8E0D4"/>
+  <rect x="1160" y="338" width="86" height="8" rx="4" fill="#0EA5E9"/>
+  <rect x="1160" y="362" width="118" height="8" rx="4" fill="#E8E0D4"/>
+  <rect x="1160" y="362" width="70" height="8" rx="4" fill="#10B981"/>
+  <rect x="1160" y="386" width="118" height="8" rx="4" fill="#E8E0D4"/>
+  <rect x="1160" y="386" width="44" height="8" rx="4" fill="#F59E0B"/>
+
+  <rect x="1004" y="484" width="302" height="310" rx="20" fill="rgba(255,255,255,0.78)" stroke="#D9CCBA"/>
+  <text x="1028" y="514" fill="#241D17" font-size="15" font-family="Space Grotesk, Arial" font-weight="700">Stats Preview</text>
+  <text x="1028" y="534" fill="#7A6F63" font-size="12" font-family="Instrument Sans, Arial">Editorial cards with tactile charts</text>
+  <rect x="1028" y="552" width="118" height="80" rx="14" fill="#FFFDF9" stroke="#E0D3C2"/>
+  <rect x="1158" y="552" width="118" height="80" rx="14" fill="#FFFDF9" stroke="#E0D3C2"/>
+  <text x="1040" y="577" fill="#7A6F63" font-size="10" font-family="Instrument Sans, Arial">COMPLETION RATE</text>
+  <text x="1040" y="607" fill="#231C16" font-size="28" font-family="Space Grotesk, Arial" font-weight="700">78%</text>
+  <text x="1170" y="577" fill="#7A6F63" font-size="10" font-family="Instrument Sans, Arial">BEST STREAK</text>
+  <text x="1170" y="607" fill="#231C16" font-size="28" font-family="Space Grotesk, Arial" font-weight="700">12</text>
+  <rect x="1028" y="646" width="248" height="118" rx="14" fill="#FBF6EE" stroke="#E0D3C2"/>
+  <polyline points="1042,736 1080,712 1118,718 1156,688 1194,702 1232,664 1262,676" fill="none" stroke="#2563EB" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="1042,742 1080,726 1118,730 1156,708 1194,716 1232,690 1262,696" fill="none" stroke="#93C5FD" stroke-width="2" opacity="0.8"/>
+  <line x1="1042" y1="754" x2="1268" y2="754" stroke="#D8CCBA"/>
+  <text x="1042" y="666" fill="#6E6257" font-size="11" font-family="Instrument Sans, Arial">Daily completions</text>
+</svg>

--- a/docs/qa/capture_nav_screens.py
+++ b/docs/qa/capture_nav_screens.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from playwright.sync_api import sync_playwright
+
+
+BASE_URL = "https://127.0.0.1:8080/"
+OUT_DIR = Path("docs/qa/nav-screens")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def set_theme(page, theme: str) -> None:
+    page.add_init_script(
+        script=f"""
+        (() => {{
+          try {{ localStorage.setItem('habitflow-theme', {theme!r}); }} catch (e) {{}}
+        }})()
+        """,
+    )
+
+
+def capture_desktop(browser, theme: str) -> None:
+    context = browser.new_context(
+        viewport={"width": 1440, "height": 900},
+        ignore_https_errors=True,
+    )
+    page = context.new_page()
+    set_theme(page, theme)
+    page.goto(BASE_URL, wait_until="domcontentloaded")
+    page.wait_for_timeout(1800)
+    page.screenshot(path=str(OUT_DIR / f"today-desktop-{theme}.png"), full_page=True)
+
+    routes = [
+        ("Habits", "habits"),
+        ("Week", "week"),
+        ("Month", "month"),
+        ("Stats", "stats"),
+        ("Settings", "settings"),
+    ]
+    for label, slug in routes:
+        page.get_by_role("link", name=label).first.click()
+        page.wait_for_timeout(1600)
+        page.screenshot(path=str(OUT_DIR / f"{slug}-desktop-{theme}.png"), full_page=True)
+    context.close()
+
+
+def capture_mobile(browser, theme: str) -> None:
+    context = browser.new_context(
+        viewport={"width": 390, "height": 844},
+        is_mobile=True,
+        has_touch=True,
+        device_scale_factor=3,
+        ignore_https_errors=True,
+        user_agent=(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 "
+            "Mobile/15E148 Safari/604.1"
+        ),
+    )
+    page = context.new_page()
+    set_theme(page, theme)
+    page.goto(BASE_URL, wait_until="domcontentloaded")
+    page.wait_for_timeout(1800)
+    page.screenshot(path=str(OUT_DIR / f"today-mobile-{theme}.png"), full_page=True)
+
+    # Bottom nav covers these routes
+    routes = [
+        ("Week", "week"),
+        ("Month", "month"),
+        ("Stats", "stats"),
+        ("Settings", "settings"),
+    ]
+    for label, slug in routes:
+        page.get_by_role("link", name=label).first.click()
+        page.wait_for_timeout(1800)
+        page.screenshot(path=str(OUT_DIR / f"{slug}-mobile-{theme}.png"), full_page=True)
+
+    # Habits route is not in mobile bottom nav; open via script pushState navigation.
+    page.evaluate("window.history.pushState({}, '', '/habits'); window.dispatchEvent(new PopStateEvent('popstate'));")
+    page.wait_for_timeout(1200)
+    # Fall back to hard navigation if app router did not render habits
+    if "/habits/" not in page.url and not page.locator("text=Habits").count():
+        page.goto(BASE_URL.rstrip("/") + "/habits", wait_until="domcontentloaded")
+        page.wait_for_timeout(1000)
+    page.screenshot(path=str(OUT_DIR / f"habits-mobile-{theme}.png"), full_page=True)
+    context.close()
+
+
+def main() -> None:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(channel="chrome", headless=True)
+        for theme in ("light", "dark"):
+            capture_desktop(browser, theme)
+            capture_mobile(browser, theme)
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/public/sample-data/habitflow-sample-power-user.json
+++ b/public/sample-data/habitflow-sample-power-user.json
@@ -1,0 +1,27111 @@
+{
+  "version": "1.0",
+  "exportedAt": "2026-02-25T15:30:00Z",
+  "app": "HabitFlow",
+  "data": {
+    "habits": [
+      {
+        "id": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "name": "Morning Walk",
+        "icon": "\ud83d\udeb6",
+        "color": "#10b981",
+        "frequency": "daily",
+        "category": "Health",
+        "sortOrder": 0,
+        "isArchived": false,
+        "createdAt": "2025-08-15T12:00:00Z",
+        "updatedAt": "2025-12-13T12:00:00Z",
+        "description": "Outdoor walk",
+        "reminderTime": "07:00"
+      },
+      {
+        "id": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "name": "Read 20 Minutes",
+        "icon": "\ud83d\udcda",
+        "color": "#3b82f6",
+        "frequency": "daily",
+        "category": "Learning",
+        "sortOrder": 1,
+        "isArchived": false,
+        "createdAt": "2025-08-16T12:00:00Z",
+        "updatedAt": "2025-12-14T12:00:00Z",
+        "description": "Reading habit",
+        "reminderTime": "21:00"
+      },
+      {
+        "id": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "name": "Meditation",
+        "icon": "\ud83e\uddd8",
+        "color": "#8b5cf6",
+        "frequency": "weekdays",
+        "category": "Mindset",
+        "sortOrder": 2,
+        "isArchived": false,
+        "createdAt": "2025-08-17T12:00:00Z",
+        "updatedAt": "2025-12-15T12:00:00Z",
+        "description": "Mindfulness",
+        "reminderTime": "08:00"
+      },
+      {
+        "id": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "name": "Strength Training",
+        "icon": "\ud83c\udfcb\ufe0f",
+        "color": "#ef4444",
+        "frequency": "specific_days",
+        "category": "Fitness",
+        "sortOrder": 3,
+        "isArchived": false,
+        "createdAt": "2025-08-18T12:00:00Z",
+        "updatedAt": "2025-12-16T12:00:00Z",
+        "description": "Mon/Wed/Fri lifts",
+        "reminderTime": "18:00",
+        "targetDays": [
+          1,
+          3,
+          5
+        ]
+      },
+      {
+        "id": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "name": "Stretching",
+        "icon": "\ud83e\uddce",
+        "color": "#f97316",
+        "frequency": "daily",
+        "category": "Mobility",
+        "sortOrder": 4,
+        "isArchived": false,
+        "createdAt": "2025-08-19T12:00:00Z",
+        "updatedAt": "2025-12-17T12:00:00Z",
+        "description": "Mobility flow",
+        "reminderTime": "06:45"
+      },
+      {
+        "id": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "name": "Meal Prep",
+        "icon": "\ud83e\udd57",
+        "color": "#14b8a6",
+        "frequency": "weekends",
+        "category": "Health",
+        "sortOrder": 5,
+        "isArchived": false,
+        "createdAt": "2025-08-20T12:00:00Z",
+        "updatedAt": "2025-12-18T12:00:00Z",
+        "description": "Weekend prep",
+        "reminderTime": "11:00"
+      },
+      {
+        "id": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "name": "Practice Guitar",
+        "icon": "\ud83c\udfb8",
+        "color": "#f59e0b",
+        "frequency": "x_per_week",
+        "category": "Creative",
+        "sortOrder": 6,
+        "isArchived": false,
+        "createdAt": "2025-08-21T12:00:00Z",
+        "updatedAt": "2025-12-19T12:00:00Z",
+        "description": "15 min minimum",
+        "reminderTime": "20:30",
+        "targetCount": 4
+      },
+      {
+        "id": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "name": "Language Practice",
+        "icon": "\ud83d\udde3\ufe0f",
+        "color": "#06b6d4",
+        "frequency": "specific_days",
+        "category": "Learning",
+        "sortOrder": 7,
+        "isArchived": false,
+        "createdAt": "2025-08-22T12:00:00Z",
+        "updatedAt": "2025-12-20T12:00:00Z",
+        "description": "Spanish lessons",
+        "reminderTime": "12:30",
+        "targetDays": [
+          0,
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "id": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "name": "Journal",
+        "icon": "\u270d\ufe0f",
+        "color": "#ec4899",
+        "frequency": "daily",
+        "category": "Mindset",
+        "sortOrder": 8,
+        "isArchived": false,
+        "createdAt": "2025-08-23T12:00:00Z",
+        "updatedAt": "2025-12-21T12:00:00Z",
+        "description": "3 lines minimum",
+        "reminderTime": "22:00"
+      },
+      {
+        "id": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "name": "Inbox Zero",
+        "icon": "\ud83d\udce5",
+        "color": "#0ea5e9",
+        "frequency": "weekdays",
+        "category": "Work",
+        "sortOrder": 9,
+        "isArchived": false,
+        "createdAt": "2025-08-24T12:00:00Z",
+        "updatedAt": "2025-12-22T12:00:00Z",
+        "description": "Email cleanup",
+        "reminderTime": "16:30"
+      },
+      {
+        "id": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "name": "Budget Check-in",
+        "icon": "\ud83d\udcb8",
+        "color": "#84cc16",
+        "frequency": "x_per_week",
+        "category": "Admin",
+        "sortOrder": 10,
+        "isArchived": false,
+        "createdAt": "2025-08-25T12:00:00Z",
+        "updatedAt": "2025-12-23T12:00:00Z",
+        "description": "Review spending",
+        "reminderTime": "19:00",
+        "targetCount": 2
+      },
+      {
+        "id": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "name": "Call Family",
+        "icon": "\ud83d\udcde",
+        "color": "#a855f7",
+        "frequency": "specific_days",
+        "category": "Relationships",
+        "sortOrder": 11,
+        "isArchived": false,
+        "createdAt": "2025-08-26T12:00:00Z",
+        "updatedAt": "2025-12-24T12:00:00Z",
+        "description": "Sunday call",
+        "reminderTime": "17:30",
+        "targetDays": [
+          0
+        ]
+      },
+      {
+        "id": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "name": "Deep Work Block",
+        "icon": "\ud83e\udde0",
+        "color": "#2563eb",
+        "frequency": "weekdays",
+        "category": "Work",
+        "sortOrder": 12,
+        "isArchived": false,
+        "createdAt": "2025-08-27T12:00:00Z",
+        "updatedAt": "2025-12-25T12:00:00Z",
+        "description": "90-minute focus sprint",
+        "reminderTime": "09:30"
+      },
+      {
+        "id": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "name": "Protein Goal",
+        "icon": "\ud83e\udd5a",
+        "color": "#f43f5e",
+        "frequency": "daily",
+        "category": "Health",
+        "sortOrder": 13,
+        "isArchived": false,
+        "createdAt": "2025-08-28T12:00:00Z",
+        "updatedAt": "2025-12-26T12:00:00Z",
+        "description": "Hit protein target",
+        "reminderTime": "20:00"
+      },
+      {
+        "id": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "name": "Drink Water",
+        "icon": "\ud83d\udca7",
+        "color": "#22c55e",
+        "frequency": "daily",
+        "category": "Health",
+        "sortOrder": 14,
+        "isArchived": false,
+        "createdAt": "2025-08-29T12:00:00Z",
+        "updatedAt": "2025-12-27T12:00:00Z",
+        "description": "Stay hydrated",
+        "reminderTime": "10:00"
+      },
+      {
+        "id": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "name": "Sleep Before 11",
+        "icon": "\ud83d\ude34",
+        "color": "#6366f1",
+        "frequency": "daily",
+        "category": "Recovery",
+        "sortOrder": 15,
+        "isArchived": false,
+        "createdAt": "2025-08-30T12:00:00Z",
+        "updatedAt": "2025-12-28T12:00:00Z",
+        "description": "Wind down routine",
+        "reminderTime": "22:15"
+      },
+      {
+        "id": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "name": "Run / Cardio",
+        "icon": "\ud83c\udfc3",
+        "color": "#0ea5e9",
+        "frequency": "specific_days",
+        "category": "Fitness",
+        "sortOrder": 16,
+        "isArchived": false,
+        "createdAt": "2025-08-31T12:00:00Z",
+        "updatedAt": "2025-12-29T12:00:00Z",
+        "description": "Tue/Thu/Sat cardio",
+        "reminderTime": "07:15",
+        "targetDays": [
+          2,
+          4,
+          6
+        ]
+      },
+      {
+        "id": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "name": "Plan Tomorrow",
+        "icon": "\ud83d\uddd3\ufe0f",
+        "color": "#f59e0b",
+        "frequency": "weekdays",
+        "category": "Planning",
+        "sortOrder": 17,
+        "isArchived": false,
+        "createdAt": "2025-09-01T12:00:00Z",
+        "updatedAt": "2025-12-30T12:00:00Z",
+        "description": "Set top 3 tasks",
+        "reminderTime": "21:30"
+      },
+      {
+        "id": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "name": "Desk Cleanup",
+        "icon": "\ud83e\uddfd",
+        "color": "#a3a3a3",
+        "frequency": "weekdays",
+        "category": "Environment",
+        "sortOrder": 18,
+        "isArchived": false,
+        "createdAt": "2025-09-02T12:00:00Z",
+        "updatedAt": "2025-12-31T12:00:00Z",
+        "description": "2-minute reset",
+        "reminderTime": "17:45"
+      },
+      {
+        "id": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "name": "Practice Typing",
+        "icon": "\u2328\ufe0f",
+        "color": "#38bdf8",
+        "frequency": "x_per_week",
+        "category": "Learning",
+        "sortOrder": 19,
+        "isArchived": false,
+        "createdAt": "2025-09-03T12:00:00Z",
+        "updatedAt": "2026-01-01T12:00:00Z",
+        "description": "Typing drills",
+        "reminderTime": "13:30",
+        "targetCount": 3
+      },
+      {
+        "id": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "name": "No Sugar Dessert",
+        "icon": "\ud83c\udf70",
+        "color": "#fb7185",
+        "frequency": "daily",
+        "category": "Nutrition",
+        "sortOrder": 20,
+        "isArchived": false,
+        "createdAt": "2025-09-04T12:00:00Z",
+        "updatedAt": "2026-01-02T12:00:00Z",
+        "description": "Avoid sweets",
+        "reminderTime": "20:45"
+      },
+      {
+        "id": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "name": "Sunlight Break",
+        "icon": "\u2600\ufe0f",
+        "color": "#eab308",
+        "frequency": "weekdays",
+        "category": "Health",
+        "sortOrder": 21,
+        "isArchived": false,
+        "createdAt": "2025-09-05T12:00:00Z",
+        "updatedAt": "2026-01-03T12:00:00Z",
+        "description": "Get outside midday",
+        "reminderTime": "12:00"
+      },
+      {
+        "id": "779db954-9b0d-4474-b078-38699fc33c86",
+        "name": "Review Goals",
+        "icon": "\ud83c\udfaf",
+        "color": "#9333ea",
+        "frequency": "specific_days",
+        "category": "Planning",
+        "sortOrder": 22,
+        "isArchived": false,
+        "createdAt": "2025-09-06T12:00:00Z",
+        "updatedAt": "2026-01-04T12:00:00Z",
+        "description": "Mon/Thu review",
+        "reminderTime": "19:30",
+        "targetDays": [
+          1,
+          4
+        ]
+      },
+      {
+        "id": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "name": "Creative Sketch",
+        "icon": "\u270f\ufe0f",
+        "color": "#f97316",
+        "frequency": "x_per_week",
+        "category": "Creative",
+        "sortOrder": 23,
+        "isArchived": false,
+        "createdAt": "2025-09-07T12:00:00Z",
+        "updatedAt": "2026-01-05T12:00:00Z",
+        "description": "Sketchbook session",
+        "reminderTime": "18:30",
+        "targetCount": 2
+      },
+      {
+        "id": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "name": "Cold Shower Challenge",
+        "icon": "\ud83e\uddca",
+        "color": "#64748b",
+        "frequency": "daily",
+        "category": "Challenge",
+        "sortOrder": 24,
+        "isArchived": true,
+        "createdAt": "2025-09-08T12:00:00Z",
+        "updatedAt": "2026-01-06T12:00:00Z",
+        "description": "Completed challenge"
+      },
+      {
+        "id": "2713d127-fc67-423a-adc2-52f9684026db",
+        "name": "Job Search Applications",
+        "icon": "\ud83d\udcbc",
+        "color": "#059669",
+        "frequency": "x_per_week",
+        "category": "Career",
+        "sortOrder": 25,
+        "isArchived": true,
+        "createdAt": "2025-09-09T12:00:00Z",
+        "updatedAt": "2026-01-07T12:00:00Z",
+        "description": "Send applications",
+        "reminderTime": "14:00",
+        "targetCount": 5
+      }
+    ],
+    "completions": [
+      {
+        "id": "d28c4382-4306-4b6d-a36b-4c3f8c1cca6d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T06:05:00Z"
+      },
+      {
+        "id": "ad3a8b89-479f-4f23-b823-373234a9f35b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T18:20:00Z"
+      },
+      {
+        "id": "6813fc77-d719-4420-a3ea-375d9d95dd16",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T07:45:00Z"
+      },
+      {
+        "id": "1a0a1975-7cbd-46c2-8a87-c06d896db8cb",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T07:10:00Z"
+      },
+      {
+        "id": "6427cddb-239a-4687-af31-47799f6bdac7",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T08:30:00Z"
+      },
+      {
+        "id": "bbc2b82b-604f-4c43-90cc-b05e834d51f3",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T20:20:00Z"
+      },
+      {
+        "id": "76abb2d4-d726-454b-9ed8-860355e3b152",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T17:45:00Z"
+      },
+      {
+        "id": "b6515d4b-3ab9-40ca-9193-a79703d74a1f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T12:30:00Z"
+      },
+      {
+        "id": "174eb4bf-8ae9-421e-82ea-ee0ac56915a3",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T08:50:00Z"
+      },
+      {
+        "id": "f7f98405-563c-49f7-9e2f-6e7b87eb2280",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T21:05:00Z"
+      },
+      {
+        "id": "e247d407-bae8-44c1-a72a-e91da99f52a0",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-02-20",
+        "completedAt": "2025-02-20T17:10:00Z"
+      },
+      {
+        "id": "dea0ca7e-39fa-4870-97aa-ec17c0fc6163",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T07:00:00Z"
+      },
+      {
+        "id": "5d731eb5-544f-4aac-bb75-5f7cf8a6f349",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T20:20:00Z"
+      },
+      {
+        "id": "ea90a43d-b9de-4c5b-9056-600fcdc88b30",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T18:40:00Z"
+      },
+      {
+        "id": "ad608ad9-212b-4028-a314-ddcf75303785",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T07:15:00Z"
+      },
+      {
+        "id": "4d74182c-820e-48ce-aa99-fd9839282da6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T22:15:00Z"
+      },
+      {
+        "id": "3101bef4-3959-4127-a7b0-d5bf694b529c",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T12:30:00Z"
+      },
+      {
+        "id": "36f3eb06-8213-495f-ac6d-92169b29f021",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T17:30:00Z"
+      },
+      {
+        "id": "b6b5c450-080a-4428-8b0b-81662f7fffcb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T21:05:00Z"
+      },
+      {
+        "id": "13117334-53be-4ae8-9136-47445a46ea1a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T20:10:00Z"
+      },
+      {
+        "id": "f5a349a1-7423-43b7-9a68-b61e4d3e0e99",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T19:45:00Z"
+      },
+      {
+        "id": "4dbc3bde-2490-452b-911d-393a952b136a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T07:30:00Z"
+      },
+      {
+        "id": "e74555ea-a4cd-4728-b145-bd3f1f119b09",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-02-21",
+        "completedAt": "2025-02-21T22:15:00Z"
+      },
+      {
+        "id": "403d9fe2-5e66-45d9-abeb-cee89fc08fe4",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T12:10:00Z"
+      },
+      {
+        "id": "a273c8f2-e451-4f1b-b1d1-0460d71b70fe",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T06:05:00Z"
+      },
+      {
+        "id": "cf41f577-cb4e-497a-a09d-46cda9bec97e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T22:05:00Z"
+      },
+      {
+        "id": "df95805a-14e0-4bc6-b1ff-e6ca875f0e00",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T08:40:00Z"
+      },
+      {
+        "id": "ca1ef18d-4c35-4663-ac97-5ecabbfc463b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T07:00:00Z"
+      },
+      {
+        "id": "d757c872-83e5-4b57-8ad1-08c87361bbd9",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T20:00:00Z"
+      },
+      {
+        "id": "55d6ca93-1390-4243-b128-4195421e04d9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T12:50:00Z"
+      },
+      {
+        "id": "029da5f7-bf70-4897-a8c6-7e4f4fa3066a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T07:15:00Z"
+      },
+      {
+        "id": "6b31d9e4-23ae-4bc3-a472-93edba7b2e59",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T07:40:00Z"
+      },
+      {
+        "id": "406a960b-ab0d-45b4-ad7e-131b06a7aeef",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T22:30:00Z"
+      },
+      {
+        "id": "b2a60f32-4a91-48cc-92e7-607bec8a4a2d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-22",
+        "completedAt": "2025-02-22T22:30:00Z"
+      },
+      {
+        "id": "0f8b1581-480b-4b35-b26c-e03b11e0580c",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T07:45:00Z"
+      },
+      {
+        "id": "276b6d9d-5800-4ec0-a2fe-03eff98b1ff7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T17:40:00Z"
+      },
+      {
+        "id": "d010611c-df32-4546-883e-9f0c1ebbbffe",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T17:50:00Z"
+      },
+      {
+        "id": "ba556d10-95c6-401b-9e11-f1c39e03e0a8",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T06:00:00Z"
+      },
+      {
+        "id": "3f8b5ba2-e68d-48e6-9cd4-576854b7a318",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T20:05:00Z"
+      },
+      {
+        "id": "4c844b6d-330c-4e22-996c-b2572866cb07",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T21:05:00Z"
+      },
+      {
+        "id": "14b7e9f5-8eee-46a8-b0ef-a1c5836650aa",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T22:45:00Z"
+      },
+      {
+        "id": "167891db-112b-450a-a9d8-8eb585e9c61d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T17:05:00Z"
+      },
+      {
+        "id": "89acd0f4-288b-41fc-ab98-7c2ad540e68e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-23",
+        "completedAt": "2025-02-23T08:45:00Z"
+      },
+      {
+        "id": "65962cf8-1b17-4555-9d10-bed91301ea5d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T18:05:00Z"
+      },
+      {
+        "id": "225a6979-32a9-4c62-826c-9fb2bba467c6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T21:50:00Z"
+      },
+      {
+        "id": "088cfab3-2d7b-452c-8a0c-c9c1f3115ec7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T19:10:00Z"
+      },
+      {
+        "id": "ad6be861-a99c-463f-a396-e97a92c24906",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T22:15:00Z"
+      },
+      {
+        "id": "4ff74ff5-422a-48b4-9ce4-6caba187b3cb",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T12:45:00Z"
+      },
+      {
+        "id": "7ebe2ea9-7cd3-4366-86db-8a1bd8da78c4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T20:50:00Z"
+      },
+      {
+        "id": "395b0dd1-5b58-43f7-84d5-786889a596d0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T17:15:00Z"
+      },
+      {
+        "id": "ec357e72-d324-4c3e-8a86-70320ec0a7c0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T20:50:00Z"
+      },
+      {
+        "id": "c1bed499-feca-4a15-8bda-f3415b1b19f5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T12:30:00Z"
+      },
+      {
+        "id": "9e212f4d-ab4b-43e0-b499-1e5db0e66e16",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T19:40:00Z"
+      },
+      {
+        "id": "b38826ca-2d22-4743-adde-65fdc1d5d4e8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T21:20:00Z"
+      },
+      {
+        "id": "5837339c-a7db-44e1-a2b5-f5a09b4e4f6b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-02-24",
+        "completedAt": "2025-02-24T19:20:00Z"
+      },
+      {
+        "id": "83577e03-e929-4cda-8e1b-5b28666166a5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T18:50:00Z"
+      },
+      {
+        "id": "3643b37d-e2ff-4773-a3ff-e0968fba2905",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T12:40:00Z"
+      },
+      {
+        "id": "3df77e55-34ad-4136-87f7-307651588ae3",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T21:15:00Z"
+      },
+      {
+        "id": "279d4e66-9dc1-4b00-b001-2d4091181750",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T21:15:00Z"
+      },
+      {
+        "id": "5d28bda3-a2ae-47e8-a5bb-1f34b1c0b9b3",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T08:20:00Z"
+      },
+      {
+        "id": "8fb5099b-b142-4fa5-ba44-617acac9f286",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T22:50:00Z"
+      },
+      {
+        "id": "90726335-8bf0-4e6c-9fa8-b459947a5166",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T20:10:00Z"
+      },
+      {
+        "id": "60bf15fd-05fc-4f06-8e37-788c27b225f0",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T21:45:00Z"
+      },
+      {
+        "id": "11aa00be-83df-46b2-ade6-758802a11918",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T22:40:00Z"
+      },
+      {
+        "id": "22e77b89-0136-458b-8b48-d00c22d8b05b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T17:05:00Z"
+      },
+      {
+        "id": "aa04265b-f1de-4afb-a0be-fcf572fedd66",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T06:05:00Z"
+      },
+      {
+        "id": "ff5db2ac-810c-45b2-91be-d19da54886ed",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T21:10:00Z"
+      },
+      {
+        "id": "9064de0c-9dca-40ae-ad11-a8d2cd33348f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T20:50:00Z"
+      },
+      {
+        "id": "37eebd43-ae4c-48d4-9001-f95d62b56175",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T19:00:00Z"
+      },
+      {
+        "id": "c96dec24-6a73-43f8-b73d-dd47b8b27435",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-25",
+        "completedAt": "2025-02-25T20:40:00Z"
+      },
+      {
+        "id": "2f77696c-3f2f-491c-bdf3-18b4f2de5612",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T17:30:00Z"
+      },
+      {
+        "id": "dd9a026a-853b-4b73-9cf8-60902d876bef",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T22:50:00Z"
+      },
+      {
+        "id": "774c54ac-e4e3-45cf-8ba2-71874b3a20ca",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T18:10:00Z",
+        "note": "Nonfiction notes"
+      },
+      {
+        "id": "2d66d797-5105-4ccb-a786-185eb7f0733c",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T07:15:00Z"
+      },
+      {
+        "id": "9c95a3d5-cf34-4fc6-bfa9-8eea705eb03f",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T22:00:00Z"
+      },
+      {
+        "id": "6c58370a-36e3-47df-812a-de39d5373519",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T12:30:00Z"
+      },
+      {
+        "id": "8d5c3928-0e68-492c-9803-5f9a1d0e7b9f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T12:50:00Z"
+      },
+      {
+        "id": "0dc74310-f0e7-4a32-b7e0-0c6af2888541",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T12:10:00Z"
+      },
+      {
+        "id": "49e2ed73-6f8f-4a26-a12d-7e24a22bb2f4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T17:45:00Z"
+      },
+      {
+        "id": "c031b8dc-a5cc-40cc-84d9-84f6f7d82464",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T21:40:00Z"
+      },
+      {
+        "id": "c2b6e519-5c80-4651-a70d-c2a6b38c474d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-26",
+        "completedAt": "2025-02-26T18:30:00Z"
+      },
+      {
+        "id": "718d4d76-53ba-4f59-a8ba-b17db6794708",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T18:45:00Z"
+      },
+      {
+        "id": "207e8e9d-05f5-4e8a-8781-6d2d85bce267",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T07:10:00Z"
+      },
+      {
+        "id": "790e0002-9c74-4f52-8e4e-6db1a46f2295",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T12:45:00Z"
+      },
+      {
+        "id": "efe68f01-3351-436b-9318-41a453e0b908",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T21:15:00Z"
+      },
+      {
+        "id": "420ee001-9485-464c-99f7-f91950be7aa0",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T07:50:00Z"
+      },
+      {
+        "id": "87ff3b30-e5ad-4169-b548-c5cfc1a83bf5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T08:20:00Z"
+      },
+      {
+        "id": "f1c90850-b2cd-44a2-97b1-b0760b9ecde9",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T12:40:00Z"
+      },
+      {
+        "id": "1836cf96-b815-4c53-b885-2e6b70e16625",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T20:00:00Z"
+      },
+      {
+        "id": "eb59c650-55ec-4ad2-a05b-3597550b4bef",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T08:15:00Z"
+      },
+      {
+        "id": "00290fc8-407e-4974-adfd-67e8d1c2e2ee",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T07:00:00Z"
+      },
+      {
+        "id": "2e3b00ae-cc78-4b18-bad4-6d85efb33d71",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-02-27",
+        "completedAt": "2025-02-27T06:00:00Z"
+      },
+      {
+        "id": "cd1d610a-3eb6-4a0c-8ea0-a1a3e1dee259",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T18:50:00Z"
+      },
+      {
+        "id": "3168880a-9cf7-45c1-9975-c4c5e92cec84",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T22:40:00Z"
+      },
+      {
+        "id": "8e681415-7c84-4170-a1d2-7dfaecab14ff",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T20:40:00Z"
+      },
+      {
+        "id": "abcaf328-626f-4914-94bd-678ea7f651ba",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T08:05:00Z"
+      },
+      {
+        "id": "c89925a2-eeea-4a01-924b-74cb1ab1cacb",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T07:50:00Z"
+      },
+      {
+        "id": "b31e13fc-13a5-4610-a2db-27008fcad6ba",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T20:45:00Z"
+      },
+      {
+        "id": "635ef1f5-07ba-45bf-9282-c4c88963965b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T20:40:00Z"
+      },
+      {
+        "id": "dde2ee91-4ab8-43ae-b377-68417834675c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T18:00:00Z"
+      },
+      {
+        "id": "850ec5c5-ebe3-4645-b379-fa8b45270fb2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T08:05:00Z"
+      },
+      {
+        "id": "cdd2d2f9-8060-4a78-b78f-7d84ae07248d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T18:10:00Z"
+      },
+      {
+        "id": "285aadda-d6c2-4f92-87c9-3461cc215ee9",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T12:20:00Z"
+      },
+      {
+        "id": "447f5239-9802-4fd9-a95a-03a9358faaa0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T20:15:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "fc06eb15-e54a-4d79-8071-45f55ee0d93d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T22:20:00Z"
+      },
+      {
+        "id": "9f80ac9d-71af-411d-a5d5-a3326b6224b4",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T22:00:00Z"
+      },
+      {
+        "id": "78d72485-de76-4a6f-8e21-959fe4ddd2c1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-02-28",
+        "completedAt": "2025-02-28T22:40:00Z"
+      },
+      {
+        "id": "312a5a9a-ef39-4e27-83d0-2e171db47526",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T19:50:00Z"
+      },
+      {
+        "id": "ee5d396a-8449-4be6-87ba-67ee3797c526",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T12:30:00Z"
+      },
+      {
+        "id": "6865abc2-c309-4c89-a20b-d9f7c8220d62",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T07:45:00Z"
+      },
+      {
+        "id": "13cd64bd-06e7-4e24-bb8b-08036d88f494",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T12:20:00Z"
+      },
+      {
+        "id": "db02ddb8-660d-460e-bba2-bca336b8941f",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T20:20:00Z"
+      },
+      {
+        "id": "43e813ba-7981-4dd3-ac33-e65b6a13d4ec",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T17:15:00Z"
+      },
+      {
+        "id": "fcdf4ac2-bb29-44f4-9ed2-56f50ebb2fc7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T12:20:00Z"
+      },
+      {
+        "id": "ee28a73b-3629-4b6b-a60a-4ed97cf25b65",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T22:10:00Z"
+      },
+      {
+        "id": "1e0e150c-a65e-4c82-90db-7c0eef076be7",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T17:05:00Z"
+      },
+      {
+        "id": "846d16a5-cf0a-42b3-beaf-ab5183812151",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-01",
+        "completedAt": "2025-03-01T06:10:00Z"
+      },
+      {
+        "id": "7163ebe6-2383-4f4d-905c-6d36d54b8d16",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T19:20:00Z"
+      },
+      {
+        "id": "afc4025e-bd4a-44fc-a804-d3e943e87e08",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T07:05:00Z"
+      },
+      {
+        "id": "ccec319b-c334-43dc-93f2-fe02958e838e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T19:40:00Z"
+      },
+      {
+        "id": "c278c666-edfc-4c3e-a777-8f04bad3aa9d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T18:05:00Z"
+      },
+      {
+        "id": "1aee1d4f-04ea-47f6-ac66-b58873f69274",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T21:20:00Z"
+      },
+      {
+        "id": "355695f9-4fe0-46e2-9e7c-ccbfeec92eb5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T21:40:00Z"
+      },
+      {
+        "id": "57309d24-5e39-410c-b665-783123b122ad",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T20:40:00Z"
+      },
+      {
+        "id": "ed97be43-1e56-4328-b051-a38c83366f00",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T22:30:00Z"
+      },
+      {
+        "id": "066128fc-7a43-4b73-ac76-a7d5bb4055d8",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T20:00:00Z"
+      },
+      {
+        "id": "8811b218-e359-456e-b6e3-3fa4b7646d95",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-02",
+        "completedAt": "2025-03-02T12:50:00Z"
+      },
+      {
+        "id": "1117c2d8-5064-4b41-acdd-937479db125b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T12:45:00Z"
+      },
+      {
+        "id": "77f86fd2-644e-49e9-a433-908bbbd2b4cb",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T12:40:00Z"
+      },
+      {
+        "id": "7954beae-bf36-45e0-a405-9c377c155acd",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T07:10:00Z"
+      },
+      {
+        "id": "132b2018-cd1f-4826-9204-c9ebbd9c19cc",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T07:05:00Z"
+      },
+      {
+        "id": "4be243e3-ceed-4cd1-a00d-f8aefb201127",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T08:50:00Z"
+      },
+      {
+        "id": "75b7dea1-da37-44e4-add9-9b346f4457ed",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T07:00:00Z"
+      },
+      {
+        "id": "01dde36d-d8f3-4fb1-9d09-64132618316a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T19:45:00Z"
+      },
+      {
+        "id": "56433b1e-129c-44a9-9edf-cd34678e4b6b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T19:40:00Z"
+      },
+      {
+        "id": "10b79d35-8db4-49ab-86c0-a7dba08de87e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T21:00:00Z"
+      },
+      {
+        "id": "eef00f1e-c4ba-439c-8b52-21ddf367df7e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T18:50:00Z"
+      },
+      {
+        "id": "7d3f60c8-157f-4f82-bebf-f362f56e0ad0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-03",
+        "completedAt": "2025-03-03T19:05:00Z"
+      },
+      {
+        "id": "70493729-2275-4ccb-9c63-069783b9450c",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T06:45:00Z"
+      },
+      {
+        "id": "cf82a2e0-cd5a-451b-836a-b38768dde44c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T18:20:00Z"
+      },
+      {
+        "id": "e719486e-f847-4c32-9f5b-9e6aadb917cb",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T21:45:00Z"
+      },
+      {
+        "id": "e95329f7-cc40-4aba-b21a-c35c9b0f5620",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T06:40:00Z"
+      },
+      {
+        "id": "c208370a-a2bd-41da-b09c-bd6449ab39e5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T12:20:00Z"
+      },
+      {
+        "id": "3accedd5-bae5-4236-93fd-a1a7c09e4081",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T19:20:00Z"
+      },
+      {
+        "id": "f1cf53f8-72ac-4d4c-9c7f-1e659c15078a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T12:05:00Z"
+      },
+      {
+        "id": "64507e85-6f25-4bad-8fd9-4251d62eb157",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T21:10:00Z"
+      },
+      {
+        "id": "aa8c19cd-e20d-41e6-8608-5ceb83c9e116",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-04",
+        "completedAt": "2025-03-04T17:45:00Z"
+      },
+      {
+        "id": "888a3541-6fd3-4608-9069-5a0146134f8b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T19:05:00Z"
+      },
+      {
+        "id": "1b835e08-f879-49c6-8a12-302e59d1b9f5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T08:20:00Z"
+      },
+      {
+        "id": "87667cfc-8eac-436e-bd78-f28da2263b78",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T21:15:00Z"
+      },
+      {
+        "id": "825d225a-5729-45bd-8a60-08f7d034f69a",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T17:00:00Z"
+      },
+      {
+        "id": "79985180-fbee-4e4b-8f0e-c2f43b6d08b9",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T21:45:00Z"
+      },
+      {
+        "id": "59f6edb5-10bf-4f9b-941d-ea7da6b1c60a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T06:20:00Z"
+      },
+      {
+        "id": "192bda4e-0254-4db1-a3d8-c505ee767071",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T06:10:00Z"
+      },
+      {
+        "id": "ecb6ac0f-cada-4159-8b5d-58ef5254035b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-05",
+        "completedAt": "2025-03-05T08:10:00Z"
+      },
+      {
+        "id": "ba92c9fa-ac16-4994-b724-fc53f9457f8c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T21:50:00Z"
+      },
+      {
+        "id": "cd770ce4-996f-4876-9240-7757b6296d17",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T07:30:00Z"
+      },
+      {
+        "id": "224f4b9c-e1e3-4276-a07e-16a25c7b305c",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T06:00:00Z"
+      },
+      {
+        "id": "d87106e6-e079-40b5-b201-a2a8360214cf",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T18:10:00Z"
+      },
+      {
+        "id": "9ba61bbb-61ed-47fd-838d-ed9136faadb7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T22:10:00Z"
+      },
+      {
+        "id": "de70a5ed-5299-4d44-a576-2371a2d84a55",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T19:10:00Z"
+      },
+      {
+        "id": "7c6e6275-e4ba-491b-9c25-37c8efa20bb4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T07:40:00Z"
+      },
+      {
+        "id": "38db8b4c-806a-45be-9bab-98312206abfb",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T07:20:00Z"
+      },
+      {
+        "id": "ae293f2c-0601-469d-a264-fe911aaeac57",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-06",
+        "completedAt": "2025-03-06T22:05:00Z"
+      },
+      {
+        "id": "08cc41a2-b5ea-4946-82d1-ecb5f9ca2402",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T20:40:00Z"
+      },
+      {
+        "id": "1fdb5327-1772-44d9-baf9-98ef8606d243",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T18:30:00Z"
+      },
+      {
+        "id": "f7834803-4292-4cff-b2ef-3710a000176e",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T20:45:00Z"
+      },
+      {
+        "id": "70920fdf-3dde-4635-948f-528a44eff90b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T08:50:00Z"
+      },
+      {
+        "id": "414ee45f-8b4a-4087-a8ce-9fa3fba9cfd1",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T19:50:00Z"
+      },
+      {
+        "id": "fbdc3447-fa0b-4bcf-a739-043a1d67fbe3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T19:20:00Z"
+      },
+      {
+        "id": "6a9965af-7109-47d8-bd93-8d334f019f26",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T12:00:00Z"
+      },
+      {
+        "id": "b59775fa-8d49-40f1-b4cf-9b817f501832",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-07",
+        "completedAt": "2025-03-07T12:45:00Z"
+      },
+      {
+        "id": "6c0a48b1-cd15-4358-8953-e115d35bbcd5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T20:45:00Z"
+      },
+      {
+        "id": "a9796a72-0ddb-4077-9f6f-db53fb32c68a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T06:50:00Z"
+      },
+      {
+        "id": "783f419e-b953-4cf8-88a6-aa04f7c791d5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T22:05:00Z"
+      },
+      {
+        "id": "c7c8fccb-9333-4bfd-bebd-47b13c451c62",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T21:00:00Z"
+      },
+      {
+        "id": "6c5c1f12-974f-4c38-a74a-62b46ed5bded",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T12:15:00Z"
+      },
+      {
+        "id": "807b372c-6e98-4c6b-8e7f-302ae5247feb",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T06:50:00Z"
+      },
+      {
+        "id": "d0967b63-15c2-42dc-aa46-20bd48799ead",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T08:10:00Z"
+      },
+      {
+        "id": "4d63c0b3-023d-4faf-98b4-a0f297c8c8d0",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-08",
+        "completedAt": "2025-03-08T19:00:00Z"
+      },
+      {
+        "id": "eb1da0eb-d7e2-4737-b76a-1dacb4dc7336",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T20:05:00Z"
+      },
+      {
+        "id": "1e5cefbb-5177-4aa5-a851-5bec50ee6941",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T17:10:00Z"
+      },
+      {
+        "id": "f94ac115-3c49-4e4f-b185-3924ae84fc93",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T17:15:00Z"
+      },
+      {
+        "id": "45f951f1-3390-4504-861d-bd839f170482",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T12:10:00Z"
+      },
+      {
+        "id": "9516f6d4-e429-409c-9bab-2967aab43fc7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T06:45:00Z"
+      },
+      {
+        "id": "6ddb016f-a6f9-4a9f-a10a-4fa436a297de",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T21:45:00Z"
+      },
+      {
+        "id": "fd1df8ff-dd24-4b43-88ba-99460b4cd044",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T22:15:00Z"
+      },
+      {
+        "id": "fe9a486d-9886-4ab8-b26b-46bf24561543",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T19:30:00Z"
+      },
+      {
+        "id": "5ffe4789-6464-4a26-95fb-38706bbd21a3",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-09",
+        "completedAt": "2025-03-09T19:50:00Z"
+      },
+      {
+        "id": "22596aed-4e76-4129-8d5b-2124e6cbf0f8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T22:45:00Z"
+      },
+      {
+        "id": "bf4c03d4-4638-4729-86a7-aca957f8d3c6",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T17:20:00Z"
+      },
+      {
+        "id": "1382fd33-afca-47b6-9fc3-471c4b7cfe4a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T17:05:00Z"
+      },
+      {
+        "id": "4f2bff16-2e14-4745-ab7b-f69b5cc628a9",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T18:30:00Z"
+      },
+      {
+        "id": "ffd992ee-8342-4ea3-b0ba-df24a7438523",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T17:15:00Z"
+      },
+      {
+        "id": "0b4b05ff-f563-431e-9815-53a4ccd80243",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T22:40:00Z"
+      },
+      {
+        "id": "fd8eef80-d69d-4052-b645-d0fb5bdd8d42",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T18:40:00Z"
+      },
+      {
+        "id": "41f31c19-0f8a-4c09-a316-16791bcfee35",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T07:15:00Z"
+      },
+      {
+        "id": "c1972cd7-90d1-4c8b-b9f9-57f0b2be1481",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-10",
+        "completedAt": "2025-03-10T22:10:00Z"
+      },
+      {
+        "id": "72066947-6573-40be-94e9-200e148817f9",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T21:45:00Z"
+      },
+      {
+        "id": "3652b957-afd3-4591-851b-eb8c08ab052d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T22:50:00Z"
+      },
+      {
+        "id": "da6c22da-9052-4b93-8aad-9a7db0afc7a9",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T06:00:00Z"
+      },
+      {
+        "id": "350ba996-e40b-4607-9fa2-450767ef196b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T06:30:00Z"
+      },
+      {
+        "id": "78dda856-dc82-4703-902b-cbbdff699f32",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T12:00:00Z"
+      },
+      {
+        "id": "aef382ab-1b12-49d2-af98-217498f195b3",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T18:20:00Z"
+      },
+      {
+        "id": "2665c079-20d9-4ba7-8c4a-ac7a649afbf4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T06:05:00Z",
+        "note": "Short entry, still counts"
+      },
+      {
+        "id": "f261bb26-2844-460b-9d97-4eb7b7d1dd96",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T20:10:00Z"
+      },
+      {
+        "id": "710276a6-4917-45c1-ba78-6e4be501b6f4",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-11",
+        "completedAt": "2025-03-11T19:50:00Z"
+      },
+      {
+        "id": "55f873da-9915-4909-9214-01ec786e8e21",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T06:30:00Z"
+      },
+      {
+        "id": "ae88f678-bb75-4682-8cbc-b36589fed710",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T07:45:00Z"
+      },
+      {
+        "id": "d53f612f-f104-4236-9185-52a9c2433189",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T21:10:00Z"
+      },
+      {
+        "id": "d3238dcc-6bc7-4f01-8852-6655ddab9bd2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T12:30:00Z"
+      },
+      {
+        "id": "da2a58b9-8b76-4118-896f-ab8fba209f4d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T17:00:00Z"
+      },
+      {
+        "id": "b3139683-ed34-4ed3-8dc4-04a416274e41",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T21:30:00Z"
+      },
+      {
+        "id": "be230b6d-5408-4131-aa69-ac267c73b8ee",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T21:30:00Z"
+      },
+      {
+        "id": "22b89173-db34-4506-87bb-366c225a46ec",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T07:50:00Z"
+      },
+      {
+        "id": "bd63045d-7976-4df2-9d00-df039fbfff0c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T07:50:00Z"
+      },
+      {
+        "id": "08fee4b0-fb67-476c-aa7b-8ff05d45fc4f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-12",
+        "completedAt": "2025-03-12T12:45:00Z"
+      },
+      {
+        "id": "c5b65b4d-9489-40c0-8f25-4ebc588d3905",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T20:20:00Z"
+      },
+      {
+        "id": "a16c3bc7-078d-439f-8dc9-d0afe43603a3",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T08:40:00Z"
+      },
+      {
+        "id": "4aaad3a1-e109-45c1-8c6e-2fd7e706fd50",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T08:20:00Z"
+      },
+      {
+        "id": "02cff769-c347-4866-b2d6-3c8dfff80a09",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T07:05:00Z"
+      },
+      {
+        "id": "3872cc94-520d-4829-a7a6-eddd40f7adc5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T21:05:00Z"
+      },
+      {
+        "id": "7e8c8d62-68b4-49b2-93ba-e18ba130d112",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T06:40:00Z"
+      },
+      {
+        "id": "3d9434f2-bad4-4bb3-b6b4-581726a3d647",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T21:50:00Z"
+      },
+      {
+        "id": "f78db698-a0af-431d-8cdd-ed3d53f3d51e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-13",
+        "completedAt": "2025-03-13T22:05:00Z"
+      },
+      {
+        "id": "65282fb7-23fa-4be8-9585-e929ceab7f93",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T18:05:00Z"
+      },
+      {
+        "id": "acd386ff-fc5c-4aa2-9ca6-99a3d8487db6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T22:50:00Z"
+      },
+      {
+        "id": "0dff2417-7c96-42f6-8d97-45a2d72e764c",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T18:15:00Z"
+      },
+      {
+        "id": "bd4189d3-f940-40a2-88db-795d3f9acba8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T17:30:00Z"
+      },
+      {
+        "id": "7bc53f29-0303-4d13-9c90-41972abef8ec",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T20:05:00Z"
+      },
+      {
+        "id": "23c298aa-c0e3-449f-aa1f-d01a102fba62",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T06:30:00Z"
+      },
+      {
+        "id": "d7750d54-b48a-4c5b-9c5e-9fcf00a14210",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T06:40:00Z"
+      },
+      {
+        "id": "a3e555e6-b94b-4427-8fb1-f3f0c79dc5d5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T08:30:00Z"
+      },
+      {
+        "id": "a5d18508-8581-4a93-8259-8f17bd74d6b1",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T20:00:00Z"
+      },
+      {
+        "id": "ccc475aa-bc9c-42aa-bf5b-f5af33392301",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-14",
+        "completedAt": "2025-03-14T18:10:00Z"
+      },
+      {
+        "id": "01b5720b-b638-42d6-954c-44906be00c5f",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T18:00:00Z"
+      },
+      {
+        "id": "9f060ef3-d257-4856-bb85-e14c334b1a16",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T08:40:00Z"
+      },
+      {
+        "id": "c358eabf-6d0e-4871-98c6-2763d6d5d4ad",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T17:20:00Z"
+      },
+      {
+        "id": "0767caa7-eec5-42e1-9d01-7d8853a09a91",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T06:15:00Z"
+      },
+      {
+        "id": "81946bd9-519e-4522-a3f1-3fe6958c6de1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T21:50:00Z"
+      },
+      {
+        "id": "61b11d60-9e65-424a-9930-1787c65672ea",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T17:05:00Z"
+      },
+      {
+        "id": "3f459292-8901-4cca-85dd-1dc19c6dc0e6",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T18:10:00Z"
+      },
+      {
+        "id": "6e12dd6b-f13f-4632-9ce7-aae53ffe38c8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T12:05:00Z"
+      },
+      {
+        "id": "2e2bb712-deb1-4b94-a06b-b4df375bd4ff",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T21:50:00Z"
+      },
+      {
+        "id": "ce6100e2-176f-48dc-aa05-1332dddf6fb0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-15",
+        "completedAt": "2025-03-15T18:05:00Z"
+      },
+      {
+        "id": "805d314b-0a27-4892-b348-38f67f4dd696",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T19:45:00Z"
+      },
+      {
+        "id": "e2697532-84d5-4006-92cb-729b2f9bd687",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T21:40:00Z"
+      },
+      {
+        "id": "c6a755b2-72fe-4daf-b218-4818381040a8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T17:30:00Z"
+      },
+      {
+        "id": "594fa2c3-2365-4a3b-88ec-c3399714cc3c",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T18:15:00Z"
+      },
+      {
+        "id": "0c069cca-e1cf-4df2-8239-9ea7b83e656f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T17:15:00Z"
+      },
+      {
+        "id": "8d128062-f41d-4e0a-8d26-e26df4f5bf1c",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T22:45:00Z"
+      },
+      {
+        "id": "d08eea88-2503-4027-9608-e7fe68bbe95d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T20:20:00Z"
+      },
+      {
+        "id": "cf567253-6353-4f6b-92f4-3bc736b2c59a",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-16",
+        "completedAt": "2025-03-16T18:50:00Z"
+      },
+      {
+        "id": "bf9d4101-5765-4adf-9a64-cb823b6f7fff",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T07:40:00Z"
+      },
+      {
+        "id": "d30442d1-2560-4d33-9d7f-1bb4666882ac",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T12:50:00Z"
+      },
+      {
+        "id": "a57516bc-d128-4df0-bb63-64610858eb7f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T22:10:00Z"
+      },
+      {
+        "id": "b04e6ce8-3322-4298-bd8c-779aecde38d7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T08:40:00Z"
+      },
+      {
+        "id": "4e5f6c8c-2d9e-449f-b290-0890b65c4024",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T21:40:00Z"
+      },
+      {
+        "id": "a767aefc-591b-4e97-9231-1840fb4fdc34",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T08:00:00Z"
+      },
+      {
+        "id": "9119699d-1bc0-4a46-897a-34b3e27fdfc2",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T08:15:00Z"
+      },
+      {
+        "id": "b29468bb-d448-45bd-a4e9-7c237ac4058d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T08:00:00Z"
+      },
+      {
+        "id": "42ea996a-a5f4-41e6-b74e-142537603156",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T07:50:00Z"
+      },
+      {
+        "id": "e16e60ae-13ff-4153-b7a9-6678f00eae52",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T08:15:00Z"
+      },
+      {
+        "id": "bfd4d0c3-5396-4bda-bd24-79f8e4d2646d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T07:40:00Z"
+      },
+      {
+        "id": "7fd424c8-7187-40e2-920f-e6c0c12ff58c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T20:05:00Z"
+      },
+      {
+        "id": "19ec35f4-bbc0-4dc3-b7e4-c6015a300a93",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T22:20:00Z"
+      },
+      {
+        "id": "3e0fd1ef-0493-49d4-8749-afdb6bc9bf27",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-17",
+        "completedAt": "2025-03-17T17:20:00Z"
+      },
+      {
+        "id": "994bd39c-0c62-4b94-8002-161ee8a280b4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T17:20:00Z"
+      },
+      {
+        "id": "08f3a231-3a7a-4edf-ad8e-f69220a4f09d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T12:20:00Z"
+      },
+      {
+        "id": "4e4f598d-2c32-483d-9d93-560e0e7d27d1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T12:20:00Z"
+      },
+      {
+        "id": "bf4aa82a-aa2a-4aaa-9055-36fcdd72953c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T12:05:00Z"
+      },
+      {
+        "id": "f7da3575-b685-4140-a2d2-252214a520c2",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T22:50:00Z"
+      },
+      {
+        "id": "d0b769c6-6c4f-45fd-9acf-86f5727d4ce0",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T07:00:00Z"
+      },
+      {
+        "id": "6f79e42f-b16b-417b-be3f-328f3599782f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T18:30:00Z"
+      },
+      {
+        "id": "745d6069-aa17-4769-b39c-33b227b2e24b",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T08:30:00Z"
+      },
+      {
+        "id": "17365885-c862-4caf-b3cc-41067a93a836",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T12:45:00Z"
+      },
+      {
+        "id": "c4c3aeed-d057-4cbe-a368-e2ded479de6b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T22:20:00Z"
+      },
+      {
+        "id": "a863e55a-42eb-441a-a50c-340966f14166",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T18:05:00Z"
+      },
+      {
+        "id": "3ad58908-74f3-4d09-b4e0-adb1ec717432",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T22:10:00Z"
+      },
+      {
+        "id": "b1d95f42-1a69-4b5b-9e43-5bca0bd5fdf7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T21:30:00Z"
+      },
+      {
+        "id": "ecff8c4d-5b13-4ddb-b859-b8557351d79c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T19:20:00Z"
+      },
+      {
+        "id": "0eacc5ab-f389-497a-8a1f-165738a7f34f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-18",
+        "completedAt": "2025-03-18T22:30:00Z"
+      },
+      {
+        "id": "86b02e3d-5e4d-414d-881a-77b2af1172bc",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T21:40:00Z"
+      },
+      {
+        "id": "cb37aabe-c6b4-472e-b830-6c8ca518b894",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T19:05:00Z"
+      },
+      {
+        "id": "cd16ba36-34a9-440e-b013-68fab640c72b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T06:40:00Z"
+      },
+      {
+        "id": "5fc81650-255b-4b5e-9fbe-b9a1c030650d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T19:40:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "b320081a-1d32-498d-9a8a-0a7ea0670a4b",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T18:45:00Z"
+      },
+      {
+        "id": "d4da3c5d-52bf-49bc-9b4b-4ea68ff4a10e",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T12:15:00Z"
+      },
+      {
+        "id": "5c048ca1-d0c8-4aa6-82d7-72b0ef105120",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T22:00:00Z"
+      },
+      {
+        "id": "349b0383-37e6-41ff-ae46-493fe92f3e2e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T08:40:00Z"
+      },
+      {
+        "id": "9c0b39e2-1240-4608-898f-c6d4fb1de9b8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T21:05:00Z"
+      },
+      {
+        "id": "b2071199-ddc4-4ffa-b523-6baeeba20e99",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T12:15:00Z"
+      },
+      {
+        "id": "ffbd31a9-191c-4d36-a2fe-35c70675dd1c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-19",
+        "completedAt": "2025-03-19T06:05:00Z"
+      },
+      {
+        "id": "12244d0f-c455-478f-aaf9-0711365a18e5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T06:50:00Z"
+      },
+      {
+        "id": "ca31ed5e-8637-4732-8f76-745344972148",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T19:05:00Z"
+      },
+      {
+        "id": "249cf431-2575-4761-ad7c-4778f7c5fb98",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T20:40:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "a59f4787-6997-4d50-831b-5f02f87f1578",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T08:40:00Z"
+      },
+      {
+        "id": "9fdaadd6-3d9e-4581-b0c5-4db96e906ee5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T17:30:00Z"
+      },
+      {
+        "id": "16907e59-bf87-4508-9fa8-51cc49893a13",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T20:30:00Z"
+      },
+      {
+        "id": "c4bfc767-1f09-4a38-bb15-72a10b18de17",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T17:20:00Z"
+      },
+      {
+        "id": "5c0540db-7d0a-40a7-93cd-62e0cc57d63c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T18:40:00Z"
+      },
+      {
+        "id": "9b22fa53-56a9-4d1c-ae41-97faf6aaf6a8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T19:00:00Z"
+      },
+      {
+        "id": "17fb5881-d2f5-4576-8df4-e63475cf6bee",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T19:15:00Z"
+      },
+      {
+        "id": "08e766ae-bf43-4be4-b05b-90eacb5bcd93",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T21:05:00Z"
+      },
+      {
+        "id": "a67a3a46-b2c9-40fa-83e4-d134f8a6fd5c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T20:10:00Z"
+      },
+      {
+        "id": "740e4965-1354-4788-99f7-03ebba2e0984",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T22:50:00Z"
+      },
+      {
+        "id": "3d1c721d-8f60-4d7f-a95b-6c64f029c632",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-20",
+        "completedAt": "2025-03-20T21:45:00Z"
+      },
+      {
+        "id": "ef90edfc-6b23-445c-a9f8-3bb14abeada2",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T22:50:00Z"
+      },
+      {
+        "id": "ee4f7d77-20ab-427a-8dd7-f7b16fd30bcd",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T18:05:00Z"
+      },
+      {
+        "id": "8cedacb5-b7ec-4d41-a5ae-535e532ebfc1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T12:40:00Z"
+      },
+      {
+        "id": "37d9ac34-2a9f-491b-a07e-f116633cadf2",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T22:20:00Z"
+      },
+      {
+        "id": "179e0075-1bca-4e7b-a175-41b7af4c62cc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T08:10:00Z"
+      },
+      {
+        "id": "be4ed788-4f3b-4776-9deb-a8fff38e51c7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T18:50:00Z"
+      },
+      {
+        "id": "b7f3948a-5d2d-481c-ae0d-4402e644bfde",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T12:20:00Z"
+      },
+      {
+        "id": "0187ce87-ebd6-49b5-b50b-75f6f71c012d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T18:00:00Z"
+      },
+      {
+        "id": "240acf31-d3e6-472a-8e28-cf6248937220",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-21",
+        "completedAt": "2025-03-21T20:10:00Z"
+      },
+      {
+        "id": "ee5a8f53-d4e2-4dba-a06c-ada14504a973",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T08:20:00Z"
+      },
+      {
+        "id": "367acac9-87d1-46e3-8aec-f2a59931f940",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T22:20:00Z"
+      },
+      {
+        "id": "b898c829-9452-4908-9488-a6dd510173c9",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T06:20:00Z"
+      },
+      {
+        "id": "b6e396ce-9566-483d-b296-414737d05580",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T18:20:00Z"
+      },
+      {
+        "id": "9898f0b3-2679-43ca-804e-736b05adb07e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T18:45:00Z"
+      },
+      {
+        "id": "ee08fb4a-daa1-41c7-a501-689e383cdeab",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T22:50:00Z"
+      },
+      {
+        "id": "ffc0d8d3-4780-4f8a-9641-f959190ea3b5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T18:45:00Z"
+      },
+      {
+        "id": "4c7b83a8-c116-4cf7-90b7-891dd1a2fdbf",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T20:15:00Z"
+      },
+      {
+        "id": "0461ac10-1148-4aff-9785-ad473dcfffa6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T12:15:00Z"
+      },
+      {
+        "id": "b02a0065-2bce-4005-8431-299d6652ad04",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T21:15:00Z"
+      },
+      {
+        "id": "4f0dbf64-1744-4597-a419-174a453b1fa2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-22",
+        "completedAt": "2025-03-22T12:00:00Z"
+      },
+      {
+        "id": "0e39e4f0-d184-4846-b468-dc3abdfc22b2",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T18:30:00Z"
+      },
+      {
+        "id": "97319b71-6102-4d5f-8077-0951840d313e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T06:50:00Z"
+      },
+      {
+        "id": "2bfec260-1517-4849-a58f-a9ee1541e06c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T17:00:00Z"
+      },
+      {
+        "id": "5ef2f3b7-9ac0-4091-a66a-35f832e7961a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T21:50:00Z"
+      },
+      {
+        "id": "fb9aa974-defe-4f04-862f-0155f0a3a017",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T12:40:00Z"
+      },
+      {
+        "id": "3a1bd9c1-9b0b-49f6-b69c-eee10bb82ab4",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T12:05:00Z"
+      },
+      {
+        "id": "fdbfe060-9e4d-46b8-a85f-024b6f8d66cd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T21:50:00Z"
+      },
+      {
+        "id": "98d78e81-088b-42c9-b7a1-08047b444e52",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T08:45:00Z"
+      },
+      {
+        "id": "89947551-2d51-4b8f-9029-81b4e2b95b30",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T22:45:00Z"
+      },
+      {
+        "id": "40e447df-711f-4347-a059-1e103f6e15ae",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-23",
+        "completedAt": "2025-03-23T17:10:00Z"
+      },
+      {
+        "id": "fa07c6fd-9032-4d1b-87c4-160388533991",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T12:50:00Z"
+      },
+      {
+        "id": "3c99ef41-06d4-47ec-ac7a-5329d0e6bb00",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T21:40:00Z"
+      },
+      {
+        "id": "746a6913-bd49-435c-9568-de57a30a66c0",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T19:05:00Z"
+      },
+      {
+        "id": "d742c19e-f3a5-420c-ae28-dbb1132a3664",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T12:20:00Z"
+      },
+      {
+        "id": "586677c5-a204-466c-9c64-f9f4b0eddb48",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T19:00:00Z"
+      },
+      {
+        "id": "272726b1-4eff-422c-b140-326dc4fd5816",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T19:15:00Z"
+      },
+      {
+        "id": "f41942be-7a3f-4b92-8cea-94a7310d056f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T06:45:00Z"
+      },
+      {
+        "id": "47bc3d33-f6e9-43d7-9e12-fc1e761950dd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T07:05:00Z"
+      },
+      {
+        "id": "82270353-7b5b-4099-9f38-561b3ecfad15",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T06:10:00Z"
+      },
+      {
+        "id": "a6476368-707a-46e1-b998-13f00c991cdc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T18:50:00Z"
+      },
+      {
+        "id": "264e0f10-e376-4eda-af66-8d67edf68328",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T18:15:00Z"
+      },
+      {
+        "id": "e6af0f88-3fbe-4b6c-83ce-81f98c0ac804",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T07:45:00Z"
+      },
+      {
+        "id": "1badc13a-9560-41b2-aeac-9290123adc94",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T19:40:00Z"
+      },
+      {
+        "id": "9a577e5f-654a-4486-9fe7-1a4dbcc58427",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-24",
+        "completedAt": "2025-03-24T18:40:00Z"
+      },
+      {
+        "id": "df5f3484-2180-405f-aa29-0281199a0eb6",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T19:20:00Z"
+      },
+      {
+        "id": "2bd39114-4cab-4248-9bf7-f26b7b91cf64",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T21:00:00Z"
+      },
+      {
+        "id": "2b701834-7390-491d-93a7-8866bbb11c20",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T08:45:00Z"
+      },
+      {
+        "id": "1244c38a-bb64-471a-84f4-92a86052b2b4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T06:00:00Z"
+      },
+      {
+        "id": "d989682c-36c5-491e-85d9-79627850d3fc",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T19:05:00Z"
+      },
+      {
+        "id": "47ad1cd9-efc0-4e6a-98d5-ea8b586b1621",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T06:40:00Z"
+      },
+      {
+        "id": "3ced7f59-538a-4ff6-a046-fa6a7b818688",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T20:05:00Z"
+      },
+      {
+        "id": "6f13b462-7d2e-4bcd-9d06-226e34021089",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T21:45:00Z"
+      },
+      {
+        "id": "c00bfeea-b314-42df-b256-9322b76dfdcf",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T18:00:00Z"
+      },
+      {
+        "id": "dd94924f-3784-436e-8795-fa5e697fa1a9",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T22:50:00Z"
+      },
+      {
+        "id": "bdfdf16f-5e0c-4301-b50d-bc97c55bc972",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T22:15:00Z"
+      },
+      {
+        "id": "a775c4bb-5323-4cc2-bb01-9722c136ac4b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-25",
+        "completedAt": "2025-03-25T22:50:00Z"
+      },
+      {
+        "id": "1f621c7d-ef3e-4d38-bd72-895a2ded2cbc",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T17:05:00Z"
+      },
+      {
+        "id": "7a6e7110-86df-4d88-916c-2aceaa681d30",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T20:05:00Z"
+      },
+      {
+        "id": "7abf81cf-ee0f-4828-a4e1-633260a00455",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T19:20:00Z"
+      },
+      {
+        "id": "89c46af9-4aa7-43b3-a6bd-7b8da5704bf3",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T08:15:00Z"
+      },
+      {
+        "id": "942357d4-72a8-47ce-bec9-c1a395235e3b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T08:30:00Z"
+      },
+      {
+        "id": "0e5db2e9-3dc1-4a40-808c-0e54e6a6614a",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T12:20:00Z"
+      },
+      {
+        "id": "40c41015-f1a6-4d1c-9c78-8b607a6171e8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T06:45:00Z"
+      },
+      {
+        "id": "52f1046c-d4c7-4488-b59e-e05aaca1256e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T21:45:00Z"
+      },
+      {
+        "id": "5a31a38b-bc03-4206-8411-8cd93985c7a5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T17:30:00Z"
+      },
+      {
+        "id": "e784ba5c-1447-463d-93f1-f77bc03abeec",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T21:30:00Z"
+      },
+      {
+        "id": "2282e295-4da2-4ad4-8cb7-5300572e8d75",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-26",
+        "completedAt": "2025-03-26T18:50:00Z"
+      },
+      {
+        "id": "d462e08e-b324-477c-a9d2-0123fe02481c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T18:20:00Z"
+      },
+      {
+        "id": "9c2ec5a3-64fe-45b8-80b5-e5e1f50a543c",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T12:10:00Z"
+      },
+      {
+        "id": "0dbe6e89-40a8-4277-a2cf-74038a29c0ff",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T21:00:00Z"
+      },
+      {
+        "id": "a8f9052b-4279-4292-8846-07d85b7d7070",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T12:50:00Z"
+      },
+      {
+        "id": "678696f5-20dd-46cc-be59-4240ff0f078b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T17:40:00Z"
+      },
+      {
+        "id": "05cc489a-7370-49ed-8971-804ecb33598a",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T22:20:00Z"
+      },
+      {
+        "id": "56e6f75c-830c-4be4-b068-b436f8a1cae4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T07:50:00Z"
+      },
+      {
+        "id": "2bfdbcb0-8b3b-404a-95f9-41660ed519fb",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T19:05:00Z"
+      },
+      {
+        "id": "ef5fba33-74e0-4005-8833-cca08d0274bd",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T20:50:00Z"
+      },
+      {
+        "id": "b3529f7c-2398-492a-b734-7f104144e4ce",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T06:30:00Z"
+      },
+      {
+        "id": "da849c41-4ff9-49c0-a5ea-795774b43ea1",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T20:50:00Z"
+      },
+      {
+        "id": "83553d61-f95e-4157-91e5-2fba740cb504",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T17:40:00Z"
+      },
+      {
+        "id": "1818d66d-4fc4-4933-8165-ba6d68811469",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T20:50:00Z"
+      },
+      {
+        "id": "08657957-85fa-41bc-901b-0677104f376b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-27",
+        "completedAt": "2025-03-27T19:20:00Z"
+      },
+      {
+        "id": "0d166d00-a1f6-4842-b431-47dc416e415f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T21:45:00Z"
+      },
+      {
+        "id": "ee277bc4-28f1-498e-9237-333cf86632ed",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T06:05:00Z"
+      },
+      {
+        "id": "16b25a69-49ca-43e8-954d-cc784939bfa0",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T17:05:00Z"
+      },
+      {
+        "id": "6316b769-bfec-4c7a-b3c7-ba2977444c2f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T19:45:00Z"
+      },
+      {
+        "id": "3bf2f354-5ae2-4f50-91a2-724206f6ce1c",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T12:10:00Z"
+      },
+      {
+        "id": "338a1a05-906f-48d1-9574-e8666f6fa579",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T12:50:00Z"
+      },
+      {
+        "id": "eb3e460d-688b-4ec4-b73e-5aeba904b7bb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T06:20:00Z"
+      },
+      {
+        "id": "7729cbc9-5363-438e-bf3a-76df916f2b1d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T21:15:00Z"
+      },
+      {
+        "id": "1571c9b0-c5ce-4630-91ae-b5f6529112f1",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T17:20:00Z"
+      },
+      {
+        "id": "71eb7e3d-6eb9-4ca4-af83-bae87bf23c33",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T17:20:00Z"
+      },
+      {
+        "id": "654e5e8d-ee1e-4d58-b57f-33fb38338c46",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T17:15:00Z",
+        "note": "Low energy but showed up"
+      },
+      {
+        "id": "93f6b85a-d320-4668-9478-6c0c6ea3e914",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T12:40:00Z"
+      },
+      {
+        "id": "eb495e2f-1fe0-4869-b5af-ee868bc3183c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-28",
+        "completedAt": "2025-03-28T08:20:00Z"
+      },
+      {
+        "id": "1a874fa9-361b-4379-a15b-ed697b10763a",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T17:40:00Z"
+      },
+      {
+        "id": "53a86c8f-651b-43a4-9cd5-222c28e454a0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T06:10:00Z"
+      },
+      {
+        "id": "c86872d8-33cb-4011-a366-9272590c3721",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T18:10:00Z"
+      },
+      {
+        "id": "39390b43-46d2-4ffc-a8c7-ee3e004463a2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T20:10:00Z"
+      },
+      {
+        "id": "c1233140-988a-400d-a2eb-3439b68204bb",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T06:20:00Z"
+      },
+      {
+        "id": "60a7aac6-4dcd-46d8-bf7d-c3d75fc57553",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T22:40:00Z"
+      },
+      {
+        "id": "e0556046-1994-4cd0-ab78-b6d6e3f0616a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T17:05:00Z"
+      },
+      {
+        "id": "cbc16e5a-4e7b-4020-95f1-d321165490c3",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T18:10:00Z"
+      },
+      {
+        "id": "1ca9857b-78b7-47ab-aae4-7e2c6e10159c",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T07:45:00Z"
+      },
+      {
+        "id": "afd95b7e-9a49-43a5-9b6c-3437df96888b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-29",
+        "completedAt": "2025-03-29T07:20:00Z"
+      },
+      {
+        "id": "d4b5974a-9d1f-48c2-bd1f-91b4f9552ba7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T20:30:00Z"
+      },
+      {
+        "id": "7bd21cca-ec24-4f72-aaac-b0564fa0b25d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T07:05:00Z"
+      },
+      {
+        "id": "da270b47-32d5-483b-b9e0-afee8d406ae1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T08:40:00Z"
+      },
+      {
+        "id": "c36b80a1-d61e-441f-a8a9-c547a32295ba",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T08:40:00Z"
+      },
+      {
+        "id": "dda13277-5422-463f-8d02-e51d34f23397",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T08:00:00Z"
+      },
+      {
+        "id": "a97e3d5b-3ae3-45bb-a4bb-fb55d0c26307",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T06:40:00Z"
+      },
+      {
+        "id": "c04a14a0-079b-42e8-9e0b-eb17e4a7cf67",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T08:05:00Z"
+      },
+      {
+        "id": "1a7a6b94-e4c8-4138-af68-9261130567ea",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T18:30:00Z"
+      },
+      {
+        "id": "79419bab-be5e-4f99-a5c9-9f770615a397",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T21:40:00Z"
+      },
+      {
+        "id": "ddf733d5-f0f4-4b28-b125-32f79726f1d7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-30",
+        "completedAt": "2025-03-30T22:30:00Z"
+      },
+      {
+        "id": "6c94459d-5831-4a94-baa7-a291541041c9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T06:15:00Z"
+      },
+      {
+        "id": "dd58108c-3190-4bde-8a44-dee94b0a0bfb",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T21:20:00Z"
+      },
+      {
+        "id": "ad5bfa65-dc80-40ff-81fe-549cdd0b5b93",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T21:20:00Z"
+      },
+      {
+        "id": "e0592f02-b044-4cf3-bd80-a87874221881",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T06:40:00Z"
+      },
+      {
+        "id": "1e003b3a-00ae-47a1-be0a-2504319ff133",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T06:10:00Z"
+      },
+      {
+        "id": "4411c679-4f8a-4666-b4a7-c6ccbb022f44",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T06:50:00Z"
+      },
+      {
+        "id": "22441031-192e-4f12-9af2-409621759107",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T21:15:00Z"
+      },
+      {
+        "id": "a1054cb6-7e7a-4bab-ba68-af88616761f9",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T08:30:00Z"
+      },
+      {
+        "id": "8a71521d-1cbe-4dd2-8916-3935a0562cd9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T12:45:00Z"
+      },
+      {
+        "id": "ea6b23d2-a755-48db-be8a-c5abf4199b50",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T22:45:00Z"
+      },
+      {
+        "id": "a05672cb-5854-4e14-b455-a5afb46148e6",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-03-31",
+        "completedAt": "2025-03-31T07:30:00Z"
+      },
+      {
+        "id": "e23abf59-6674-4c91-8e10-1ff970f57dd5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T18:30:00Z"
+      },
+      {
+        "id": "7a4c38e6-bd20-4bc8-8dbd-a8dcd1e2c690",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T07:45:00Z"
+      },
+      {
+        "id": "da6dda1b-b822-489d-ac54-1bfd96dec2e4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T06:10:00Z"
+      },
+      {
+        "id": "86f97e28-74a1-48c3-bcf9-df88afe54c18",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T22:45:00Z"
+      },
+      {
+        "id": "aa6c6d5d-eb19-431b-aea8-806d7d9f7321",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T18:20:00Z"
+      },
+      {
+        "id": "30613070-b9d5-4369-89c5-07184bb32cb4",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T07:05:00Z"
+      },
+      {
+        "id": "0d7a9280-cd2c-4407-b212-a9f02b205b14",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T07:50:00Z"
+      },
+      {
+        "id": "3eb404a3-0bd9-40c5-8934-3945635bf738",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T06:45:00Z"
+      },
+      {
+        "id": "7174cc28-34de-4c43-a6ae-3a79586bc44d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T08:30:00Z"
+      },
+      {
+        "id": "34ed691a-dd91-4d1a-88ef-cfcbe1def13d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T12:40:00Z"
+      },
+      {
+        "id": "3a0342e1-7fd3-4ad3-bd64-4cd9a4936edd",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T12:20:00Z"
+      },
+      {
+        "id": "967b2ee5-34d0-471c-9de9-b1b490b793c6",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-01",
+        "completedAt": "2025-04-01T22:50:00Z"
+      },
+      {
+        "id": "79aab744-8f78-4aad-9fc9-61e59e7e008d",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T08:20:00Z"
+      },
+      {
+        "id": "a44b4f15-9924-45dd-bbee-8201e1f4f01a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T08:00:00Z"
+      },
+      {
+        "id": "926497e5-0810-495f-a814-0dda3fd10137",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T07:45:00Z"
+      },
+      {
+        "id": "9d3a7c56-e8a5-40db-8258-dda82d683c17",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T18:45:00Z"
+      },
+      {
+        "id": "b189355b-898e-4650-99b2-49bef7323835",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T06:40:00Z"
+      },
+      {
+        "id": "2e2ac6e1-27ae-461e-8c71-80691fa6b299",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T07:40:00Z"
+      },
+      {
+        "id": "32a92966-e48b-415a-a831-13967fb67c6e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T19:20:00Z"
+      },
+      {
+        "id": "648235a8-bd53-42f9-9297-d5eb8d4a365f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T06:10:00Z"
+      },
+      {
+        "id": "2cf8bef8-a2d3-4ece-a539-c99cf9cbcfd7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T17:45:00Z"
+      },
+      {
+        "id": "f20b102c-f645-43c2-98a4-1017a3f74e5f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T06:20:00Z"
+      },
+      {
+        "id": "16fe13da-f13f-41ce-a81c-59c33b44c0f3",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-02",
+        "completedAt": "2025-04-02T19:00:00Z"
+      },
+      {
+        "id": "f30adb12-742b-4966-b3f6-26c31011ef17",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T19:15:00Z"
+      },
+      {
+        "id": "f4c834ba-74f4-4d5a-b6e2-68e3c935f2c5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T08:00:00Z"
+      },
+      {
+        "id": "886d6f9c-17df-4bc9-9106-a717ba13cff2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T12:10:00Z"
+      },
+      {
+        "id": "d314330a-7e51-4c86-a099-301b919629ad",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T17:30:00Z"
+      },
+      {
+        "id": "7f9cf685-4647-4615-99d9-631056e3d198",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T22:20:00Z"
+      },
+      {
+        "id": "97c98e50-e1d6-4a6b-b854-4e4214252d57",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T12:00:00Z"
+      },
+      {
+        "id": "0afec6be-abd6-44a6-a8d1-c7c26c249d4d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T18:40:00Z"
+      },
+      {
+        "id": "0321914d-d98a-4d32-b53e-bcaedcb9d7e8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T08:10:00Z"
+      },
+      {
+        "id": "9f569d68-8ab2-403a-9f80-74a874fa95b3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T20:20:00Z"
+      },
+      {
+        "id": "98d13646-422b-4613-87d8-eda7ffa0a00e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T08:15:00Z"
+      },
+      {
+        "id": "623cc8f1-31a4-4406-b960-e6b138d034e7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T22:50:00Z"
+      },
+      {
+        "id": "7774f9b7-508d-4260-a87f-d5a8236b6fb3",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T18:40:00Z"
+      },
+      {
+        "id": "463bc3a3-9724-4cb1-b2d4-7fccfb89b475",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T21:05:00Z"
+      },
+      {
+        "id": "71bacaf8-f7e3-469a-8f49-24542d83923e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-03",
+        "completedAt": "2025-04-03T12:40:00Z"
+      },
+      {
+        "id": "69cc754c-d3ad-45b3-b25e-67d59392550b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T08:15:00Z"
+      },
+      {
+        "id": "81018c54-599a-4ba6-836b-99ba5fafe6bd",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T21:20:00Z"
+      },
+      {
+        "id": "cd94aea4-db2c-4764-9f10-f4b29d166d97",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T21:15:00Z"
+      },
+      {
+        "id": "a776ba2e-e525-472b-b282-a25c65e79660",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T06:00:00Z"
+      },
+      {
+        "id": "5fc4934f-796c-4b5d-9038-524b0acbc4ac",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T22:20:00Z"
+      },
+      {
+        "id": "8a7e8550-f99a-4e71-bdf7-b373e92814a8",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T20:40:00Z"
+      },
+      {
+        "id": "d2ee2ce9-0fc7-48d0-81a1-8ed99919647a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T18:05:00Z"
+      },
+      {
+        "id": "cdc25734-baf7-4810-860f-882a239932e4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T22:10:00Z"
+      },
+      {
+        "id": "79bd8e75-905c-4677-9436-e7723407f008",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T08:50:00Z"
+      },
+      {
+        "id": "6db17f69-a24c-495b-b60b-5b594e82a522",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T06:40:00Z"
+      },
+      {
+        "id": "6d42cc89-840c-4378-a164-6c98c9c36edf",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T07:00:00Z"
+      },
+      {
+        "id": "8c1e0816-d1e1-4162-ad13-cdcc819c12bc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T22:40:00Z"
+      },
+      {
+        "id": "da77f087-6b8d-42c2-a7ac-9f9e4457c9bd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T20:15:00Z"
+      },
+      {
+        "id": "efa45887-a9d9-43d9-9554-8777a9dfdebd",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-04",
+        "completedAt": "2025-04-04T17:20:00Z"
+      },
+      {
+        "id": "6ddb1fe4-8696-4420-bc1c-5da7e6f37ed7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T22:15:00Z"
+      },
+      {
+        "id": "f55f8ec1-f73b-44eb-90d8-d7fb3e1ea70d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T18:15:00Z"
+      },
+      {
+        "id": "18b35b2e-300b-4565-ae0e-91f45a0859b7",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T21:50:00Z"
+      },
+      {
+        "id": "0db99333-5dba-4e13-8f94-e64506c16b27",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T08:45:00Z"
+      },
+      {
+        "id": "50f869e7-c31b-4478-9a97-babf23e3ed7c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T18:30:00Z"
+      },
+      {
+        "id": "23e96f2f-fd0e-40bc-9cb7-b133fcd4be27",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T19:15:00Z"
+      },
+      {
+        "id": "22a572a8-94eb-4f74-bbf0-7a05846d596e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T08:15:00Z"
+      },
+      {
+        "id": "811ffe52-fa27-4846-a43a-1952abe3ea76",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T12:20:00Z"
+      },
+      {
+        "id": "5fe41f65-c727-4ebb-847e-6767ca84bbed",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-05",
+        "completedAt": "2025-04-05T08:20:00Z"
+      },
+      {
+        "id": "ea89a229-f58e-4436-ad3c-b876391d572c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T06:05:00Z"
+      },
+      {
+        "id": "0af8245e-0dc5-4287-9348-33d928b17259",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T17:05:00Z"
+      },
+      {
+        "id": "2e7a3a71-7ad3-4274-965b-f939f4c86249",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T19:30:00Z"
+      },
+      {
+        "id": "8fc44552-60b6-4c08-8fb9-e9942f6999e4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T21:20:00Z"
+      },
+      {
+        "id": "8bfc2ed1-5677-4ce8-acfb-9525f9f6d209",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T22:05:00Z"
+      },
+      {
+        "id": "95444f6b-d8d5-4d02-afaf-850e3779ef6d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T20:15:00Z"
+      },
+      {
+        "id": "38b99cc8-21ac-4519-8acc-6d62c45b96e9",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-06",
+        "completedAt": "2025-04-06T17:20:00Z"
+      },
+      {
+        "id": "39cbb896-d6a2-4a61-93c4-4541a2ab22bd",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T07:05:00Z"
+      },
+      {
+        "id": "52cd6092-e0a7-4f46-a2cf-f0592710458f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T12:15:00Z"
+      },
+      {
+        "id": "c5479ac7-8af8-4d78-bd82-26f80db5391a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T17:40:00Z"
+      },
+      {
+        "id": "92b59d63-0134-4932-98f1-c420fff4233f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T21:00:00Z"
+      },
+      {
+        "id": "1a63433e-3419-413e-bc9f-b6373a311840",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T06:40:00Z"
+      },
+      {
+        "id": "229ac03c-a695-45f5-9065-28a95dab3cc2",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T20:40:00Z"
+      },
+      {
+        "id": "e69d8a26-ab1b-48a9-86cb-e5fea70df768",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T21:50:00Z"
+      },
+      {
+        "id": "65373ed0-490a-42d5-aab8-e26f9db4a0a6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T12:00:00Z"
+      },
+      {
+        "id": "6af86a41-e38a-4a05-864e-71a80a90ab8e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T22:50:00Z"
+      },
+      {
+        "id": "54a049d6-f48a-419b-97bd-b010b78216ff",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T17:00:00Z"
+      },
+      {
+        "id": "27baa993-a95b-43c0-8390-1cf3f1dbabf3",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T21:30:00Z"
+      },
+      {
+        "id": "d43c2e98-6c8d-4660-86b0-19671c56c3f6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T20:00:00Z"
+      },
+      {
+        "id": "4fe00d17-1aff-4fed-a279-c0683784b23a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T12:20:00Z"
+      },
+      {
+        "id": "41a181a4-0415-4a04-85ac-0983054897ff",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-07",
+        "completedAt": "2025-04-07T21:40:00Z"
+      },
+      {
+        "id": "0bc41707-574a-410c-8cdd-453dff328796",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T22:00:00Z"
+      },
+      {
+        "id": "2f87c376-8010-4b35-96ea-4def42acc087",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T17:45:00Z"
+      },
+      {
+        "id": "5f52a81f-ac46-4fb8-9da0-96c973cb7871",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T20:30:00Z"
+      },
+      {
+        "id": "7b905511-0c6e-4a96-b1ac-953f2204a73f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T18:15:00Z"
+      },
+      {
+        "id": "a2556a3f-83e3-4bae-afc7-3318b7075c63",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T22:40:00Z"
+      },
+      {
+        "id": "cd4b9c9e-d7e4-4c37-b43e-a70cdb8120a1",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T06:05:00Z"
+      },
+      {
+        "id": "1d5ed2cb-3c52-416d-abb3-d04067cff64e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T18:00:00Z"
+      },
+      {
+        "id": "c51c98d3-164e-4b82-9e61-8260a94fc98a",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T20:45:00Z"
+      },
+      {
+        "id": "6affec93-bce4-4650-a5e5-f90cd362ad76",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T21:45:00Z"
+      },
+      {
+        "id": "4496b2d4-1336-40e8-995b-7325dcb5671c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T21:50:00Z"
+      },
+      {
+        "id": "9cab1ad7-4b78-4b6c-88fd-57282047bb68",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-08",
+        "completedAt": "2025-04-08T18:50:00Z"
+      },
+      {
+        "id": "f8e253b8-348e-40c8-b47d-9cffd418f8f5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T08:00:00Z"
+      },
+      {
+        "id": "320392bd-3d07-4874-97b2-94c53b9279ca",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T06:30:00Z"
+      },
+      {
+        "id": "ce943f5e-ec4c-43a7-bdfd-05cdfe5db19f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T22:20:00Z"
+      },
+      {
+        "id": "99b8445e-ad1a-40c6-b609-e58f3b44e270",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T22:30:00Z"
+      },
+      {
+        "id": "244ffbd7-64c2-4fad-a5e4-bfb8609be0aa",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T20:05:00Z"
+      },
+      {
+        "id": "6b39f185-b465-4c69-b6ee-7b6231df8b62",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T20:40:00Z"
+      },
+      {
+        "id": "9b4fcccf-5d71-47ff-b296-6224fd43af29",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T17:10:00Z"
+      },
+      {
+        "id": "fba8df09-1d35-4886-a763-0b8e5bd7af6c",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T07:20:00Z"
+      },
+      {
+        "id": "21b5c237-f4d2-40bb-add5-b7b13747b045",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T18:05:00Z"
+      },
+      {
+        "id": "7cd2274e-7a51-4f62-a7c2-735a0e514c9a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T17:40:00Z"
+      },
+      {
+        "id": "bf5db538-5f03-4409-af2c-a876fac2ff5d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T19:45:00Z"
+      },
+      {
+        "id": "a186741e-665b-46f5-8c13-81174a512039",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T19:00:00Z"
+      },
+      {
+        "id": "32960163-4a77-4c00-a359-390e2352994d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-09",
+        "completedAt": "2025-04-09T18:05:00Z"
+      },
+      {
+        "id": "b3b4b128-8383-45f8-9eb8-a3eb31dccb7c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T18:10:00Z"
+      },
+      {
+        "id": "540277e3-d6b7-4d1d-899b-465c51bdbc65",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T08:45:00Z"
+      },
+      {
+        "id": "bfe98b5c-6d6d-4ab5-a4e0-e74775c29dbf",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T17:10:00Z"
+      },
+      {
+        "id": "c1e9c0a1-a2ed-4f8c-af3e-463153f87347",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T22:10:00Z"
+      },
+      {
+        "id": "1e06f4e6-bbf8-4739-ad40-909fa67a0388",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T12:20:00Z"
+      },
+      {
+        "id": "d6c122ef-e1f1-4c9b-8719-1b623b4e81ac",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T18:15:00Z"
+      },
+      {
+        "id": "8f87282a-368b-418d-bed5-07297ce2fabd",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T12:00:00Z"
+      },
+      {
+        "id": "adf1f1d6-3991-42be-b592-5201b8b5f489",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T07:45:00Z"
+      },
+      {
+        "id": "85550f1f-50f9-45b0-8671-c2ff52fd4363",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T22:00:00Z"
+      },
+      {
+        "id": "41a48b27-5aa0-4550-80a9-1a9b57433f5e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T17:10:00Z"
+      },
+      {
+        "id": "6496d5a0-f98c-41a2-a96c-bfdc2e3155a5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T07:40:00Z"
+      },
+      {
+        "id": "59850af0-a5c9-4998-824c-99c909ca8e35",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T19:20:00Z"
+      },
+      {
+        "id": "a7ac5bda-6c88-4286-a404-e454a197333f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T17:10:00Z"
+      },
+      {
+        "id": "048c59d1-c506-4150-9119-38d7fdcaecef",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T22:15:00Z"
+      },
+      {
+        "id": "650b0a88-dcc1-4bfc-b24b-06de60c84593",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T19:10:00Z"
+      },
+      {
+        "id": "95952250-0057-4bc9-922f-cdf11489a5aa",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-10",
+        "completedAt": "2025-04-10T18:30:00Z"
+      },
+      {
+        "id": "bfde9188-3b2a-48b9-aa86-6c63971b4905",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T21:05:00Z"
+      },
+      {
+        "id": "d5185777-e709-4a78-a296-8f392b5cd66a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T07:40:00Z"
+      },
+      {
+        "id": "34ae903c-b13a-461b-8252-a1bb6d0f233c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T21:50:00Z"
+      },
+      {
+        "id": "0857b5b3-86ba-4b66-a896-5b829343438c",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T12:00:00Z"
+      },
+      {
+        "id": "59e1bf62-35ea-4bc4-bbce-80cc303ca3d6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T17:30:00Z"
+      },
+      {
+        "id": "5dfc347a-011b-4a2b-a28f-d79f2fbe7768",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T21:40:00Z"
+      },
+      {
+        "id": "8d1d036e-c87d-44be-b77a-c5c6b3519691",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T12:05:00Z"
+      },
+      {
+        "id": "1710df75-5dbe-48e8-ae51-00c31d155e09",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T06:10:00Z"
+      },
+      {
+        "id": "b40d3967-baf6-4a94-8cf9-c6b1da42127e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T07:00:00Z"
+      },
+      {
+        "id": "c56c54ce-f581-417c-b7ce-f5f948102cb5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T12:45:00Z"
+      },
+      {
+        "id": "8778a204-a78e-4a48-80cf-c6ebe091cb8e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T22:15:00Z"
+      },
+      {
+        "id": "3404f615-0528-43eb-bb33-f90ffea1e8fe",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T20:05:00Z"
+      },
+      {
+        "id": "c166c77d-5ae3-4efa-97c9-a28f9a58dfba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T07:05:00Z"
+      },
+      {
+        "id": "58c52fcb-84d2-4cf9-8339-44654831e6d3",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-11",
+        "completedAt": "2025-04-11T18:00:00Z"
+      },
+      {
+        "id": "6bb4809f-f572-4d1c-92ac-f5b214d4b227",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T08:45:00Z"
+      },
+      {
+        "id": "bbcc1642-28d1-402d-94bc-4bd7bf20101f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T19:45:00Z"
+      },
+      {
+        "id": "c13b6319-3583-47ad-af6d-0906673fdce8",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T17:45:00Z"
+      },
+      {
+        "id": "fb7852f9-0c2d-48bd-852b-185212824eb8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T07:00:00Z"
+      },
+      {
+        "id": "61b43477-2b3b-4375-8f6b-b5c639272a3c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T17:05:00Z"
+      },
+      {
+        "id": "efc770ba-4e12-4a5b-9869-8c92d6362e1b",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-12",
+        "completedAt": "2025-04-12T19:15:00Z"
+      },
+      {
+        "id": "9d0c29eb-249a-49b8-a9ae-c0e1d6cea342",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T08:50:00Z"
+      },
+      {
+        "id": "0d7d9144-32bd-4d03-9a8e-9b063907ebc8",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T22:15:00Z"
+      },
+      {
+        "id": "8f5c87d8-c9ae-4c43-96a2-87584a860e88",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T08:20:00Z"
+      },
+      {
+        "id": "00e63c3d-21f1-4337-a0e3-10e230941ecc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T20:00:00Z"
+      },
+      {
+        "id": "062e4c4f-0015-45cb-8f40-fdb321706465",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T21:05:00Z"
+      },
+      {
+        "id": "9f57b0f5-3c4f-4cc5-b09a-9b0e72485e0d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-13",
+        "completedAt": "2025-04-13T21:20:00Z"
+      },
+      {
+        "id": "51f49cc7-e4f0-4def-8166-a642459e632a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T12:30:00Z"
+      },
+      {
+        "id": "38a83398-e5d5-4f59-aae6-f91f70a65cab",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T18:40:00Z"
+      },
+      {
+        "id": "c1c5eb06-3399-486a-8829-a9fab8942498",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T18:05:00Z"
+      },
+      {
+        "id": "5541f90a-d9d6-4008-bede-1f0ba9f873f8",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T18:45:00Z"
+      },
+      {
+        "id": "fcfb1efb-e79c-47a7-b525-63e1a6834090",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T21:20:00Z"
+      },
+      {
+        "id": "6cac3c04-e758-43bd-aba9-642267468308",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T22:05:00Z"
+      },
+      {
+        "id": "606b08a9-e77f-4063-bf1e-fb2be5b7f65e",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T06:00:00Z"
+      },
+      {
+        "id": "88e92397-e4ef-4ef4-a09c-2a6e96271b7d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T18:05:00Z"
+      },
+      {
+        "id": "cd0c3621-0a73-4d01-bb82-bd1bb7e6f563",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T18:40:00Z"
+      },
+      {
+        "id": "020170c9-ff6d-4599-ac8c-da64b86c5f4c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T17:10:00Z"
+      },
+      {
+        "id": "d196dd39-ceb1-4116-9240-bdf7b6c0a730",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T08:45:00Z"
+      },
+      {
+        "id": "946c6ecf-67c1-4785-b519-2185668e66de",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T08:10:00Z"
+      },
+      {
+        "id": "300f456a-9ab4-48e5-b4d2-212552c49174",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T20:40:00Z"
+      },
+      {
+        "id": "828d27ff-d401-4a98-9d7e-dc9d2d2bb3b3",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-14",
+        "completedAt": "2025-04-14T08:40:00Z"
+      },
+      {
+        "id": "b5eb6348-9a2b-4086-b171-4566fc27b55a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T20:20:00Z"
+      },
+      {
+        "id": "3eef0a57-9a5e-432c-80a8-8351d5d4d5d4",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T06:20:00Z"
+      },
+      {
+        "id": "4642fb48-2313-4ed1-95e0-411e4e12eb6c",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T21:30:00Z"
+      },
+      {
+        "id": "de81b53b-21f8-4d0d-8620-6a0baa2e078c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T08:30:00Z"
+      },
+      {
+        "id": "fab84725-a5f7-42f7-bacb-d1957cbc18a1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T19:30:00Z"
+      },
+      {
+        "id": "1eba9cdf-c03d-4f16-97f2-ab9d231cea6f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T12:00:00Z"
+      },
+      {
+        "id": "9f2e61fc-384e-48bf-816b-d3a9ea1d3818",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T21:15:00Z"
+      },
+      {
+        "id": "5846a055-6d69-4c7b-a8ef-d897807d7a6e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T12:05:00Z"
+      },
+      {
+        "id": "177c90bf-8bcd-4c95-ae2d-ceb7d0bf8ee7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T17:20:00Z"
+      },
+      {
+        "id": "6ecc540f-d914-4f25-bc04-35befa2dd0be",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T08:05:00Z"
+      },
+      {
+        "id": "c847f3cd-74a7-401a-ac26-45bf51ff42f6",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-15",
+        "completedAt": "2025-04-15T22:50:00Z"
+      },
+      {
+        "id": "50a83c0e-7874-4763-9044-5c5727e7dc26",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T12:20:00Z"
+      },
+      {
+        "id": "b1ea7fec-ece8-4d60-abd9-dc9afc7ed4d6",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T21:15:00Z"
+      },
+      {
+        "id": "fce8a58b-3b9f-4a2d-b660-09e56782df71",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T19:50:00Z"
+      },
+      {
+        "id": "240e6e1e-6b58-4cf6-bc46-b68e1f416f1c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T21:15:00Z"
+      },
+      {
+        "id": "773eb50b-3b1c-408a-8e73-ee2e5e8f34f3",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T08:45:00Z"
+      },
+      {
+        "id": "c51920f1-41ff-422f-a594-ec3394d231d2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T07:10:00Z"
+      },
+      {
+        "id": "a6cae82f-1e64-45ef-b088-97674aa3f2c1",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T07:00:00Z"
+      },
+      {
+        "id": "3d0ef70f-fa76-44f5-84d9-f5d93dffcb6d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T20:00:00Z"
+      },
+      {
+        "id": "2ecdefcd-2893-4657-8c7e-f252a5b70ac9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T08:00:00Z"
+      },
+      {
+        "id": "fb9ef4a2-0eb1-4d8e-a413-63b325d99542",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T08:40:00Z"
+      },
+      {
+        "id": "2080c547-7e91-412a-b1c2-7680c3c443a3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T08:30:00Z"
+      },
+      {
+        "id": "8be01fc7-b01e-402e-bb91-b3c85975848d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T22:30:00Z"
+      },
+      {
+        "id": "f76d019a-1a30-45f2-9275-5eb1614166c7",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-16",
+        "completedAt": "2025-04-16T18:00:00Z"
+      },
+      {
+        "id": "cf0e4c21-d84b-4650-ba6a-d165e65cd303",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T08:15:00Z"
+      },
+      {
+        "id": "90a45384-98fd-484c-9af6-935386f40f8e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T17:05:00Z"
+      },
+      {
+        "id": "a2903b1a-0cec-49c3-a8d9-960a88cbcff3",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T20:15:00Z"
+      },
+      {
+        "id": "5ec978c6-6302-4142-9d3e-e7c6806c5f9b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T19:00:00Z"
+      },
+      {
+        "id": "6a9242a0-45ec-49c8-bc19-0bd0777c611e",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T20:30:00Z"
+      },
+      {
+        "id": "c3c2a357-d754-4f59-8833-cf3a9a2cea7d",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T22:45:00Z"
+      },
+      {
+        "id": "9c0cdf69-c4e3-48c7-a916-70e513e1e871",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T07:15:00Z"
+      },
+      {
+        "id": "cc20f687-cdc1-43e5-be91-9178bc620cb5",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T19:30:00Z"
+      },
+      {
+        "id": "0f314d83-c197-4b7a-a77d-b771c0b75cc9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T18:40:00Z"
+      },
+      {
+        "id": "9db681f3-f5f0-47b8-bd09-596f8dd80559",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T20:15:00Z"
+      },
+      {
+        "id": "fdea7f04-d3f0-49ef-93b7-92f938458248",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T17:00:00Z"
+      },
+      {
+        "id": "967e1fc2-7fda-4b30-af97-c18d5280a6a4",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-17",
+        "completedAt": "2025-04-17T06:30:00Z"
+      },
+      {
+        "id": "2c473e06-acd1-420a-a828-4460e22817b1",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T20:30:00Z"
+      },
+      {
+        "id": "158e6e7a-1a8f-4f29-b658-f014c531f5c1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T20:00:00Z"
+      },
+      {
+        "id": "bfb1c997-9212-4994-a149-25b7e514196b",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T18:10:00Z"
+      },
+      {
+        "id": "c3d76bb4-468b-4754-93e3-758e8188428b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T21:50:00Z"
+      },
+      {
+        "id": "0ea4a86b-787f-4d76-975e-f66da1fdafd8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T12:40:00Z"
+      },
+      {
+        "id": "aa078bf5-f7c7-4a88-b710-f7d736c04e71",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T20:20:00Z"
+      },
+      {
+        "id": "ba83aa20-33ba-4bd3-a467-75cef079c635",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T06:20:00Z"
+      },
+      {
+        "id": "b6bc2a5a-ea2e-4fe3-b48a-a3d01acf67ba",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T17:10:00Z"
+      },
+      {
+        "id": "5af5b294-8f56-41e4-b2f7-3cb79d1b77fc",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T22:05:00Z"
+      },
+      {
+        "id": "d87af92f-c69b-4baf-b16b-37154a26eb1d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-18",
+        "completedAt": "2025-04-18T08:20:00Z"
+      },
+      {
+        "id": "4f8686bd-c765-43ef-b251-1a7b8f5ee6af",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T12:15:00Z"
+      },
+      {
+        "id": "32c753fd-c085-47c2-8ea2-45f5f2254ecb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T08:10:00Z"
+      },
+      {
+        "id": "13fc4214-f8d4-4748-a4c7-944d64a29187",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T17:05:00Z"
+      },
+      {
+        "id": "7447bff3-9ce1-4d4a-9029-8a836716ef9a",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T07:15:00Z"
+      },
+      {
+        "id": "16bb30f2-b223-4865-9c66-01ffaaee5696",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T17:45:00Z"
+      },
+      {
+        "id": "eac54663-639e-4d52-b41e-12205ab21f05",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T06:30:00Z"
+      },
+      {
+        "id": "43a7b61f-d5fa-4d51-8309-81b0e553186a",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T22:10:00Z"
+      },
+      {
+        "id": "bbbce108-1175-4cc4-b2c5-6f54816ef615",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-19",
+        "completedAt": "2025-04-19T08:05:00Z"
+      },
+      {
+        "id": "fc143263-c9dc-4295-9d88-e56001c046c4",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T07:40:00Z"
+      },
+      {
+        "id": "d11af323-b44a-4ddd-94b7-2832a91090c4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T22:40:00Z"
+      },
+      {
+        "id": "a0c3bc9d-5b93-4244-a448-a30cf78816d0",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T20:50:00Z"
+      },
+      {
+        "id": "35a3aa39-1267-4012-9e2c-46c7b1e8f0f2",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T07:05:00Z"
+      },
+      {
+        "id": "6bbfd716-6e32-46e9-8f78-8aa5442eca9c",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T12:40:00Z"
+      },
+      {
+        "id": "f74b112b-118a-4f30-8b04-b7f2c4e6571b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T20:10:00Z"
+      },
+      {
+        "id": "78b088af-8b72-4257-8ef6-057e9be9357f",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T22:30:00Z"
+      },
+      {
+        "id": "be53b1b6-7b90-4215-bf4b-c0ffc04b4ae6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T19:20:00Z"
+      },
+      {
+        "id": "1cbfae53-67bb-4b9b-a180-661b49de3b51",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T19:05:00Z"
+      },
+      {
+        "id": "b81e3b70-a0aa-4183-a7c3-35e4002576b7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-20",
+        "completedAt": "2025-04-20T22:10:00Z"
+      },
+      {
+        "id": "2c02d17f-b26e-40b1-aaf1-73c27a2514f0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T21:30:00Z"
+      },
+      {
+        "id": "e93358ff-6a8c-43e3-884a-9ef83e3e6e8a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T21:30:00Z"
+      },
+      {
+        "id": "f7f8cb54-5afa-4a2e-8af6-b0e657c35f3d",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T21:30:00Z"
+      },
+      {
+        "id": "b60d8a00-67c2-4902-84ae-493a9407c816",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T17:45:00Z"
+      },
+      {
+        "id": "7ae50920-456d-4967-93a9-1dd30b0f418e",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T07:40:00Z"
+      },
+      {
+        "id": "a4dde9c4-6161-42a3-99b9-37372666aaf9",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T17:50:00Z"
+      },
+      {
+        "id": "61c0ea19-247c-4f6e-b040-f45ebd4256fb",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T08:10:00Z"
+      },
+      {
+        "id": "a44f787b-2e02-4839-8cb7-59461d2166a9",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T06:20:00Z"
+      },
+      {
+        "id": "fdb143ea-485c-4bdf-a4fa-a99a8c85e9f5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T19:30:00Z"
+      },
+      {
+        "id": "b54a5984-1728-45b7-9024-7629a86de2d0",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T21:05:00Z"
+      },
+      {
+        "id": "49bf9e56-138f-43c4-90f8-a553058675f2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T18:05:00Z"
+      },
+      {
+        "id": "34d35c41-7458-4b24-b59c-a0f8b7e71169",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-21",
+        "completedAt": "2025-04-21T08:50:00Z"
+      },
+      {
+        "id": "7a4bc49b-8470-4611-91ac-9126a7354b35",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T08:20:00Z"
+      },
+      {
+        "id": "dd53c840-9494-4c82-a73b-f2646e468810",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T21:10:00Z"
+      },
+      {
+        "id": "cd21accd-e73f-408c-acd8-455a38985cae",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T19:15:00Z"
+      },
+      {
+        "id": "c5e863b3-2b04-4f4a-a9bc-cd48fbfa47ee",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T06:45:00Z"
+      },
+      {
+        "id": "34ec22f8-3600-4c18-afd3-43f200329698",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T07:50:00Z"
+      },
+      {
+        "id": "72d12fb3-1312-4a16-a00d-d43216a82ee4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T21:15:00Z"
+      },
+      {
+        "id": "d7c3f13b-4649-4013-babd-da76d2e856ef",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T18:00:00Z"
+      },
+      {
+        "id": "13bdd3eb-9a05-453b-b58e-5a44ff06ae40",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T22:00:00Z"
+      },
+      {
+        "id": "76448cc8-b2c9-4645-8b3e-25e89acb76f8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T18:45:00Z"
+      },
+      {
+        "id": "a54fcd75-390d-457f-ba0a-93d559b84acb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T22:20:00Z"
+      },
+      {
+        "id": "b6794c26-036a-4602-a110-746334b3ca21",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T21:00:00Z"
+      },
+      {
+        "id": "a5e67f26-009d-488f-b495-8fcfe37b73fa",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T12:30:00Z"
+      },
+      {
+        "id": "1a838a71-ce61-4a01-b509-591e31a45b3b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T08:50:00Z"
+      },
+      {
+        "id": "9e36c6b2-33da-4086-b0a1-64c1d9a64185",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T19:10:00Z"
+      },
+      {
+        "id": "94bbf8f9-98dd-48fc-9d1f-a0fe1eaf54ed",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-22",
+        "completedAt": "2025-04-22T07:15:00Z"
+      },
+      {
+        "id": "6ef98b49-fcfa-4c5f-8857-61c4c2591114",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T12:15:00Z"
+      },
+      {
+        "id": "2917090e-5b2d-4b3c-8dc3-525aba2fd621",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T21:45:00Z"
+      },
+      {
+        "id": "2ba5cbbc-ba93-4fb8-8e69-824aaece11f1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T12:40:00Z"
+      },
+      {
+        "id": "61339c41-9dca-4f0f-b415-fae5617e6661",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T21:10:00Z"
+      },
+      {
+        "id": "0a3415ab-5e63-47b2-90cd-7abb01bf6d91",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T17:40:00Z"
+      },
+      {
+        "id": "09530508-ad4e-4ca1-9e01-b96392e40976",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T07:00:00Z"
+      },
+      {
+        "id": "55d799be-f47b-4081-afa2-df34d3f2664d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T07:45:00Z"
+      },
+      {
+        "id": "13bccb94-b05d-445e-8148-d4e8d181e778",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T07:20:00Z"
+      },
+      {
+        "id": "46f3da36-4cc5-4330-86db-5e43f1ab87c1",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T18:20:00Z"
+      },
+      {
+        "id": "97bb2a79-953b-42d3-aecb-eed69c369bc4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T18:30:00Z"
+      },
+      {
+        "id": "3e40f16c-51de-48e2-bf39-7a9fafb10e0c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T19:10:00Z"
+      },
+      {
+        "id": "6e595957-d17e-4475-87ea-a899ddfacfa1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T08:05:00Z"
+      },
+      {
+        "id": "e8e6b24e-0ff9-4a0e-ad18-dc33f748e23f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-23",
+        "completedAt": "2025-04-23T19:40:00Z"
+      },
+      {
+        "id": "4a65fa81-14d6-46b6-a363-e8d767736063",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T07:20:00Z"
+      },
+      {
+        "id": "b3467333-9652-4057-ba9a-b6da0ff7fe3f",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T06:50:00Z"
+      },
+      {
+        "id": "06ec67a1-7c28-46d6-b7fd-668a3d8f41d0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T06:05:00Z"
+      },
+      {
+        "id": "e6bc19d5-e6b6-4c08-81d4-023990e7037b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T22:50:00Z"
+      },
+      {
+        "id": "bf9dfbb4-9e88-4d55-9946-4bcd20560aed",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T06:10:00Z"
+      },
+      {
+        "id": "49c43f5c-1d35-4f71-8835-05b14af8e623",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T08:10:00Z"
+      },
+      {
+        "id": "4f0a9550-2dc3-4eaf-bc65-4cd0a32804fd",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T22:00:00Z"
+      },
+      {
+        "id": "57c38692-0b1c-4d0f-a71c-5b51a1a2816d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T07:15:00Z"
+      },
+      {
+        "id": "fccbd40b-7998-438b-9852-a60c691fa126",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T18:10:00Z"
+      },
+      {
+        "id": "ccfdae0a-4eb6-4e44-aa02-2d41f6891e82",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T17:40:00Z"
+      },
+      {
+        "id": "067250ad-9954-483b-b1e0-783b959788d5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T17:30:00Z"
+      },
+      {
+        "id": "a7d461b4-2f97-494a-8b70-45eace77656f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T20:40:00Z"
+      },
+      {
+        "id": "943403e9-f337-4a45-8437-3547183600fc",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T18:45:00Z"
+      },
+      {
+        "id": "c430c2bb-8d65-4ad4-926c-560c3bc981c2",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T21:45:00Z"
+      },
+      {
+        "id": "d3d0d6de-4fae-4030-b8f8-997b5761d221",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T12:45:00Z"
+      },
+      {
+        "id": "df23f02e-f1b1-4291-8766-5ac27c3b333e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-24",
+        "completedAt": "2025-04-24T07:05:00Z"
+      },
+      {
+        "id": "73b21793-30b6-4062-9acd-f90dcd881b6f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T08:15:00Z"
+      },
+      {
+        "id": "23cde441-d2fc-4f1f-aa90-998613bbe19a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T18:10:00Z"
+      },
+      {
+        "id": "924a3f3b-fb3c-47c2-89ad-74df10536420",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T08:30:00Z"
+      },
+      {
+        "id": "57fc94d8-0ee7-4e7c-9911-7ddd6d9f5c34",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T22:15:00Z"
+      },
+      {
+        "id": "8c836b8e-5fbd-431d-b115-babee0dec1b2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T19:50:00Z"
+      },
+      {
+        "id": "3b184a91-a370-47cd-b2f7-caf0b06fe23d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T22:30:00Z"
+      },
+      {
+        "id": "4154c6d2-610a-4ee6-b5b0-2b9f8a9aac4c",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T22:00:00Z"
+      },
+      {
+        "id": "f7237e56-e38b-43df-93e4-0ff9295b2dc6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T22:05:00Z"
+      },
+      {
+        "id": "247ad6be-447a-4546-9fff-e8ed5dce97f0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T17:50:00Z"
+      },
+      {
+        "id": "c77e9e75-98b9-47bb-9773-a674b1a6b3bd",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T20:30:00Z"
+      },
+      {
+        "id": "3ee43519-8642-496c-894a-938287e9a834",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T07:45:00Z"
+      },
+      {
+        "id": "e1d3e656-2b8a-4199-bc56-32a17122c8ff",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-25",
+        "completedAt": "2025-04-25T21:15:00Z"
+      },
+      {
+        "id": "dab58839-e427-479f-a9f3-c66d09158fee",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T18:50:00Z"
+      },
+      {
+        "id": "f7a20f7f-59df-4f72-80fe-230ccfdb8247",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T12:05:00Z"
+      },
+      {
+        "id": "6050b18d-6e8a-4cef-a62f-885f5391cd76",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T20:40:00Z"
+      },
+      {
+        "id": "fea4cf7e-5221-4b67-8512-62279196f58e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T06:45:00Z"
+      },
+      {
+        "id": "570a4e2e-b4cb-4f90-8dea-84f425a4a5b0",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T12:20:00Z"
+      },
+      {
+        "id": "2384cc8f-20d8-402b-9e2d-aa5e87c7d680",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T22:30:00Z"
+      },
+      {
+        "id": "b8dcfe82-c5f3-49b7-8ddf-11b650ba0e43",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T12:50:00Z"
+      },
+      {
+        "id": "b1878b71-4fcc-4331-880a-8d42d60e9a1b",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T07:15:00Z"
+      },
+      {
+        "id": "2e59e1cb-ad68-4509-a8dd-4f8a9f8c1712",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T12:50:00Z"
+      },
+      {
+        "id": "41db375d-5559-4acc-9701-d55558c04b9b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T18:00:00Z"
+      },
+      {
+        "id": "a2f4fce5-bb3e-4295-9bfe-9e70246115af",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T19:00:00Z"
+      },
+      {
+        "id": "6a0c857a-a686-4955-9ea1-10dc66065961",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-26",
+        "completedAt": "2025-04-26T07:15:00Z"
+      },
+      {
+        "id": "809d74b2-d3e8-413d-bedc-4700ccbec5ed",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T22:10:00Z"
+      },
+      {
+        "id": "97e78b82-20a3-4040-b867-e338030eb6c1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T06:20:00Z"
+      },
+      {
+        "id": "cb200863-dd83-4a24-bf2c-2445bf5172ed",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T20:00:00Z"
+      },
+      {
+        "id": "70a51a04-cc5a-4858-9701-6c03a90698b9",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T22:20:00Z"
+      },
+      {
+        "id": "b5000641-59a7-490c-b7ec-d4dc4386c827",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T08:05:00Z"
+      },
+      {
+        "id": "374ee286-4d7a-4656-90f4-a559d6f9de02",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T17:00:00Z"
+      },
+      {
+        "id": "a4453d50-da75-40f2-a5d3-d5273ff5536e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T12:45:00Z"
+      },
+      {
+        "id": "69720145-d7ce-47ae-a6e7-433baa706fdd",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T06:20:00Z"
+      },
+      {
+        "id": "bd31c9a1-2c4e-4ca4-9a5a-1b2bea1bbfad",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-27",
+        "completedAt": "2025-04-27T12:40:00Z"
+      },
+      {
+        "id": "a5025de5-b69b-4b28-8c24-1cfd32615c1f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T19:15:00Z"
+      },
+      {
+        "id": "0f26d0f7-ec63-4412-951f-991b7a09c3ef",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T12:00:00Z"
+      },
+      {
+        "id": "dbd09a48-dd74-4704-8ee5-72ca358388bc",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T07:20:00Z"
+      },
+      {
+        "id": "d728baa2-4179-47cf-a164-f1debbf486de",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T22:00:00Z"
+      },
+      {
+        "id": "89e71557-ebd6-4cac-9102-83246258fd1d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T18:30:00Z"
+      },
+      {
+        "id": "8fbb433c-1165-4597-9ed2-3c00744978fd",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T22:15:00Z"
+      },
+      {
+        "id": "470fc659-122b-48a6-be8e-0a3c0ab2a941",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T07:30:00Z"
+      },
+      {
+        "id": "716656b1-7197-4a35-b737-d94e2b704006",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T19:30:00Z"
+      },
+      {
+        "id": "c3c6f4d6-66b6-41f4-bef1-d7a1f8ad9520",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T07:50:00Z"
+      },
+      {
+        "id": "c6892fd0-3106-444d-912f-301ebc26cb38",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T08:00:00Z"
+      },
+      {
+        "id": "411e2daf-4e98-48ed-b84a-609488af74e5",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T17:45:00Z"
+      },
+      {
+        "id": "3f7a77b0-a6db-4796-8eb7-2f7820192bd7",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T22:05:00Z"
+      },
+      {
+        "id": "8a8a94e0-140c-4526-86cf-e5a2df0aa6a5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T08:05:00Z"
+      },
+      {
+        "id": "5770173c-a75a-42c1-a31c-d2238849fa95",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T08:45:00Z"
+      },
+      {
+        "id": "1d0c65ac-02a2-4645-8033-53f2e5f6c1f4",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-28",
+        "completedAt": "2025-04-28T07:50:00Z"
+      },
+      {
+        "id": "095f0c3f-e25d-4848-b74f-1f68b0e80397",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T22:30:00Z"
+      },
+      {
+        "id": "a3c3e820-010d-460c-b4b9-311f6663252a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T08:45:00Z"
+      },
+      {
+        "id": "a27f7fcd-76ad-449a-8002-dbd9b1477ce9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T18:00:00Z"
+      },
+      {
+        "id": "b300879c-be8e-4829-998f-49a0f633fe6d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T19:50:00Z"
+      },
+      {
+        "id": "26924d0d-47b7-4c9f-95a7-c31e8386b108",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T20:05:00Z"
+      },
+      {
+        "id": "cdfc1d8f-da08-4c5b-b201-a3a9cde24baf",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T08:20:00Z"
+      },
+      {
+        "id": "556552fc-b13a-43d7-93b8-f40c6a21cd76",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T12:05:00Z"
+      },
+      {
+        "id": "1cc7909b-04f0-43d9-9541-e23e6fa713bc",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T07:20:00Z"
+      },
+      {
+        "id": "9647062d-91c3-4622-94cd-bc33d2c709bb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T18:15:00Z"
+      },
+      {
+        "id": "571887cb-3196-4155-8f6e-5edc41e6a499",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T20:40:00Z"
+      },
+      {
+        "id": "01051f2f-9544-4ee2-8464-651354dcb9af",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T17:05:00Z"
+      },
+      {
+        "id": "3b6f9b60-7a9c-422e-9c0a-027b843b18de",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T21:00:00Z"
+      },
+      {
+        "id": "382a9b58-aca5-43aa-be1a-ee7bc6e58625",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T22:10:00Z"
+      },
+      {
+        "id": "dc190e03-fb92-4020-ac0c-4641521e1a51",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T12:40:00Z"
+      },
+      {
+        "id": "5dca5863-ed69-4611-85d9-b7cad007839c",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-04-29",
+        "completedAt": "2025-04-29T18:30:00Z"
+      },
+      {
+        "id": "2510fffe-d1f9-462d-808f-aa9952c76c6e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T12:15:00Z"
+      },
+      {
+        "id": "7186d107-dd72-4746-8ea5-e3025bf87ae5",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T17:45:00Z"
+      },
+      {
+        "id": "e47d2965-badd-430e-ad59-774d09d0993a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T20:40:00Z"
+      },
+      {
+        "id": "ac804579-cc2a-4cd0-be52-5cd50c351ff1",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T07:10:00Z"
+      },
+      {
+        "id": "00f44335-e735-47b7-94bc-10331e9f6bca",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T18:40:00Z"
+      },
+      {
+        "id": "b09324e8-6fa5-40ab-b7db-f3b7e9a8cae4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T22:10:00Z"
+      },
+      {
+        "id": "3f95044c-508e-4c84-b3cc-027bf273d54d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T12:45:00Z"
+      },
+      {
+        "id": "559ce21c-930c-45e7-84f3-b2b1df6ddb53",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T12:00:00Z"
+      },
+      {
+        "id": "ac462901-60ab-494f-bac8-a18066a639f1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-04-30",
+        "completedAt": "2025-04-30T19:50:00Z"
+      },
+      {
+        "id": "34b9dae1-59e2-4526-87f3-0ae96d43cab0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T17:20:00Z"
+      },
+      {
+        "id": "a394ebad-4bda-429a-b1c5-4a8cc8ffed6c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T08:20:00Z"
+      },
+      {
+        "id": "b6390eaa-0a4b-4eeb-b245-abdeb00a1462",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T17:00:00Z"
+      },
+      {
+        "id": "85e8e172-c86f-4126-9e54-94d159a1aa68",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T18:10:00Z"
+      },
+      {
+        "id": "fa939c73-23a4-4793-842b-dc12a30b9e1d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T07:00:00Z"
+      },
+      {
+        "id": "911d8688-768e-46ee-a54c-237cf3e3f6a2",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T07:10:00Z"
+      },
+      {
+        "id": "b56f2a16-0927-4405-ada5-0d5445a8119e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T22:20:00Z"
+      },
+      {
+        "id": "52940b77-4bc2-4c07-8be2-9f34336f0bbd",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T12:45:00Z"
+      },
+      {
+        "id": "111a72fe-d385-46ca-ada7-9a1ed73fe83a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T06:50:00Z"
+      },
+      {
+        "id": "74155c34-da66-4473-ae60-58999bc0cbb8",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T22:45:00Z"
+      },
+      {
+        "id": "8c16bd6f-ba5f-40c1-a5c8-8ed2cdac2ce9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T08:20:00Z"
+      },
+      {
+        "id": "6154d7d0-de1f-49da-bbd8-45e757a70e53",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T06:30:00Z"
+      },
+      {
+        "id": "66647658-e8c9-4ff5-a6d6-92e3c17b8f60",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T06:45:00Z"
+      },
+      {
+        "id": "81d42579-de3d-4df6-94b4-8c949a5dc094",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-01",
+        "completedAt": "2025-05-01T07:00:00Z"
+      },
+      {
+        "id": "f31e4334-d41e-403e-b5c9-4c12149c30e6",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T12:50:00Z"
+      },
+      {
+        "id": "08abd7c3-4843-40e0-a51c-0600fbdd9a3e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T18:40:00Z"
+      },
+      {
+        "id": "eb8fd20b-b267-49ae-80e0-b3456713643f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T08:10:00Z"
+      },
+      {
+        "id": "51c968a7-f2ca-4b46-ba75-74c47c48140b",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T07:20:00Z"
+      },
+      {
+        "id": "a57ed8fe-6257-42a8-8396-5246bffddf0b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T12:05:00Z"
+      },
+      {
+        "id": "1f4f5e89-2f73-42af-aeba-6e0503619b32",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T22:30:00Z"
+      },
+      {
+        "id": "c5b4c6e8-d00d-4a92-bcec-d267ea359341",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T18:00:00Z"
+      },
+      {
+        "id": "3b8abc0f-4c0b-4760-b0ba-741c6ea01b3e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T19:00:00Z"
+      },
+      {
+        "id": "1a5fe576-ccec-409a-9a4c-fc6204ef85f3",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T18:30:00Z"
+      },
+      {
+        "id": "b7956b7b-d696-47f3-82eb-8c353c0fe125",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T19:45:00Z"
+      },
+      {
+        "id": "484b8216-d0b0-4b9c-91ca-a478f6b9c0b8",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T12:40:00Z"
+      },
+      {
+        "id": "8624fadf-b7df-4b5a-a7f0-aefe1a812d61",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T18:50:00Z"
+      },
+      {
+        "id": "fa6148c6-5080-4065-8f63-cb0a3d7ad58d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T21:40:00Z"
+      },
+      {
+        "id": "3be8883b-df33-4b2c-85d8-3b09668d91fe",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-02",
+        "completedAt": "2025-05-02T17:50:00Z"
+      },
+      {
+        "id": "d691dc4d-5fc7-4e5e-9847-a408c35cace8",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T12:50:00Z"
+      },
+      {
+        "id": "f6eff79a-dffc-402b-a290-0c1b10e4afee",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T12:05:00Z"
+      },
+      {
+        "id": "96ce19af-a603-490b-88cb-7fcd2ef76213",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T08:20:00Z"
+      },
+      {
+        "id": "0c51c1d1-5494-4f69-9e99-fc9456daa51e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T12:10:00Z"
+      },
+      {
+        "id": "f93607ea-b2b0-4da8-b4f5-679cb7ecc867",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T17:45:00Z"
+      },
+      {
+        "id": "c297e33f-7aee-40b3-9dbc-0b5587f8e89d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T22:10:00Z"
+      },
+      {
+        "id": "2edf10a7-a9fe-4502-af26-097eff1ce5f0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T19:40:00Z"
+      },
+      {
+        "id": "985f626f-65b1-46fa-96af-d78e43288d31",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T20:45:00Z"
+      },
+      {
+        "id": "d95eaf6f-65e3-4697-a059-e29c8cd70fe3",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T22:05:00Z"
+      },
+      {
+        "id": "61f3cf43-d6a9-4acc-a6a5-7d54d44d321e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T07:05:00Z"
+      },
+      {
+        "id": "0c30337c-0fce-437e-92c2-78879d41f709",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T21:50:00Z"
+      },
+      {
+        "id": "4dc60739-f771-436b-a56c-83c8ffab696b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-03",
+        "completedAt": "2025-05-03T12:20:00Z"
+      },
+      {
+        "id": "46f17e56-ca93-4667-b31e-0c03c28f69e2",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T22:05:00Z"
+      },
+      {
+        "id": "4f3ea77c-d943-4a3f-88b6-357d0e9acd27",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T18:00:00Z"
+      },
+      {
+        "id": "ca93a6da-220a-4f43-9bb1-fb006e5c4242",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T06:15:00Z"
+      },
+      {
+        "id": "d22e9042-f527-472d-a8c5-f32f8e8ec748",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T21:10:00Z"
+      },
+      {
+        "id": "0020b6a3-bf4b-48c9-81d3-396453166b01",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T17:20:00Z"
+      },
+      {
+        "id": "82da9b4d-6507-44c7-b550-30d8852831f3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T17:20:00Z"
+      },
+      {
+        "id": "64528b0e-b3d0-4a7a-ad12-b5fe1720a3c7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T07:10:00Z"
+      },
+      {
+        "id": "a04e52d5-15da-4ec9-a13d-8b8906dcb164",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T19:40:00Z"
+      },
+      {
+        "id": "424981f7-52ed-41e0-8e66-4fa915dcdb14",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T18:05:00Z"
+      },
+      {
+        "id": "db6e498c-f0e9-4a97-9ff2-ddc1ece3262f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-04",
+        "completedAt": "2025-05-04T20:20:00Z"
+      },
+      {
+        "id": "a4686285-18ac-4335-a9de-a26035277c48",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T06:50:00Z"
+      },
+      {
+        "id": "3aad5968-eefe-4387-9e31-a82a717faff7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T07:05:00Z"
+      },
+      {
+        "id": "4f3de4dc-8c88-43d5-8aac-0d1c1cd87f8a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T19:30:00Z"
+      },
+      {
+        "id": "618f093c-d32f-4dc1-9071-0749fe721788",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T17:15:00Z"
+      },
+      {
+        "id": "d9ad2fbe-ce68-484d-9634-f0f5c4518ca7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T21:20:00Z"
+      },
+      {
+        "id": "9db49fc2-efc8-45d6-86cd-a948e837a500",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T12:15:00Z"
+      },
+      {
+        "id": "d1fe1e70-bd61-469d-bd1b-7dc03a95e0bf",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T20:00:00Z"
+      },
+      {
+        "id": "a7eaf45c-4d7d-4c58-8c4c-d5905d9f91df",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T07:40:00Z"
+      },
+      {
+        "id": "7f76e449-2ddb-4d19-8e6f-5b8655197602",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T21:40:00Z"
+      },
+      {
+        "id": "682a14cf-8c08-4ba3-a81c-52f051557e56",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T08:45:00Z"
+      },
+      {
+        "id": "08c63ce5-14ae-4189-aee3-d95bb3f816bc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T08:40:00Z"
+      },
+      {
+        "id": "3c95c0c7-0b88-4d2b-9415-9219c85b195e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T08:50:00Z"
+      },
+      {
+        "id": "265683f5-7ab5-4f3b-badd-df72cbf3df53",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T07:15:00Z"
+      },
+      {
+        "id": "69625fe4-a97d-4f90-ac66-cefd2574376d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-05",
+        "completedAt": "2025-05-05T08:50:00Z"
+      },
+      {
+        "id": "14d7d3ee-24be-4713-83ce-05d15fb1128a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T07:05:00Z"
+      },
+      {
+        "id": "8de43a1a-b9b8-4b16-a808-5a9ffcc80aed",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T12:15:00Z"
+      },
+      {
+        "id": "210fb32f-21da-4701-8a4f-eaea4c3dc0a1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T19:50:00Z"
+      },
+      {
+        "id": "060ad494-ee28-43d5-ae41-d5a5a02332ff",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T21:15:00Z"
+      },
+      {
+        "id": "3e4131dc-ba6c-4884-aae8-ab7a022b9223",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T22:50:00Z"
+      },
+      {
+        "id": "4598e762-3119-4f0e-901d-bb17b752e239",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T17:30:00Z"
+      },
+      {
+        "id": "be47c65a-5f55-4d2b-85ca-3a9865231f42",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T12:00:00Z"
+      },
+      {
+        "id": "f577ff03-8741-46b6-9d67-acb28bbd394b",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T08:10:00Z"
+      },
+      {
+        "id": "2506729b-a9f1-4206-8ff4-efaf96e9e2bc",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T22:20:00Z"
+      },
+      {
+        "id": "ce935b99-052b-468d-9faf-263625681848",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T21:50:00Z"
+      },
+      {
+        "id": "c509b552-e12d-4809-8b2d-14975a557de6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T19:10:00Z"
+      },
+      {
+        "id": "49c9756c-1553-41eb-9f6a-c86871fc5dd6",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T12:50:00Z"
+      },
+      {
+        "id": "aa11ac7d-c87c-43a0-9d55-0c17a1d5b04f",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T06:30:00Z"
+      },
+      {
+        "id": "6fa4173c-9811-466b-9abc-6d2e1dff24ca",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T17:00:00Z"
+      },
+      {
+        "id": "18dc2418-2c35-439b-9fb8-e61ef36a270b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-06",
+        "completedAt": "2025-05-06T06:30:00Z"
+      },
+      {
+        "id": "8a5f4f21-9996-4fec-a578-c00c09dbf49a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T19:10:00Z"
+      },
+      {
+        "id": "68b39fa2-2440-41f4-af33-d6034e33e0e7",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T17:05:00Z"
+      },
+      {
+        "id": "bdc12084-4a34-40e8-b5ff-45bd0248210e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T17:30:00Z"
+      },
+      {
+        "id": "8f4f6585-b0f7-4d5c-b35c-3d408e649c3c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T12:40:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "1e8b9344-7253-438b-ae4b-f6f5cd121dea",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T22:20:00Z"
+      },
+      {
+        "id": "97c0dca2-4c31-42f9-8cca-d40444657289",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T12:45:00Z"
+      },
+      {
+        "id": "d9d7c352-0ebb-47d5-9cd5-ce7050769ade",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T21:50:00Z"
+      },
+      {
+        "id": "3c6365c7-2e32-4d9d-b6fb-426405a73b02",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T21:50:00Z"
+      },
+      {
+        "id": "e03b7946-f4e0-4c4c-beff-206fc4067edf",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T19:15:00Z"
+      },
+      {
+        "id": "2e68cb65-8c3a-40cb-8be2-116e774b6b6e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T20:10:00Z"
+      },
+      {
+        "id": "f92e9926-dcda-4143-b6f0-17274400cf8d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T08:40:00Z"
+      },
+      {
+        "id": "75854c6b-1bc2-4c0e-8346-b5e1d69ff1de",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-07",
+        "completedAt": "2025-05-07T08:10:00Z"
+      },
+      {
+        "id": "fd96956e-785a-4494-be39-e4e1dcdbe0b8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T08:15:00Z"
+      },
+      {
+        "id": "96b423b5-0baf-41cc-8c01-f237b322e61d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T18:45:00Z"
+      },
+      {
+        "id": "18ad2a9b-8909-4654-bc0d-b4cf5b22938f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T18:05:00Z"
+      },
+      {
+        "id": "e81342c5-53c4-4f5b-ba7b-152c0092d65b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T07:50:00Z"
+      },
+      {
+        "id": "c2b4ed22-a18f-4437-946b-ffd41b968aa4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T19:40:00Z"
+      },
+      {
+        "id": "8fe75b40-5988-4554-b03e-39dfc6aec7a5",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T12:50:00Z"
+      },
+      {
+        "id": "f6cabaf7-7ab5-4278-a191-08e3f5cec268",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T20:30:00Z"
+      },
+      {
+        "id": "7e73f813-74b4-4ecb-86aa-9e37f4fb3ba6",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T22:05:00Z"
+      },
+      {
+        "id": "af77a14e-dd63-4971-88d5-ac9673c36d2b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T07:50:00Z"
+      },
+      {
+        "id": "ae188e1b-7ceb-450f-86ec-7848aa2ff00c",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T20:45:00Z"
+      },
+      {
+        "id": "ae78bd68-e07e-407f-b178-19aa2400a1f8",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T12:05:00Z"
+      },
+      {
+        "id": "c0d88d21-2887-45c2-81d2-3b8126faa502",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T17:15:00Z"
+      },
+      {
+        "id": "5669594f-7638-40c9-b355-1ef8fc7b9bed",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-08",
+        "completedAt": "2025-05-08T18:50:00Z"
+      },
+      {
+        "id": "ab987b05-d17d-45be-9ab9-473f48c704ff",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T12:45:00Z"
+      },
+      {
+        "id": "03f47bee-0dd5-4379-9154-e599f84089f4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T07:30:00Z"
+      },
+      {
+        "id": "676d00c2-1d63-49c0-bad7-badc10dee7c4",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T08:10:00Z"
+      },
+      {
+        "id": "079bc2f8-feb3-41bd-b0e2-57b57cb34144",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T17:20:00Z"
+      },
+      {
+        "id": "11d1033c-c8fd-4082-bbcb-d5204103043d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T22:20:00Z"
+      },
+      {
+        "id": "d3e31f27-2451-42ba-8ba7-4c1bd17256f0",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T12:45:00Z"
+      },
+      {
+        "id": "f8579a94-c740-4c88-93c8-9c63e7352790",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T20:15:00Z"
+      },
+      {
+        "id": "654ee6d7-c804-4d18-a6fd-5ddb37b9e610",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T19:05:00Z"
+      },
+      {
+        "id": "6358f044-2262-4a7a-b7a0-88698b514de2",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T06:15:00Z"
+      },
+      {
+        "id": "2238845b-8602-4e26-be5a-efde29bac3fd",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-09",
+        "completedAt": "2025-05-09T19:50:00Z"
+      },
+      {
+        "id": "a1bddaf2-1e8c-4675-8dea-f5af63be5e88",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T07:50:00Z"
+      },
+      {
+        "id": "c19a6843-b492-4205-b1b4-a6409368997e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T19:30:00Z"
+      },
+      {
+        "id": "e56d0101-df2f-428c-83a1-69d9e54b2b21",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T20:45:00Z"
+      },
+      {
+        "id": "4d3b9f95-e7c9-4fe3-a3df-aee3e417ef88",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T21:15:00Z"
+      },
+      {
+        "id": "a77e52a4-380a-4288-a79b-b86dc141db9c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T07:20:00Z"
+      },
+      {
+        "id": "65eb3da0-18a4-445c-9bcf-5f85b5b887f7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T07:30:00Z",
+        "note": "Caught a duplicate charge"
+      },
+      {
+        "id": "90e1f211-a817-4da7-81d3-b6b87c660ed5",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T08:50:00Z"
+      },
+      {
+        "id": "ff0eee27-0243-4355-aef2-a40257035628",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-10",
+        "completedAt": "2025-05-10T08:45:00Z"
+      },
+      {
+        "id": "706d0cff-df8b-4bc3-97bf-79eccf096ebe",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T18:05:00Z"
+      },
+      {
+        "id": "6dc676cd-5849-4a81-b6fe-2ab7d17f7458",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T08:05:00Z"
+      },
+      {
+        "id": "44d3c01d-3f1f-46c1-869a-99af383aa596",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T20:45:00Z"
+      },
+      {
+        "id": "b2a24a17-fb27-4f00-9f71-fbf593644f5b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T19:15:00Z"
+      },
+      {
+        "id": "96ebf996-511c-4632-bcb6-425225c25ac5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T08:30:00Z"
+      },
+      {
+        "id": "8f732c34-5920-48ce-9031-78d572dfaf64",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T07:30:00Z"
+      },
+      {
+        "id": "a1458118-a923-4245-9c22-25267f0a7dd8",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T12:15:00Z"
+      },
+      {
+        "id": "6d9c5c80-34ab-4cb6-98f2-3a0f5136b78e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T21:45:00Z"
+      },
+      {
+        "id": "4d1a8f09-edbf-4ea4-8675-5d9c63a64d9f",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T21:30:00Z"
+      },
+      {
+        "id": "962a4468-b18e-4c08-a93b-81db2a3155da",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T06:00:00Z"
+      },
+      {
+        "id": "4b8bd608-3fb9-47fe-8c8b-3d8ddf86e66e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-11",
+        "completedAt": "2025-05-11T17:45:00Z"
+      },
+      {
+        "id": "3833f963-a472-403c-838c-e5837aa85df8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T08:40:00Z"
+      },
+      {
+        "id": "f78cf6ff-6a0a-4ae0-951e-746801f8c1db",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T07:50:00Z"
+      },
+      {
+        "id": "899c4223-89a5-40b5-a3c6-a25cafdb4e97",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T18:20:00Z"
+      },
+      {
+        "id": "c0f405f3-cd61-4a52-9d95-6b9d131e1278",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T18:45:00Z"
+      },
+      {
+        "id": "c3bac56c-c0b7-4200-8df2-71364d2595fb",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T17:00:00Z"
+      },
+      {
+        "id": "34d74d93-b7a2-4916-ae09-06580797cba7",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T06:40:00Z"
+      },
+      {
+        "id": "e1a4ec65-35ec-4824-ac11-27d9f0d25bf5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T06:10:00Z"
+      },
+      {
+        "id": "89e5a934-41ec-471b-96ac-e2636cdd1b4b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T18:45:00Z"
+      },
+      {
+        "id": "dccc0809-53cf-48c2-b633-1d0926fb5884",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T22:20:00Z"
+      },
+      {
+        "id": "5103338a-5a09-49fa-aa99-4962fede7da3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T21:40:00Z"
+      },
+      {
+        "id": "a3ef7799-3d9c-4c74-a5ea-caf140d5dbb7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T08:20:00Z"
+      },
+      {
+        "id": "76ec2d0a-a6fc-4ea3-9b8e-15997c794f0a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-12",
+        "completedAt": "2025-05-12T08:40:00Z"
+      },
+      {
+        "id": "98cd6286-62b1-4fd6-909a-1c7062b8c1f4",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T22:10:00Z"
+      },
+      {
+        "id": "dcf5e6cb-ca43-42b0-8c1a-892a49b00976",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T18:10:00Z"
+      },
+      {
+        "id": "dbc614af-e517-497e-808d-2264a0929f21",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T06:40:00Z"
+      },
+      {
+        "id": "24a597d0-8948-4cc8-b129-8838cd9fc928",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T17:45:00Z"
+      },
+      {
+        "id": "c2a89f12-3c18-4673-ad35-dfe83ab2f15a",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T19:40:00Z"
+      },
+      {
+        "id": "02ae8a4f-ab67-4991-9169-ac30129087c5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T19:40:00Z"
+      },
+      {
+        "id": "8c63bd1c-6b52-4db5-8bcc-5395e54296b1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T08:40:00Z"
+      },
+      {
+        "id": "e9462104-99c1-4a22-81ad-b8b1c25c436a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T17:20:00Z"
+      },
+      {
+        "id": "f9f13234-1154-4485-8eb1-0f927bbf28b0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T08:15:00Z"
+      },
+      {
+        "id": "a9c40e28-b349-471b-a2aa-831bd1173146",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T08:15:00Z"
+      },
+      {
+        "id": "2abf0f69-6830-49c3-ba85-734de8dd8596",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-13",
+        "completedAt": "2025-05-13T17:15:00Z"
+      },
+      {
+        "id": "dfc5a338-6416-40d9-80a9-3343400db448",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T07:45:00Z"
+      },
+      {
+        "id": "0e029450-9554-4230-b116-d1f6e2f4fd91",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T21:30:00Z"
+      },
+      {
+        "id": "37912bd3-9c50-4a44-9c97-8f7df9a6a5b7",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T19:20:00Z"
+      },
+      {
+        "id": "448ed289-23ad-46c9-83de-8f9a50e5a9b4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T22:30:00Z"
+      },
+      {
+        "id": "53cc4498-8049-4f0c-8c85-98b7a57a3c7b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T21:30:00Z"
+      },
+      {
+        "id": "96dc5483-135f-49b6-b4f1-e0ba2314d4f8",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T18:05:00Z"
+      },
+      {
+        "id": "b2217d85-bb04-4329-be9c-7b4fb3b0c4ca",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T07:20:00Z"
+      },
+      {
+        "id": "0afa243d-5db4-44e2-8ffd-d2ce7bc96293",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T21:45:00Z"
+      },
+      {
+        "id": "e3c3a18a-79b9-4b4c-8a01-38ef745c95a1",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T19:30:00Z"
+      },
+      {
+        "id": "ea7da7dd-32a6-4501-9e3c-0f68a9e61b1a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T08:00:00Z"
+      },
+      {
+        "id": "e4eeea24-5da3-4c9d-bfa8-4bf9112e354d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-14",
+        "completedAt": "2025-05-14T18:30:00Z"
+      },
+      {
+        "id": "05f98c05-18df-4136-b6f3-3b410e05be12",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T12:10:00Z"
+      },
+      {
+        "id": "7c016207-7a6a-40da-92b6-f5bd0010b5a0",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T17:10:00Z"
+      },
+      {
+        "id": "8874b28d-bbdb-4d19-b339-7a22972f8971",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T17:15:00Z"
+      },
+      {
+        "id": "d75f0bdb-1230-450d-adcf-68ccbad2dcfe",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T21:10:00Z"
+      },
+      {
+        "id": "9e296e45-e9ea-41a5-a49a-a62312a0f92b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T08:05:00Z"
+      },
+      {
+        "id": "d78cfadb-589a-499f-827e-28387a9012e6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T12:30:00Z"
+      },
+      {
+        "id": "43480d13-1408-4779-a666-1f88379d3557",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T19:45:00Z"
+      },
+      {
+        "id": "479ea6f1-b3bc-45cd-9954-f5536f7b7954",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T17:20:00Z"
+      },
+      {
+        "id": "135a0135-d371-4fba-8f6b-294e569e7ea6",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T12:15:00Z"
+      },
+      {
+        "id": "4c114988-043b-4c0b-8f19-caeb07e79503",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T06:20:00Z"
+      },
+      {
+        "id": "6845a929-9f86-41c8-aeb1-fdda1cd1fd56",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T20:00:00Z"
+      },
+      {
+        "id": "7e5ddd0e-ff37-467f-a89f-7fbaee778980",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T07:40:00Z"
+      },
+      {
+        "id": "cb53cd9f-aa5c-4b45-ab39-753feeb16875",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T07:20:00Z"
+      },
+      {
+        "id": "c6ab9a0e-f86e-47ed-ae26-f389e21210cc",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T12:10:00Z"
+      },
+      {
+        "id": "fa8c0808-35e0-4bbf-981b-0c5a542d41a6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-15",
+        "completedAt": "2025-05-15T17:20:00Z"
+      },
+      {
+        "id": "603a11e3-1fb3-4e32-9ca6-f6cd7b2bb0fb",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T17:05:00Z"
+      },
+      {
+        "id": "8064472f-52d1-4103-b65c-b5342251ca62",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T20:15:00Z"
+      },
+      {
+        "id": "d8b11498-eac0-4f37-8bad-3ecc8d5eddee",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T18:15:00Z"
+      },
+      {
+        "id": "1dc81cb8-7790-4c3a-b25e-4a8ea1c17e5d",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T12:15:00Z"
+      },
+      {
+        "id": "e410fcd8-800f-4f47-86db-2dfc1efbd3f7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T12:15:00Z"
+      },
+      {
+        "id": "d25a67a1-5308-4a11-871d-7259d50747af",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T07:30:00Z"
+      },
+      {
+        "id": "afd91023-1d40-4c57-88e6-54f76d46d3a2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T20:30:00Z"
+      },
+      {
+        "id": "27140069-39ee-42df-bd8d-2970a9cc190d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T22:45:00Z"
+      },
+      {
+        "id": "c766b8c7-ac5f-497c-a916-a195cc0b64b4",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T20:50:00Z"
+      },
+      {
+        "id": "b69a3859-824e-4047-ab90-6c72728fd457",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T12:30:00Z"
+      },
+      {
+        "id": "e00f13ab-c534-4f9a-bff2-42c0a9c56f93",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T07:10:00Z"
+      },
+      {
+        "id": "df4e037b-b393-4070-8a74-8af0d0428f8b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-16",
+        "completedAt": "2025-05-16T19:00:00Z"
+      },
+      {
+        "id": "128a21ed-9364-4586-bf14-47db195cd6d6",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T12:20:00Z"
+      },
+      {
+        "id": "77c171dd-33ae-49d3-90b5-b581a385ffa1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T12:40:00Z"
+      },
+      {
+        "id": "79543cac-bfc4-44d3-bcd4-5d8817f65759",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T17:30:00Z"
+      },
+      {
+        "id": "1d8acee0-5bf1-4cec-8e53-545e4bdec518",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T08:10:00Z"
+      },
+      {
+        "id": "3090b74d-87e7-44b6-a6ac-8162d978c60e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T17:40:00Z"
+      },
+      {
+        "id": "26750d01-9713-4d3c-b595-0012acadf6bf",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T20:20:00Z"
+      },
+      {
+        "id": "c0ccb6b7-3761-4d94-8178-4c98ceaa46ef",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T07:20:00Z"
+      },
+      {
+        "id": "bd3807bc-db71-4ae9-b7e2-774ca879abc6",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T18:00:00Z"
+      },
+      {
+        "id": "8c4c03e4-820a-4576-8bb0-6439a4e48e63",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-17",
+        "completedAt": "2025-05-17T12:20:00Z"
+      },
+      {
+        "id": "44b534b8-ec8f-41a9-8ebb-9ea9741e1a21",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T12:15:00Z"
+      },
+      {
+        "id": "1ec68d9b-2844-473c-8144-3365ff66339f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T22:30:00Z"
+      },
+      {
+        "id": "72fd6ba1-745e-4735-9cdd-09345d380bf5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T19:05:00Z"
+      },
+      {
+        "id": "d2a8491a-75ef-489e-8023-5d2f41bb2358",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T17:10:00Z"
+      },
+      {
+        "id": "3cfd9edd-414d-4bfe-82ab-0f0e32a91f69",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T21:05:00Z"
+      },
+      {
+        "id": "af37c55f-6436-482e-b3ca-cf838f202c80",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T06:50:00Z"
+      },
+      {
+        "id": "533eee5a-3632-4f7c-b011-a14867e73690",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-18",
+        "completedAt": "2025-05-18T08:15:00Z"
+      },
+      {
+        "id": "89c54511-22d9-4d35-b21e-6cf6f2be462d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T19:50:00Z"
+      },
+      {
+        "id": "52cdac95-31cf-45af-ac34-68a60a2a7269",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T21:10:00Z"
+      },
+      {
+        "id": "7cc45290-dbff-4854-8fe1-332e8633fe49",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T08:00:00Z"
+      },
+      {
+        "id": "24daa829-2218-4088-8056-97383c83781e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T07:15:00Z"
+      },
+      {
+        "id": "aff3d980-68fc-4e4e-92c9-88482b257ac4",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T18:15:00Z"
+      },
+      {
+        "id": "00abcf5a-a776-47e0-b7e6-082351a920fc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T19:40:00Z"
+      },
+      {
+        "id": "c9b24001-101d-4709-a2ab-e551b3bf6c40",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T06:30:00Z"
+      },
+      {
+        "id": "2fdbfe99-0e91-4e4e-9033-6423e0da75b8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T17:30:00Z"
+      },
+      {
+        "id": "fae601c4-3131-43e5-9f12-d4d1e62fd88c",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T12:50:00Z"
+      },
+      {
+        "id": "032e3d74-6263-44e8-978b-e9d3823da6ef",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T06:30:00Z"
+      },
+      {
+        "id": "b26af050-7dd2-49a3-a2b5-95d4fdaebfd8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T21:00:00Z"
+      },
+      {
+        "id": "044c5431-5b9d-417e-b068-f7239f063829",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-19",
+        "completedAt": "2025-05-19T22:05:00Z"
+      },
+      {
+        "id": "dbc9d6d0-2e8f-488c-a0b7-2d1822d1baaa",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T18:50:00Z"
+      },
+      {
+        "id": "450aa709-abd1-4411-a5db-fc10ce5d4a64",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T06:15:00Z"
+      },
+      {
+        "id": "2e1c90c4-899c-466a-ab3f-4726032095f1",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T08:50:00Z"
+      },
+      {
+        "id": "cda9ad94-f533-4751-8bf9-66e84096ac7e",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T08:30:00Z"
+      },
+      {
+        "id": "60299a85-2930-4b5d-9484-3d8cad69d2f8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T22:15:00Z"
+      },
+      {
+        "id": "4cd193c4-a0c8-4537-bd9b-854d24610ebd",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T06:20:00Z"
+      },
+      {
+        "id": "c795df78-e588-49a3-bd20-e292f03d269c",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T07:40:00Z"
+      },
+      {
+        "id": "30d32a35-3366-49fb-b5ab-a29dbfdc5057",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T12:10:00Z"
+      },
+      {
+        "id": "cf543854-ff38-4e2b-aa82-52e27835eac1",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T08:10:00Z"
+      },
+      {
+        "id": "b93f4238-bb72-44fe-a319-662218ce3a26",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T07:45:00Z"
+      },
+      {
+        "id": "b3929d08-6945-4072-8516-3cd0942fd352",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T21:30:00Z"
+      },
+      {
+        "id": "6dca87ff-f463-4e68-b82d-cce77652726c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T08:45:00Z"
+      },
+      {
+        "id": "bbb0a8ae-edd9-43fc-91f2-cc25329546dd",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-20",
+        "completedAt": "2025-05-20T06:10:00Z"
+      },
+      {
+        "id": "800589bf-d6a3-4e8e-aba5-b3532be40741",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T06:15:00Z"
+      },
+      {
+        "id": "b92d3609-5429-47b4-8d57-28b700b17e88",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T08:40:00Z"
+      },
+      {
+        "id": "de58cffe-939a-4336-9695-96927e73abdb",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T20:30:00Z"
+      },
+      {
+        "id": "3d266230-eb5b-408e-b357-6855379c7c54",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T17:45:00Z"
+      },
+      {
+        "id": "9cb75460-10c5-4cc0-9d53-9056aa5e3009",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T18:00:00Z"
+      },
+      {
+        "id": "8ddddd7b-8593-4165-ab69-944d94f94fd4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T19:30:00Z"
+      },
+      {
+        "id": "9a0ee572-7ae5-4cda-bad6-c3a5e14feb96",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T12:45:00Z"
+      },
+      {
+        "id": "60b864b7-192d-43cb-a55d-b6094f1776d4",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T17:10:00Z"
+      },
+      {
+        "id": "d5145d04-1cb2-416b-85e2-323038da0c26",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T21:40:00Z"
+      },
+      {
+        "id": "e50d447e-61f8-4c2b-a3e3-72a8842e4660",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T12:30:00Z"
+      },
+      {
+        "id": "e3064443-1cc5-45fa-a68d-94977b56f909",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T06:15:00Z"
+      },
+      {
+        "id": "d3706793-5f11-42c5-9629-17d9fc5334da",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T17:05:00Z"
+      },
+      {
+        "id": "ce7e7ef1-c71d-481a-a0d7-27948bd11f06",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-21",
+        "completedAt": "2025-05-21T21:15:00Z"
+      },
+      {
+        "id": "5754961b-7d68-4bc2-aa9d-c2028be25722",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T06:10:00Z"
+      },
+      {
+        "id": "b4207129-902b-4b87-971e-131b88a3f576",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T18:30:00Z"
+      },
+      {
+        "id": "79358aff-8f4c-47de-a5cb-876a92ed2846",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T08:50:00Z"
+      },
+      {
+        "id": "7d765d71-fe1b-4a4a-9b94-47de7fe0f428",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T17:30:00Z"
+      },
+      {
+        "id": "42bba64d-aca9-41d2-a666-46dee77a9493",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T17:40:00Z"
+      },
+      {
+        "id": "a6f62f65-f7dc-42f2-8816-d1c2d395563e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T17:05:00Z"
+      },
+      {
+        "id": "0a0962bb-5736-42fd-806a-89bd24186a42",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T08:10:00Z"
+      },
+      {
+        "id": "c0c1586e-8c97-46ad-97de-c2bcb7b64aee",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T06:15:00Z"
+      },
+      {
+        "id": "dc8079f1-e04f-498c-8875-ba802af4d0bb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T17:10:00Z"
+      },
+      {
+        "id": "c77a3ccb-c02d-4462-ad79-cc41cd7ef617",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T06:20:00Z"
+      },
+      {
+        "id": "8fad9a8e-5677-47ef-b731-aac380bdcb19",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T17:40:00Z"
+      },
+      {
+        "id": "08efe4b1-e7d7-4abf-b027-49ec1fdb77a9",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T20:20:00Z"
+      },
+      {
+        "id": "926fc3a0-c38a-4363-b51a-0e6f627774e6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T06:45:00Z"
+      },
+      {
+        "id": "f8824d7e-ec5e-4432-b6e4-4b8af71dc955",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-22",
+        "completedAt": "2025-05-22T08:10:00Z"
+      },
+      {
+        "id": "e603eff3-8d98-46ff-bb7d-bb8fbc26c8dd",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T18:20:00Z"
+      },
+      {
+        "id": "d133ba38-485c-42fe-a610-a026793a3ed0",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T21:20:00Z"
+      },
+      {
+        "id": "f432e6e7-44ae-4334-91e6-5cba4d76b616",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T21:50:00Z"
+      },
+      {
+        "id": "36af9467-da63-46f6-92b8-cf91aae70066",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T18:20:00Z"
+      },
+      {
+        "id": "593b52d1-f130-4d00-8096-4457b77b5e6a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T07:00:00Z"
+      },
+      {
+        "id": "11e8f0ba-88d1-4d75-95a0-52be2c1a21a6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T20:30:00Z"
+      },
+      {
+        "id": "a1514d11-c3bd-4b07-abfa-d00525d2af48",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T20:45:00Z"
+      },
+      {
+        "id": "129ec890-5dfe-451f-b570-cf42fada698b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T17:50:00Z"
+      },
+      {
+        "id": "3609fd68-1573-479f-8378-e88dddf5a14d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T06:00:00Z"
+      },
+      {
+        "id": "ce49bf75-2aca-4584-afd9-4aef85afcd06",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T07:45:00Z"
+      },
+      {
+        "id": "7c28d64d-aa09-4070-acb5-8d84f9f859c8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T07:20:00Z"
+      },
+      {
+        "id": "25e2ec78-6256-403a-82aa-3d530375ef1a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T07:00:00Z"
+      },
+      {
+        "id": "4b4f9c68-99a5-4406-a334-abd24b14e033",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T19:40:00Z"
+      },
+      {
+        "id": "271305f1-6fcf-4d87-9aed-316ac8e4b5d4",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T21:10:00Z"
+      },
+      {
+        "id": "4fae8d81-0c8a-4bca-a38c-39a208ccd962",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T17:05:00Z"
+      },
+      {
+        "id": "5ecff639-8f94-4dc7-96d3-c873177bd199",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-23",
+        "completedAt": "2025-05-23T19:05:00Z"
+      },
+      {
+        "id": "641e089d-ceef-4540-8f41-d01686d95c8f",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T20:30:00Z"
+      },
+      {
+        "id": "3dffe392-9742-48fc-bd6b-0e4e965e928d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T21:15:00Z"
+      },
+      {
+        "id": "d2408632-ce38-4cc3-8be0-044c051c2199",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T20:45:00Z"
+      },
+      {
+        "id": "003fd60d-945d-42bc-b797-be86c7d21190",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T20:40:00Z"
+      },
+      {
+        "id": "72c6c010-289c-4cfb-9996-b01712c45484",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T07:50:00Z"
+      },
+      {
+        "id": "60a788fc-34a3-44fb-af4d-54f26dbf9759",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T22:30:00Z"
+      },
+      {
+        "id": "7d44f32a-c54a-4d92-a42f-443572d32c47",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T21:40:00Z"
+      },
+      {
+        "id": "17bec634-ea5a-4247-9ef5-29cfa923cf24",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-24",
+        "completedAt": "2025-05-24T12:15:00Z"
+      },
+      {
+        "id": "2fe0c8d9-82a8-4ad8-be98-3041c647ee86",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T12:40:00Z"
+      },
+      {
+        "id": "7e66bc1c-4c37-4d3c-93a1-982decb8b322",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T12:30:00Z"
+      },
+      {
+        "id": "abf16245-a90e-4cbe-9d1c-ab364739b26b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T12:10:00Z"
+      },
+      {
+        "id": "cfd55a8c-45e6-4acd-ac73-d4ce1a720df4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T19:15:00Z"
+      },
+      {
+        "id": "ef82bfc9-a680-4c15-b654-5d3313278ad8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T19:50:00Z"
+      },
+      {
+        "id": "2f8f2bb3-47bc-405a-9596-dfe191e03c10",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T07:50:00Z"
+      },
+      {
+        "id": "5880cdd9-2496-420e-8509-4d25b543d7fd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T06:00:00Z"
+      },
+      {
+        "id": "58c7f9e9-c992-41ea-b008-c1c0ea39c1a2",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T06:40:00Z"
+      },
+      {
+        "id": "d1c5ebc6-50aa-43c3-87ee-27c09d3c849f",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T18:50:00Z"
+      },
+      {
+        "id": "7988320b-042a-471e-8dac-238aa517cbb2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-25",
+        "completedAt": "2025-05-25T07:30:00Z"
+      },
+      {
+        "id": "7e737473-c96f-482f-bdbb-80a352766c98",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T18:15:00Z"
+      },
+      {
+        "id": "7d5d6eee-3245-46a9-bce3-72bbb36e917d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T12:15:00Z"
+      },
+      {
+        "id": "87220709-ca6d-44f4-9747-6ca10d179876",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T22:50:00Z"
+      },
+      {
+        "id": "adea5b86-2e62-4a9b-8d80-d80147572a57",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T21:10:00Z"
+      },
+      {
+        "id": "cdc7b979-a580-4253-9d99-39e582050d80",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T19:20:00Z"
+      },
+      {
+        "id": "2d9589f9-047f-4fe0-bfa9-dbbcb5d0787b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T17:10:00Z"
+      },
+      {
+        "id": "73d82234-779d-45dc-88f7-99c6d03f6d32",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T19:45:00Z"
+      },
+      {
+        "id": "153828e2-8418-494e-a7c9-70c8d9b81655",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T19:45:00Z"
+      },
+      {
+        "id": "00b29814-e69a-44ec-ab5e-4cadc1e2ed87",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T21:45:00Z"
+      },
+      {
+        "id": "545df736-742d-4641-9f86-75c34e4cda24",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T12:40:00Z"
+      },
+      {
+        "id": "cb5f9714-125e-4f71-8e06-5bc737e0715f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T08:50:00Z"
+      },
+      {
+        "id": "eba89815-d262-40c3-bd98-219aee243003",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T19:15:00Z"
+      },
+      {
+        "id": "e6b11e18-0129-4338-9726-7c8ff2efb6c0",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T12:50:00Z"
+      },
+      {
+        "id": "555f879b-f040-48e9-b787-c0db941e5355",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T19:20:00Z"
+      },
+      {
+        "id": "7be15836-c996-48b9-8501-bc6b9aad218b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-26",
+        "completedAt": "2025-05-26T18:40:00Z"
+      },
+      {
+        "id": "f4411668-55a0-4f77-bb56-7d45acd96eb7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T20:20:00Z"
+      },
+      {
+        "id": "74c2a224-d71e-43d9-b111-2eea31a9ef2d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T07:30:00Z"
+      },
+      {
+        "id": "f8f6919f-361d-4976-9b3f-56ccd797f67c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T19:15:00Z"
+      },
+      {
+        "id": "a208182d-02ca-4cca-8ed9-54226239a1cd",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T22:05:00Z"
+      },
+      {
+        "id": "c345c27a-f7a5-42c2-a3f5-e580dac2240a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T07:50:00Z"
+      },
+      {
+        "id": "3e0aa3d0-1130-4817-ad9d-0c271a3bafbc",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T21:40:00Z"
+      },
+      {
+        "id": "e60f36e5-c138-428b-b09c-3091376d5715",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T18:20:00Z"
+      },
+      {
+        "id": "eb9f28a3-f542-40cf-8bcf-af4dc137ea17",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-27",
+        "completedAt": "2025-05-27T07:10:00Z"
+      },
+      {
+        "id": "c839a04b-8678-4cf0-b57f-5f7e85824f2b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T18:15:00Z"
+      },
+      {
+        "id": "a8fba4ac-12f2-41ee-91ff-71e165d6877c",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T22:00:00Z"
+      },
+      {
+        "id": "4b587239-6763-48b1-b8bf-cd967fb01fb7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T17:00:00Z"
+      },
+      {
+        "id": "9a9c49a8-8ef3-4b0c-9f57-c86e8352de6f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T20:20:00Z"
+      },
+      {
+        "id": "2c3b1996-73d8-4652-b416-20a419eca2e4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T08:20:00Z"
+      },
+      {
+        "id": "676c8f3a-c92c-431f-b460-259cdb692326",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T07:20:00Z"
+      },
+      {
+        "id": "f069d6df-d2e4-4789-bde6-cd3d08113238",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T06:40:00Z"
+      },
+      {
+        "id": "7ee8b67a-fbfd-4711-b229-a50fe9aed5fa",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T07:20:00Z"
+      },
+      {
+        "id": "42b07797-c4e3-4bb3-bbac-9477f5d66326",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T06:30:00Z"
+      },
+      {
+        "id": "13356a21-4a3b-4943-b0a7-3169b0736c98",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T17:20:00Z"
+      },
+      {
+        "id": "0f36b5c3-6357-43b8-a5bc-4aa1caf85b4b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-28",
+        "completedAt": "2025-05-28T17:30:00Z"
+      },
+      {
+        "id": "0066ce02-2adc-4872-98af-3f652d550093",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T18:15:00Z"
+      },
+      {
+        "id": "68d57804-c887-4592-be19-59f43587f972",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T17:05:00Z"
+      },
+      {
+        "id": "acc1bc35-8dd0-4060-bab9-740bc2e68d07",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T20:00:00Z"
+      },
+      {
+        "id": "0eeef0d4-d1d2-4a5c-b1d6-82185eb91c8b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T07:40:00Z"
+      },
+      {
+        "id": "90860a70-4826-40b8-94b2-241e65fc839c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T21:10:00Z"
+      },
+      {
+        "id": "30f81ac7-802d-4334-8804-0e978c6897a8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T19:40:00Z"
+      },
+      {
+        "id": "859551fe-3c4b-4c05-a271-46dfc22f89e2",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T18:00:00Z"
+      },
+      {
+        "id": "d0ceec70-70b2-4e1c-b13e-a1a1da389d71",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T06:05:00Z"
+      },
+      {
+        "id": "f0f3e696-f3c8-4875-908d-43d8a91afae8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T20:45:00Z"
+      },
+      {
+        "id": "35ebd97d-e1ac-44f8-b817-90ea533c1101",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T06:40:00Z"
+      },
+      {
+        "id": "316f401d-04f8-4a25-82d7-587bec57b99f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T08:10:00Z"
+      },
+      {
+        "id": "69544369-9b72-49ea-9217-17b0e7a64c75",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T22:20:00Z"
+      },
+      {
+        "id": "07ae2673-9ded-4482-a8c4-ad2a4c4906a9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T07:15:00Z"
+      },
+      {
+        "id": "4c450a59-d4f3-4402-98db-c446cc90a37c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T06:45:00Z"
+      },
+      {
+        "id": "492cb3fa-3dc8-4851-939d-504e78586b6a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T20:40:00Z"
+      },
+      {
+        "id": "aa7c7a96-f000-4454-bdb3-2cfbf5e146e5",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-29",
+        "completedAt": "2025-05-29T08:40:00Z"
+      },
+      {
+        "id": "478a7b39-d5ee-447c-ba8d-fb6e5c21ef3b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T22:00:00Z"
+      },
+      {
+        "id": "6ee0dfce-85a5-4dd4-8f14-f314a18280ef",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T07:50:00Z"
+      },
+      {
+        "id": "244b6ea9-3afb-48b4-87fc-537e74b6647c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T06:20:00Z"
+      },
+      {
+        "id": "b3c7c9b7-996f-4bda-88f3-8bc1f6260b70",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T08:05:00Z"
+      },
+      {
+        "id": "3251e543-428e-42ec-9c5e-c712b6169af5",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T17:50:00Z"
+      },
+      {
+        "id": "c5e225bc-ac5b-4cc1-a260-17f8096457e7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T07:20:00Z"
+      },
+      {
+        "id": "fbe0d083-3b97-48c2-9f10-0ac7638223c2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T17:45:00Z"
+      },
+      {
+        "id": "170b4617-980c-4c1c-98df-55282c78373f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T08:45:00Z"
+      },
+      {
+        "id": "4bb06eef-dd7a-473f-b5cd-8b805c0dd43f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T07:30:00Z"
+      },
+      {
+        "id": "0ee6987c-3857-4b10-8fa5-5b3f83446d16",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T19:10:00Z"
+      },
+      {
+        "id": "91f6ca9b-fcc4-4004-996e-7540ca1a429a",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T07:05:00Z"
+      },
+      {
+        "id": "b3d05a44-4626-472f-b855-835df026e01f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T21:15:00Z"
+      },
+      {
+        "id": "95790aea-ffca-470f-bdf7-d3b7d4048238",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-05-30",
+        "completedAt": "2025-05-30T12:10:00Z"
+      },
+      {
+        "id": "dd0fc3e8-ea8a-4514-af3a-cf88662bffbc",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T19:10:00Z"
+      },
+      {
+        "id": "ff9a350d-adf7-45ac-b762-41d0eab538e2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T12:45:00Z"
+      },
+      {
+        "id": "84962e7e-c9ef-4665-b2e6-86ae09fdbe68",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T06:45:00Z"
+      },
+      {
+        "id": "428f8a61-3eb6-464d-8a63-daf925770993",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T07:45:00Z"
+      },
+      {
+        "id": "0dc4a7f4-b968-46ac-8b13-20b8415d72d3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T17:00:00Z"
+      },
+      {
+        "id": "5a0544a0-4a8e-48fb-baa7-cb0e38cdd148",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T21:40:00Z"
+      },
+      {
+        "id": "e1eda73b-b333-4236-828f-65cd317c861b",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T12:15:00Z"
+      },
+      {
+        "id": "ac9b9d90-1f25-4fd1-bf33-f882da74979c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T22:15:00Z"
+      },
+      {
+        "id": "e11220f1-dabd-4aaa-b05c-3a292b0e3b49",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T17:10:00Z"
+      },
+      {
+        "id": "404c94b4-8dbc-473a-83aa-daab396c3320",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T07:45:00Z"
+      },
+      {
+        "id": "05738197-83c8-47f8-8677-a8eba0f6a97b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-05-31",
+        "completedAt": "2025-05-31T21:50:00Z"
+      },
+      {
+        "id": "87fc576b-5623-496b-81b8-e0a502e722f4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T22:30:00Z"
+      },
+      {
+        "id": "95c10467-4c07-4132-bee8-09615ae546cf",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T21:20:00Z"
+      },
+      {
+        "id": "b30a76a9-0da9-4254-8647-3f5c4400eed0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T20:10:00Z"
+      },
+      {
+        "id": "c77e9ce2-e433-42bf-9971-ebcf1d174809",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T07:00:00Z"
+      },
+      {
+        "id": "8b05743b-1aea-4153-87ae-af800cd4c931",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T18:40:00Z"
+      },
+      {
+        "id": "3a0e5f83-e9f5-428d-8616-58c0bcb52e25",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T18:00:00Z"
+      },
+      {
+        "id": "fe7d7f4d-d7cf-4115-b86c-f2e0e4949075",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T21:50:00Z"
+      },
+      {
+        "id": "f9eb634e-8d6d-4da3-be0d-e4d6ffbd3b5e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T12:10:00Z"
+      },
+      {
+        "id": "a40fb211-af9a-4251-be76-fbfb00012c8c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T12:50:00Z"
+      },
+      {
+        "id": "5d3d87e7-2e1c-4f55-afd0-74531390c40a",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T21:40:00Z"
+      },
+      {
+        "id": "99021d48-a6f1-4cd0-bdd1-9ac357b6fbd6",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T08:20:00Z"
+      },
+      {
+        "id": "26e39426-f2b4-43c5-8b55-62a4ff3306fe",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-01",
+        "completedAt": "2025-06-01T06:40:00Z"
+      },
+      {
+        "id": "bf02ca37-477e-4ec8-940c-884e6f2ec2f2",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T06:00:00Z"
+      },
+      {
+        "id": "f613c65a-ba54-457c-9e88-74888edcef25",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T22:45:00Z"
+      },
+      {
+        "id": "407e7ac7-cec8-4971-aaae-87bc2a5aff2d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T22:20:00Z"
+      },
+      {
+        "id": "d0d34f36-e559-473c-8c9e-83e04f092182",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T18:05:00Z"
+      },
+      {
+        "id": "ea53efa5-2c45-41cf-aecb-d031c5e8be79",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T07:30:00Z"
+      },
+      {
+        "id": "1b5aff80-6ca1-4b91-82c5-846b4a322516",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T12:10:00Z"
+      },
+      {
+        "id": "e4d9fd64-2e10-4c9d-8311-ac55b81ef89f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T21:05:00Z"
+      },
+      {
+        "id": "a4d4e928-839e-4204-bf0d-c7b9605ed652",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T18:05:00Z"
+      },
+      {
+        "id": "df15e6a5-5415-47db-a082-d7369d9acdff",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T22:10:00Z"
+      },
+      {
+        "id": "a486612a-ead9-4a41-a6ba-ff322b955828",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T17:45:00Z"
+      },
+      {
+        "id": "5a35333f-d114-4545-9429-0863e5afc217",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T22:40:00Z",
+        "note": "Caught a duplicate charge"
+      },
+      {
+        "id": "ab784994-0dbe-4e8a-a79e-b30b64dd09ed",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T22:50:00Z"
+      },
+      {
+        "id": "995176b7-90ed-4b31-8962-531e00e2f16f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-02",
+        "completedAt": "2025-06-02T19:50:00Z"
+      },
+      {
+        "id": "272326df-8297-444d-9a82-a41ccda0cfad",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T18:20:00Z"
+      },
+      {
+        "id": "200c4de5-088c-4342-bb67-2be67c8f24e4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T07:00:00Z"
+      },
+      {
+        "id": "9108fb90-bd08-4bbf-9256-31afd88e2f8e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T07:50:00Z"
+      },
+      {
+        "id": "116f38c7-1acc-4496-898e-d0da1c66987f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T21:30:00Z"
+      },
+      {
+        "id": "e1db2e2d-fd50-41eb-a657-4965cca2dbfe",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T06:20:00Z"
+      },
+      {
+        "id": "6938b6bf-2e5d-49cb-a705-74c3a409c3fd",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T22:05:00Z"
+      },
+      {
+        "id": "9c7528c6-8830-4a5d-aa10-a938ecb0c4ff",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T18:20:00Z"
+      },
+      {
+        "id": "c8a80f4c-a701-4748-a32a-ef89deddf3de",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T08:40:00Z"
+      },
+      {
+        "id": "1f92abee-de49-4d5f-a96c-f189719b1def",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T22:10:00Z"
+      },
+      {
+        "id": "aef0cf16-19a8-40ca-adce-416fa110c17c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T06:30:00Z"
+      },
+      {
+        "id": "878dde0d-68e0-44d2-ba11-e33bd0c80e36",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-03",
+        "completedAt": "2025-06-03T06:20:00Z"
+      },
+      {
+        "id": "f9de304d-8a54-43b1-a32d-57ff9d4aa53a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T20:10:00Z"
+      },
+      {
+        "id": "112a4720-97a9-49f1-be72-ea75ca4d646a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T08:00:00Z"
+      },
+      {
+        "id": "d86215fc-420c-45e9-93b6-d918d4e7c7ae",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T22:20:00Z"
+      },
+      {
+        "id": "85edc822-5997-4b91-aa77-cd429f76b42a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T07:20:00Z"
+      },
+      {
+        "id": "f5d4d851-f5a5-4cdc-864d-3598821f709a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T17:10:00Z"
+      },
+      {
+        "id": "26c065d8-dee9-4697-bbe9-a85dcfba5666",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T12:05:00Z"
+      },
+      {
+        "id": "b8b24e22-923b-430b-91f7-6bb5d17ae011",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T17:10:00Z"
+      },
+      {
+        "id": "29a2fb57-01af-4fa3-8084-ae75b4d0bfd0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T12:30:00Z"
+      },
+      {
+        "id": "c355c26a-3b1f-44ee-b063-4e1a87ad5b93",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T20:50:00Z"
+      },
+      {
+        "id": "8334a97e-f1c5-4fb7-9aee-b3b79ddbb904",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T06:50:00Z"
+      },
+      {
+        "id": "07c3350e-54db-44dd-9a24-b1385cab14c0",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T21:40:00Z"
+      },
+      {
+        "id": "19bc3ca9-91b8-4879-ade3-222a5c200c96",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T18:15:00Z"
+      },
+      {
+        "id": "ae9db8b9-2573-4eef-9b1d-47589ab7bc4d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-04",
+        "completedAt": "2025-06-04T21:00:00Z"
+      },
+      {
+        "id": "a5816e30-c187-4b82-b4f4-94d1b8023f9b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T22:05:00Z"
+      },
+      {
+        "id": "5389a0ee-b320-462b-9220-67a8b04ac5ba",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T21:05:00Z"
+      },
+      {
+        "id": "93900358-27db-47de-97d4-98c02d4bc391",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T19:05:00Z"
+      },
+      {
+        "id": "3dad27d5-1911-421a-9940-127f29102f1c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T19:30:00Z"
+      },
+      {
+        "id": "7dca8712-3c16-4a73-8389-a2338d5a748e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T06:10:00Z"
+      },
+      {
+        "id": "0ec0cd50-740a-441e-9952-8c4378abd324",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T21:45:00Z"
+      },
+      {
+        "id": "e21df9d4-cd99-4047-a870-681daf04b3be",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T18:05:00Z"
+      },
+      {
+        "id": "f7285a11-3129-4b75-885f-6c61afc97044",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T21:05:00Z"
+      },
+      {
+        "id": "6353e26a-479e-4718-965f-a73630f6009e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T17:40:00Z"
+      },
+      {
+        "id": "dc748a5a-90f0-40db-ab43-0d7f6809445c",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T18:05:00Z"
+      },
+      {
+        "id": "4f7bd155-8151-4149-9ece-2d4448a8aad4",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T21:05:00Z"
+      },
+      {
+        "id": "a044cee6-05e0-41b8-81c5-a27a7fa22340",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T18:40:00Z"
+      },
+      {
+        "id": "09a6e808-f899-4f86-84ed-4c820d8b1bc2",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T08:10:00Z"
+      },
+      {
+        "id": "973b1c7c-11c2-4d62-82e4-8586f2e527e0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T07:10:00Z"
+      },
+      {
+        "id": "4d3a0947-7f35-46ca-8f2d-6e0c2d88475d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-05",
+        "completedAt": "2025-06-05T22:00:00Z"
+      },
+      {
+        "id": "5742541f-cd7a-4ea6-a1f2-2ce5ec90ce63",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T07:10:00Z"
+      },
+      {
+        "id": "2205cc2e-e5dc-4e48-91b1-b568e16b4ea9",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T08:40:00Z"
+      },
+      {
+        "id": "da392a47-491c-42d9-8bb3-62cad8c03ff1",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T19:05:00Z"
+      },
+      {
+        "id": "d65ea346-cc2b-49eb-9175-668ce2be8e73",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T06:10:00Z"
+      },
+      {
+        "id": "17e67655-26a0-43d7-8634-6ac8904f8ddc",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T18:50:00Z"
+      },
+      {
+        "id": "e67cdfc0-f60c-4286-aeae-810d2beeaee8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T12:30:00Z"
+      },
+      {
+        "id": "5318cdae-380a-4e3a-9241-e5524ea8865d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T20:45:00Z"
+      },
+      {
+        "id": "6a13c9ca-e4aa-4244-b4d5-54ea33bbb450",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T22:00:00Z"
+      },
+      {
+        "id": "a3bfa1e2-cc8e-4002-8c41-ec15b4cd0605",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T12:50:00Z"
+      },
+      {
+        "id": "74aa6b8b-b856-4990-b653-ce111efce975",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T18:00:00Z"
+      },
+      {
+        "id": "14e0f4c7-8f13-4207-863b-0543ac902ed2",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T12:05:00Z"
+      },
+      {
+        "id": "a7f116d0-36c8-4f33-af2a-7d1c9aa2a4e3",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T08:00:00Z"
+      },
+      {
+        "id": "047f441a-7a2f-4e12-acc0-a8e25f2c5e73",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-06",
+        "completedAt": "2025-06-06T22:20:00Z"
+      },
+      {
+        "id": "d4999a73-9cce-4208-a3da-398d2f95f255",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T08:50:00Z"
+      },
+      {
+        "id": "b193b371-b6ec-49c4-9e33-f96bfecac8d5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T08:05:00Z"
+      },
+      {
+        "id": "b0c574b1-c59c-425b-8cf0-83dfece120fe",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T19:20:00Z"
+      },
+      {
+        "id": "bc32e46d-b35f-46c0-96bf-087b10292478",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T06:30:00Z"
+      },
+      {
+        "id": "30df8cef-431d-4bc0-b760-24064a296013",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T22:45:00Z"
+      },
+      {
+        "id": "ad472a8e-09c8-4be9-8a36-dab4453df741",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T21:20:00Z"
+      },
+      {
+        "id": "1c3f6fa3-858d-48b1-90e9-aab50216af04",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T20:00:00Z"
+      },
+      {
+        "id": "f8b85d60-c3c8-42c9-b84d-0dc16a1237b6",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T21:15:00Z"
+      },
+      {
+        "id": "82be5eb9-82b9-48d2-93c3-0453bbc20b0b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-07",
+        "completedAt": "2025-06-07T22:15:00Z"
+      },
+      {
+        "id": "e9064ed5-cefb-4ace-801f-e1915f43a16f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T08:00:00Z"
+      },
+      {
+        "id": "9895ec5c-cc94-45ac-a3ac-19cd3e3023cd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T08:05:00Z"
+      },
+      {
+        "id": "f8c2ee8f-2500-434a-aed2-05188a7b640e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T22:50:00Z"
+      },
+      {
+        "id": "5b0c36b5-d642-44be-9bca-fee18a2d7d5c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T08:00:00Z"
+      },
+      {
+        "id": "303aa530-6ec6-446d-aefb-759888927357",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T22:20:00Z"
+      },
+      {
+        "id": "3e524caf-65af-4b7a-9488-15b60d44685b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T18:05:00Z"
+      },
+      {
+        "id": "c43b60db-b40e-48ac-9fba-7b261950ac81",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T18:10:00Z"
+      },
+      {
+        "id": "3dc8b2e6-e1cc-40b6-b3ea-d254ab93694d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T20:10:00Z"
+      },
+      {
+        "id": "66a6f71c-b5c4-4eac-b461-628b8b810d1e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-08",
+        "completedAt": "2025-06-08T21:05:00Z"
+      },
+      {
+        "id": "5e3b82f3-952d-498c-8dcd-8ce72b19bf07",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T17:40:00Z"
+      },
+      {
+        "id": "03e05bdb-2ccf-43fe-8802-f6cebe2bc766",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T19:10:00Z"
+      },
+      {
+        "id": "edd75711-6a42-4aa1-9e28-dc1d1d994fae",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T18:20:00Z"
+      },
+      {
+        "id": "ee9c82d6-c3d7-4fb0-82af-7f531bef8d19",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T08:05:00Z"
+      },
+      {
+        "id": "ca344eda-435a-46c3-a4a3-0b2ba5449d14",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T07:05:00Z"
+      },
+      {
+        "id": "54770d53-2c47-4cd9-b5b7-2d42f06eed51",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T22:45:00Z"
+      },
+      {
+        "id": "e40bfbd2-a11c-4b88-9d54-f6276ff146b3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T08:15:00Z"
+      },
+      {
+        "id": "80d2c98e-1b7c-469f-934d-9d608cc7b29c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T07:45:00Z"
+      },
+      {
+        "id": "ded9ec0c-5b60-4310-9249-51561e298f7a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T18:05:00Z"
+      },
+      {
+        "id": "f8be91c7-2635-4652-9f9f-a93d86615c26",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T22:20:00Z"
+      },
+      {
+        "id": "b60b9d80-d416-41c5-80a5-fbbac55cc673",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T12:15:00Z"
+      },
+      {
+        "id": "31dd5d61-1b61-4c7a-951e-3f3941bc62ef",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-09",
+        "completedAt": "2025-06-09T20:40:00Z"
+      },
+      {
+        "id": "3b0ed67c-f63a-453b-968f-62ada55501c9",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T19:10:00Z"
+      },
+      {
+        "id": "642940bc-2fe3-4b09-9c56-a127122d1e5a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T07:50:00Z"
+      },
+      {
+        "id": "9f14b364-4b22-4188-9450-248d925136a3",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T12:05:00Z"
+      },
+      {
+        "id": "bb9c4c1c-427b-4713-a36f-24f58743228c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T07:05:00Z"
+      },
+      {
+        "id": "7a02ce45-3eb7-40c8-92a9-116f79c3b3c7",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T12:00:00Z"
+      },
+      {
+        "id": "af5f4257-01d6-49cf-bdd0-9486c9081b7f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T21:10:00Z"
+      },
+      {
+        "id": "16007dd1-b636-465f-862c-527835e2daa1",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T20:10:00Z"
+      },
+      {
+        "id": "339b7cdc-c268-4285-886e-227659f6423c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T18:45:00Z"
+      },
+      {
+        "id": "48c7dc54-5768-4a06-92d7-87af25f8333d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T08:50:00Z"
+      },
+      {
+        "id": "cd0141f9-46d3-4c15-8d6e-5deedc81be60",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T06:20:00Z"
+      },
+      {
+        "id": "912d0b37-b8f2-48f1-b7f2-b4f513ecc34e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T06:50:00Z"
+      },
+      {
+        "id": "183aa395-4876-4ebe-9140-8801c3fa0806",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T08:40:00Z"
+      },
+      {
+        "id": "30672de6-f0d0-4460-acf2-ed4a801141cf",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T17:45:00Z"
+      },
+      {
+        "id": "57019b62-30c2-4950-8b5a-0c30adb3be52",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-10",
+        "completedAt": "2025-06-10T18:20:00Z"
+      },
+      {
+        "id": "dc3a0042-08c8-4a91-8c99-f7c82e73d536",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T22:05:00Z"
+      },
+      {
+        "id": "0a0c30fd-8dd0-4c71-b32c-ffece9158ac7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T19:15:00Z"
+      },
+      {
+        "id": "b08be230-d5fb-43be-b23e-a9d7339fddfe",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T22:30:00Z"
+      },
+      {
+        "id": "51d3328d-6156-485d-95e9-cc6172c0986f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T08:50:00Z"
+      },
+      {
+        "id": "7d314c56-bb84-4b39-a2b8-1b43244138fb",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T12:10:00Z"
+      },
+      {
+        "id": "4fed87ed-3399-455e-addb-aa4c2e16432b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T20:15:00Z"
+      },
+      {
+        "id": "e2ebb27a-cc98-4c41-b7d5-26ed8ec031b0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T06:20:00Z"
+      },
+      {
+        "id": "f65a11d2-ff04-4c44-b64c-82705d332c5f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T12:05:00Z"
+      },
+      {
+        "id": "56d0cbe7-a32a-4aa7-b04b-95acde4d79ce",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T06:00:00Z"
+      },
+      {
+        "id": "cd914ad0-e802-492f-a3ae-0d56b480b530",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T07:15:00Z"
+      },
+      {
+        "id": "52587da1-594a-47ea-b006-9493e1a2766a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T06:00:00Z"
+      },
+      {
+        "id": "1d169874-1a67-43cf-98fd-0bfa05106aad",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T07:50:00Z"
+      },
+      {
+        "id": "a5129ff4-5431-45e5-b13e-f6e65bc84ace",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-11",
+        "completedAt": "2025-06-11T08:45:00Z"
+      },
+      {
+        "id": "726a30af-335d-45f9-a104-30064886eabd",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T17:40:00Z"
+      },
+      {
+        "id": "9997ba48-7aa9-4a3e-89c6-4e3ee20c86f8",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T06:10:00Z"
+      },
+      {
+        "id": "287a50fc-9586-4649-9cf4-556cea2291b4",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T07:50:00Z"
+      },
+      {
+        "id": "e5676a7d-cf3a-43c3-acc6-9941fef90d66",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T20:45:00Z"
+      },
+      {
+        "id": "33012304-ee8e-43e0-8e94-bc01e5c2494a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T19:40:00Z"
+      },
+      {
+        "id": "468be563-3b84-4e79-93ec-34465e4f9228",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T22:45:00Z"
+      },
+      {
+        "id": "e290803a-da4a-428b-bb82-2de817050dff",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T22:20:00Z"
+      },
+      {
+        "id": "e1f5258b-b926-4f52-a99d-ba387d9c1a9e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T08:30:00Z"
+      },
+      {
+        "id": "670edc62-241b-4f4f-bcc7-a53bb185f26c",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-12",
+        "completedAt": "2025-06-12T12:00:00Z"
+      },
+      {
+        "id": "a9c682d6-0b68-4df3-9277-964679c131c5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T19:10:00Z"
+      },
+      {
+        "id": "a743c9a9-8105-407e-bc34-f172cfe3c528",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T18:15:00Z"
+      },
+      {
+        "id": "881acf80-b8e8-46b1-832e-092e70b753d0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T18:15:00Z"
+      },
+      {
+        "id": "605d57af-b142-4ae1-9fb0-73bf137b1e2a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T08:10:00Z"
+      },
+      {
+        "id": "0e981fd0-c95c-494b-bd0e-7fc3268e93e2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T06:20:00Z"
+      },
+      {
+        "id": "19d6901a-99a3-400e-bd07-54eeb485ce1a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T21:15:00Z"
+      },
+      {
+        "id": "801ea485-94f4-4e3a-b5fa-f9b713930b0a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T21:45:00Z"
+      },
+      {
+        "id": "42e0ce03-3f4b-4207-857b-74ef29048b17",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T07:00:00Z"
+      },
+      {
+        "id": "c6021c9f-ec1f-404c-ab63-269450b85021",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T22:10:00Z"
+      },
+      {
+        "id": "51c86105-8536-4c76-848a-14f70bb6bc57",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T20:15:00Z"
+      },
+      {
+        "id": "61e5ec57-b352-41e9-8357-dd5e32c3e8ca",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T19:00:00Z"
+      },
+      {
+        "id": "c494d300-b2ee-4822-b313-5fc7e92a2a97",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T21:10:00Z"
+      },
+      {
+        "id": "047c54b0-38fc-479d-ba29-161d5b4c2bb1",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-13",
+        "completedAt": "2025-06-13T17:50:00Z"
+      },
+      {
+        "id": "5dbf04bb-f730-4978-9ec7-17254b36a11d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T20:40:00Z"
+      },
+      {
+        "id": "1d5b975c-6577-43c3-9496-f46227c480fb",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T17:20:00Z"
+      },
+      {
+        "id": "06f71fab-ad1f-4790-9137-ed554723dfab",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T08:50:00Z"
+      },
+      {
+        "id": "34f8a927-fa68-44f5-8d0d-9775271297c7",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T19:45:00Z"
+      },
+      {
+        "id": "e3a89b36-a3a7-4cdd-90e2-9b59956dc1c7",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T18:50:00Z"
+      },
+      {
+        "id": "23d34137-255d-4644-861b-b376cf5bd4ac",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T17:40:00Z"
+      },
+      {
+        "id": "bfc2e494-f455-481a-ba97-5110d997a1f9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T12:30:00Z"
+      },
+      {
+        "id": "47fcf8aa-af86-49e4-96d0-5197ace65c31",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T20:00:00Z"
+      },
+      {
+        "id": "0235b8ab-b5f9-47fb-9688-0c3bf32e0d47",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T20:30:00Z"
+      },
+      {
+        "id": "0c72fc86-b8dc-4867-a51b-71302de6148f",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T18:30:00Z"
+      },
+      {
+        "id": "aa498aa3-40a4-4aca-b349-890916186734",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-14",
+        "completedAt": "2025-06-14T22:50:00Z"
+      },
+      {
+        "id": "05a4f063-2514-4952-a8c8-cc9d86341f4f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T22:05:00Z"
+      },
+      {
+        "id": "72a2878e-8f0c-4b15-b013-522f89467a17",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T22:45:00Z"
+      },
+      {
+        "id": "c786dd5d-312f-433e-bc39-0fca61c06c3a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T22:00:00Z"
+      },
+      {
+        "id": "4669ac4d-9d3e-4b12-8883-ebfc2e953a9b",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T22:20:00Z"
+      },
+      {
+        "id": "ef1ac27f-b41d-42be-a049-a775d4fa14c8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T07:15:00Z"
+      },
+      {
+        "id": "6435ceb2-6f48-4101-9324-39b1cc55a263",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T07:00:00Z"
+      },
+      {
+        "id": "41147f99-badf-4f75-9883-fe90b39fcb82",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T22:15:00Z"
+      },
+      {
+        "id": "d6d907cb-b17c-4be5-8487-f7b413f5da41",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T08:20:00Z"
+      },
+      {
+        "id": "8293e2b9-3131-405b-8dfa-913ce3fe17de",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-15",
+        "completedAt": "2025-06-15T20:00:00Z"
+      },
+      {
+        "id": "112a52c1-aafb-451a-a66e-ab38cdcca783",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T08:50:00Z"
+      },
+      {
+        "id": "eab75b22-0185-48af-80af-72d279b1a514",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T06:30:00Z"
+      },
+      {
+        "id": "75d8a23a-8bd1-4797-878c-18b411fc98b9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T17:05:00Z"
+      },
+      {
+        "id": "73fce876-c0bf-4769-88e5-c63077f37518",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T22:00:00Z"
+      },
+      {
+        "id": "832f182e-9038-4656-bab2-9d865dfe1ff1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T21:15:00Z"
+      },
+      {
+        "id": "27de8f34-4d88-48c4-a9aa-2ed78c065daf",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T19:50:00Z"
+      },
+      {
+        "id": "57f9beb3-64dc-4a26-b436-d68660dfb5a2",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T22:20:00Z"
+      },
+      {
+        "id": "1c7399e7-b7f0-4f8c-9d71-960176bae5a9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T18:05:00Z"
+      },
+      {
+        "id": "6f2e4136-540c-445b-9a40-7588e58576fb",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T06:15:00Z"
+      },
+      {
+        "id": "a6e14bf9-2de3-42cb-83e8-22c6a4c012be",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T06:45:00Z"
+      },
+      {
+        "id": "d1aa24a0-6438-4fd9-b9b6-68bf9661eaa6",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-16",
+        "completedAt": "2025-06-16T20:45:00Z"
+      },
+      {
+        "id": "ce5de30b-6d09-4f1f-ac33-c531c5d948d8",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T20:05:00Z"
+      },
+      {
+        "id": "02c189b0-5fb7-49a1-8c4b-2ae17b8acdd5",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T21:20:00Z"
+      },
+      {
+        "id": "f99b3c83-ceda-4093-a9a4-62f0375a22ea",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T06:20:00Z"
+      },
+      {
+        "id": "0679d307-f541-4fe6-b9d0-c1e1f42c00cd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T17:50:00Z"
+      },
+      {
+        "id": "580a12d3-d69d-4285-bed1-db39065cbb1a",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T07:50:00Z"
+      },
+      {
+        "id": "7b097686-a8a3-4b66-8f79-5fc91ef536ea",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T20:40:00Z"
+      },
+      {
+        "id": "f3ca9646-6fb2-404a-adc2-01f1c163e96a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T21:20:00Z"
+      },
+      {
+        "id": "5919956c-c672-4a5d-bb53-d6b7fea769a9",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T08:40:00Z"
+      },
+      {
+        "id": "54874fbb-e17e-4a47-a0d1-879cae1ba20b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T17:20:00Z"
+      },
+      {
+        "id": "6fa860a4-85f8-4828-b657-11a17514afab",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T08:45:00Z"
+      },
+      {
+        "id": "501773de-d82d-4644-8a39-df479d7efc75",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T22:45:00Z"
+      },
+      {
+        "id": "e850585c-bef0-4417-9331-92af83267f38",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-17",
+        "completedAt": "2025-06-17T06:15:00Z"
+      },
+      {
+        "id": "0be66cec-6701-4d3a-b47e-fa5ab0dc023f",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T18:15:00Z"
+      },
+      {
+        "id": "dbdff2ee-068f-4e02-9032-30c20ad6bdbe",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T21:10:00Z"
+      },
+      {
+        "id": "7247f9b8-d7eb-4cdb-b9e1-028cd1be7165",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T22:30:00Z"
+      },
+      {
+        "id": "7c8c9e1e-2a33-40cb-8e3f-9ba426ba037f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T17:05:00Z"
+      },
+      {
+        "id": "a7acff7b-a875-443b-897a-58b00eaa38d8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T19:30:00Z"
+      },
+      {
+        "id": "c3a34a18-491e-4b37-9078-8728f452f8bc",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T08:30:00Z"
+      },
+      {
+        "id": "571f30f5-d5e3-48c7-9f6c-99b35f834fe2",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T06:05:00Z"
+      },
+      {
+        "id": "ad9e3b2a-db99-4dc7-aeca-c2a010c48761",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T06:15:00Z"
+      },
+      {
+        "id": "5ecaff4b-b0bc-4da8-95dc-1f85636010a9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T12:50:00Z"
+      },
+      {
+        "id": "64c43452-6480-41db-9430-da7c81eb631b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-18",
+        "completedAt": "2025-06-18T12:40:00Z"
+      },
+      {
+        "id": "eb8bd033-d4fd-486f-b3db-1fa8b3e2cc16",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T19:45:00Z"
+      },
+      {
+        "id": "3e99dcad-ce4f-41b3-bf02-d54e9aed0866",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T20:00:00Z"
+      },
+      {
+        "id": "486d5a87-b5a7-4064-a1ef-6ceded016266",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T22:50:00Z"
+      },
+      {
+        "id": "b394e183-66ff-4b4a-a907-af20ca6192e4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T12:30:00Z"
+      },
+      {
+        "id": "24dc780f-5f2c-4383-b8b0-3b49b477713d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T17:40:00Z"
+      },
+      {
+        "id": "0c0a4dc3-b324-4b42-9b8f-78a04cb15273",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T18:45:00Z"
+      },
+      {
+        "id": "ba2f136e-c161-4ab2-b2b6-c035c2e082e2",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T07:50:00Z"
+      },
+      {
+        "id": "c03d257b-79e1-41af-bd55-caad5fc9d908",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T06:20:00Z"
+      },
+      {
+        "id": "bb5c99f9-8fea-4445-a3ec-5004486022b4",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T17:10:00Z"
+      },
+      {
+        "id": "5f9d962b-3470-4f9f-987e-512a16f08e1e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T20:50:00Z"
+      },
+      {
+        "id": "9e153a11-d5c3-4ea3-942b-508efccf6382",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T22:10:00Z"
+      },
+      {
+        "id": "973e7036-28ee-46d0-8d0c-93735d667b4f",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T20:10:00Z"
+      },
+      {
+        "id": "e8299fbe-3433-4325-9861-d8f251719a8a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T22:15:00Z"
+      },
+      {
+        "id": "3b6b989e-debf-4843-9111-b5b8060e279a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-19",
+        "completedAt": "2025-06-19T18:45:00Z"
+      },
+      {
+        "id": "b0785c3a-72dc-4d8e-89a6-34e69f1f0012",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T20:45:00Z"
+      },
+      {
+        "id": "8d21e615-0ba6-4c41-bf56-c5d3a817d0fd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T18:15:00Z"
+      },
+      {
+        "id": "1dff47ae-1a83-4d77-95f0-f2440f53b480",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T18:05:00Z"
+      },
+      {
+        "id": "86ed4e2d-8351-460a-9357-345bc054a35d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T17:15:00Z"
+      },
+      {
+        "id": "3b692014-ad83-40c5-9ae2-1f7353e256f6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T18:05:00Z"
+      },
+      {
+        "id": "7c3ffad9-9627-4a6c-8bc9-c088c3e7e532",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T18:10:00Z"
+      },
+      {
+        "id": "ef6b02a4-38f9-4889-b8f5-5d05ef88f4a5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T07:10:00Z"
+      },
+      {
+        "id": "8abc9ede-5374-4133-bf97-d8612bb4d3de",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T08:40:00Z"
+      },
+      {
+        "id": "54a63182-c705-4a2c-9d89-caf98e168d42",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T22:45:00Z"
+      },
+      {
+        "id": "ab28157b-0106-4d84-a62d-0af1d6318e7b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T06:45:00Z"
+      },
+      {
+        "id": "6bd1835d-f6ab-4029-874b-3c8228697d25",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T21:45:00Z"
+      },
+      {
+        "id": "3e06b1ce-a040-4f96-96ee-f35fba2250aa",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T22:15:00Z"
+      },
+      {
+        "id": "20e6f257-cdf0-4b46-9ca7-de81d834e6c6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T22:15:00Z"
+      },
+      {
+        "id": "9fed798a-5bba-492d-a2e6-4d915c4e463e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-20",
+        "completedAt": "2025-06-20T07:10:00Z"
+      },
+      {
+        "id": "3580712a-6074-4c3b-ac3e-7b14176aba13",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T12:15:00Z"
+      },
+      {
+        "id": "b751717d-b683-4365-a00a-86cf96fc9f20",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T08:20:00Z"
+      },
+      {
+        "id": "4f4f7fdb-2ca1-4f45-be96-33609e53bd1c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T08:50:00Z"
+      },
+      {
+        "id": "9a88267e-87c3-446d-9178-48055a74c13d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T18:15:00Z"
+      },
+      {
+        "id": "e06fbba1-9465-414f-8818-088f8198ab7f",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T18:30:00Z"
+      },
+      {
+        "id": "6b81313c-b282-4976-957f-cb4369588e22",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T08:20:00Z"
+      },
+      {
+        "id": "3a2f117d-2282-4b3a-b089-1dec0a8c9bb7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T12:45:00Z"
+      },
+      {
+        "id": "b7135ae4-6499-44d4-90ec-bfe4f034408b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T21:10:00Z"
+      },
+      {
+        "id": "d1507cde-0cfd-488e-9722-1bd0ece5d210",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T12:05:00Z"
+      },
+      {
+        "id": "8fe94c3c-1df9-49ee-8662-368ecb93e50e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T18:15:00Z"
+      },
+      {
+        "id": "48c7103f-c49b-421a-825b-0b0cfd8f0d15",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T18:30:00Z"
+      },
+      {
+        "id": "6a32b13d-383e-4be2-b06b-9ecd81d9e295",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-21",
+        "completedAt": "2025-06-21T22:15:00Z"
+      },
+      {
+        "id": "5fcb6178-782b-430c-b937-c0e03a973b8b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T06:30:00Z"
+      },
+      {
+        "id": "e1fe9f4a-1968-481e-8463-e30b943be190",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T18:15:00Z"
+      },
+      {
+        "id": "e76fd25d-409f-4789-acfe-5d0c6423fe0c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T17:40:00Z"
+      },
+      {
+        "id": "2001816d-a334-4a57-a6e4-07c2dfd48cce",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T22:40:00Z"
+      },
+      {
+        "id": "2b0cc9cd-e3d3-437a-b9ab-93059b97a68b",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T19:50:00Z"
+      },
+      {
+        "id": "0dfea3e0-d1a5-4a9b-b1a8-419b638c2ed1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-22",
+        "completedAt": "2025-06-22T07:40:00Z"
+      },
+      {
+        "id": "8a8e6699-48a2-4443-b033-c5ae62b01343",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T19:20:00Z"
+      },
+      {
+        "id": "70a4a0f6-9f12-47d9-9b55-5d410ce35e26",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T12:10:00Z"
+      },
+      {
+        "id": "1319b08c-2e2b-4114-9318-37ab859d30f3",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T22:15:00Z"
+      },
+      {
+        "id": "2fb7023c-3043-4fa5-a663-a7e7fc886576",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T22:30:00Z"
+      },
+      {
+        "id": "d025097c-9f44-4320-9a37-93b9b10a0104",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T18:05:00Z"
+      },
+      {
+        "id": "8a0d78f7-65b4-497f-b7c7-8c7ff977a3c6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T22:05:00Z"
+      },
+      {
+        "id": "131fbefe-abde-4208-bf67-18f3f375d47a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T06:50:00Z"
+      },
+      {
+        "id": "e1d520c1-d6d6-4de3-ba43-a8e64d487322",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T19:10:00Z"
+      },
+      {
+        "id": "592eac71-4446-4316-b84e-c6eee324a824",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T12:05:00Z"
+      },
+      {
+        "id": "ffa3e7fa-2ad6-430c-8257-2b7d1c5a731d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T18:15:00Z"
+      },
+      {
+        "id": "2fd493c5-d9e3-4382-a193-df951a242604",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T21:30:00Z"
+      },
+      {
+        "id": "625f9c72-68a2-4bde-a279-91a1f1df4ceb",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T07:20:00Z"
+      },
+      {
+        "id": "860f721a-a11b-4d79-af81-4e2063ea0f45",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T12:20:00Z"
+      },
+      {
+        "id": "7d9d58ab-90e5-49ae-92a4-686d97f41570",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T07:20:00Z"
+      },
+      {
+        "id": "55e9df0f-20c2-41d4-831f-ac1ce2038eb4",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-23",
+        "completedAt": "2025-06-23T20:45:00Z"
+      },
+      {
+        "id": "815fd0f4-043b-471c-883e-1314ff3bb4c6",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T22:20:00Z"
+      },
+      {
+        "id": "78b6d3d1-84bf-4eb6-b3a6-1d0ef35d7b6e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T22:20:00Z"
+      },
+      {
+        "id": "c904ccbb-cb30-4b57-b2b2-48776b726d46",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T12:00:00Z"
+      },
+      {
+        "id": "54f30c80-7717-4ed4-a56b-5fde1e322257",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T08:50:00Z"
+      },
+      {
+        "id": "55ed9884-6ea7-41b0-a38c-fcf927b21363",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T12:05:00Z"
+      },
+      {
+        "id": "395ce3ec-a5b4-473b-a8dd-479511a54505",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T19:00:00Z"
+      },
+      {
+        "id": "0dc2f759-4cae-496e-856e-5cbad84ab3e7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T12:45:00Z"
+      },
+      {
+        "id": "da78d93d-0d4a-4e8e-a15f-a70c45cbe398",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T17:10:00Z"
+      },
+      {
+        "id": "620ee870-bc89-47d6-b4d3-78f170df15fd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T20:45:00Z"
+      },
+      {
+        "id": "a0b2ffe7-81c7-4081-b108-2949524d9fb8",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T19:15:00Z",
+        "note": "Caught a duplicate charge"
+      },
+      {
+        "id": "94688164-3f65-4874-b82b-482406b8da00",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T12:20:00Z"
+      },
+      {
+        "id": "8eabb4fa-8a81-401d-b6b7-255aa61df4b5",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-24",
+        "completedAt": "2025-06-24T18:10:00Z"
+      },
+      {
+        "id": "10322780-320d-4132-9fa8-358fba47b9ab",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T18:20:00Z"
+      },
+      {
+        "id": "7a18ae15-3a89-448f-80db-f56a525b1574",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T08:30:00Z"
+      },
+      {
+        "id": "081ef87d-5eaf-421a-8c83-132a36e64637",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T21:50:00Z"
+      },
+      {
+        "id": "0819bc23-13d0-48ee-aba1-3de22db69b9c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T12:15:00Z"
+      },
+      {
+        "id": "9950c11e-bb7b-4caf-94a4-ad24c2148bae",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T07:45:00Z"
+      },
+      {
+        "id": "5488e6de-d996-4872-b153-c37de6cc790b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T08:10:00Z"
+      },
+      {
+        "id": "8cf1774f-2e65-4d6e-9b4b-bdb9ef3c2222",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T07:50:00Z"
+      },
+      {
+        "id": "8daed5aa-8eab-4e67-9b2f-7b874e4328fe",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T06:50:00Z"
+      },
+      {
+        "id": "4ce9ac37-3d44-4eb4-b36f-583ce833b0f2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T20:30:00Z"
+      },
+      {
+        "id": "321d543c-1181-4807-8f2f-c47e475ef928",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T20:05:00Z"
+      },
+      {
+        "id": "d4360209-750f-4b3c-82f9-a924671c1bba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T22:05:00Z"
+      },
+      {
+        "id": "262008d9-9f04-494f-a161-1781aabe5222",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-25",
+        "completedAt": "2025-06-25T18:00:00Z"
+      },
+      {
+        "id": "414145ba-fba6-4577-9425-6494fdd2c8d8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T18:30:00Z"
+      },
+      {
+        "id": "1a29088f-fe5d-4139-bc2a-be39a3c1d7f1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T07:20:00Z"
+      },
+      {
+        "id": "525fe157-2145-4b19-8906-f5b3534eff6e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T12:20:00Z"
+      },
+      {
+        "id": "4b54ff48-3ef1-4a4c-894e-103097864667",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T06:40:00Z"
+      },
+      {
+        "id": "b7b947d5-35c1-41bf-8129-78bfede2b403",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T06:05:00Z"
+      },
+      {
+        "id": "3581716b-1d6c-4e5c-96fb-88dae1588cdd",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T22:15:00Z"
+      },
+      {
+        "id": "0db87b9c-2924-4ef7-91c7-eb231abf60a0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T06:10:00Z"
+      },
+      {
+        "id": "5745d974-8be8-4d4c-8fe3-51cb15455578",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T18:40:00Z"
+      },
+      {
+        "id": "87fce9c5-7a09-4b1b-b4d5-c54c894697d2",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T12:40:00Z"
+      },
+      {
+        "id": "ed8f56dc-4517-419f-8447-e248c4332b13",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T17:30:00Z"
+      },
+      {
+        "id": "85257aab-7ca2-48bc-984a-fa0ae65d62f9",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T06:40:00Z"
+      },
+      {
+        "id": "67f32dea-26b0-4f7d-a243-b78f6db7baff",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T20:45:00Z"
+      },
+      {
+        "id": "5c11f36f-5640-4a7c-ab66-ef4bcdfa5ea8",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T19:15:00Z"
+      },
+      {
+        "id": "7acd0486-790f-49d8-986c-8b6e3bea6a72",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T20:40:00Z"
+      },
+      {
+        "id": "5c46076f-8bc7-4453-8f5a-66cce9283f1b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T17:15:00Z"
+      },
+      {
+        "id": "2e2ac7f4-44c7-45cf-8864-d375d0c09a84",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-26",
+        "completedAt": "2025-06-26T06:15:00Z"
+      },
+      {
+        "id": "2f778799-12f6-4a1d-b779-70d3d5c69767",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T06:10:00Z"
+      },
+      {
+        "id": "bd5c8b4a-e2f6-44b7-ba09-29a8a25c6ce1",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T06:45:00Z"
+      },
+      {
+        "id": "bf19fe39-1a5c-492c-a504-a4b5fa909fa1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T06:15:00Z"
+      },
+      {
+        "id": "e448dc4a-db6d-4617-a6ae-b348d9490c3f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T12:00:00Z"
+      },
+      {
+        "id": "fb32099e-8f18-49bc-8047-66402c6f018d",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T08:15:00Z"
+      },
+      {
+        "id": "dbd9abd1-8ea9-4c72-84f1-b91872725695",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T22:15:00Z"
+      },
+      {
+        "id": "e05132f7-9707-4a1b-b59e-3cb942966839",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T06:10:00Z"
+      },
+      {
+        "id": "1f129e86-dd8d-41a7-bb7a-78ecc7dc57c7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T12:15:00Z"
+      },
+      {
+        "id": "958fa554-abf2-4d1c-97d4-a7e50c8c4f1e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T12:45:00Z"
+      },
+      {
+        "id": "99ef7230-60ab-4928-881b-8dc6a5ad621e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T08:15:00Z"
+      },
+      {
+        "id": "0814c93d-7ec3-4907-b4a6-c57a740c0f7b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T06:30:00Z"
+      },
+      {
+        "id": "b2c761ab-bd02-44e1-8e8d-9a5f55f93afa",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T19:50:00Z"
+      },
+      {
+        "id": "5e3438d6-c2d3-4f4c-a5f5-7bd443a03a07",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-27",
+        "completedAt": "2025-06-27T22:05:00Z"
+      },
+      {
+        "id": "d4b377d9-6c67-4457-bdb2-c3469ec39b80",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T06:15:00Z"
+      },
+      {
+        "id": "15b043b5-e393-4625-9229-dd7da23b0104",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T22:20:00Z"
+      },
+      {
+        "id": "2e60047a-7d19-459f-b89e-e84b0be476c4",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T12:30:00Z"
+      },
+      {
+        "id": "51e915db-ff0a-47ba-96f7-7156f88b7127",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T17:10:00Z"
+      },
+      {
+        "id": "816d9487-a146-40df-88a4-7b02b963f6c6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T20:50:00Z"
+      },
+      {
+        "id": "dce3a1fc-0269-4903-95ab-25a1050be07d",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T06:30:00Z"
+      },
+      {
+        "id": "6a3305c5-36b4-4afc-a5a0-afcc74129399",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T20:30:00Z"
+      },
+      {
+        "id": "bd662547-70d0-4938-8bc0-8c1b0242fc0c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T19:45:00Z"
+      },
+      {
+        "id": "7b35a1b9-ef97-49b6-965c-4374ad3f5468",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-28",
+        "completedAt": "2025-06-28T22:00:00Z"
+      },
+      {
+        "id": "65f1dbee-b7d4-4643-917f-2a549926bb62",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T22:10:00Z"
+      },
+      {
+        "id": "6393c3e8-ef34-46d3-b28c-635adaa19d30",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T12:05:00Z"
+      },
+      {
+        "id": "506c3fac-0b1a-489f-9c1b-557d3e40018a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T21:50:00Z"
+      },
+      {
+        "id": "8e5b99ce-8c25-40c3-9715-52093a3ae3c4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T06:30:00Z"
+      },
+      {
+        "id": "35770d34-f570-4bd0-af61-13604f3c0a93",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T08:05:00Z"
+      },
+      {
+        "id": "8e8c6f9c-ae47-4bc0-9305-ff58a10a1720",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T19:20:00Z"
+      },
+      {
+        "id": "f6f75e88-67f5-41a5-8ad4-a12a0f0b5e46",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T06:40:00Z"
+      },
+      {
+        "id": "90308ca8-bb2f-4955-b926-38192c73557b",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T19:30:00Z"
+      },
+      {
+        "id": "ab5d35a7-db35-47e2-ae7c-d00b141b064e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T08:50:00Z"
+      },
+      {
+        "id": "f01abcfe-9954-4b5f-b369-b58d42b4f7ae",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T17:40:00Z"
+      },
+      {
+        "id": "97af67a7-662a-45fb-a2ab-2ae8c6bf1816",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-29",
+        "completedAt": "2025-06-29T12:50:00Z"
+      },
+      {
+        "id": "bab1bf6b-c1c8-4ddb-95cb-83bff8a7a6ea",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T22:45:00Z"
+      },
+      {
+        "id": "a0002b41-c69f-4be6-96ab-53544a8ffd8f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T07:15:00Z"
+      },
+      {
+        "id": "ad0e8805-aa37-4ff6-8b59-e503cf2b1d4f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T07:05:00Z"
+      },
+      {
+        "id": "1d0baae6-5044-4abc-af6f-c5234299f319",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T06:20:00Z"
+      },
+      {
+        "id": "7ae2f46c-4c8a-47b3-b5a3-36e88980b3a8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T19:40:00Z"
+      },
+      {
+        "id": "b46fa1ae-788c-4319-8e6f-d4d3961a71d5",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T17:20:00Z"
+      },
+      {
+        "id": "b1973851-7c89-4240-90af-486033f5f5d7",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T20:00:00Z"
+      },
+      {
+        "id": "2d3b0e25-d600-450e-83d2-58d34c3708ee",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T08:40:00Z"
+      },
+      {
+        "id": "7c59d49f-47c2-48f0-80f5-8ac1a28772da",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T07:15:00Z"
+      },
+      {
+        "id": "05c486e6-8bf2-49c5-b852-76d4187026bb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T12:40:00Z"
+      },
+      {
+        "id": "2a2919a6-65b3-4ad0-b0ca-3e1520b3d921",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T12:20:00Z"
+      },
+      {
+        "id": "b36719cc-6288-431f-99ef-09fa0b9d68e7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T22:50:00Z"
+      },
+      {
+        "id": "440a242b-1839-46a4-be6b-5bf5e3a2e7a5",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T08:15:00Z"
+      },
+      {
+        "id": "71b89315-cdfa-4383-998e-840cbd9cd21a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-06-30",
+        "completedAt": "2025-06-30T20:20:00Z"
+      },
+      {
+        "id": "d1580514-2211-42b8-9c13-62310db4ce71",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T19:10:00Z"
+      },
+      {
+        "id": "5640867f-4f20-4daa-8c8f-c2c50d80ee42",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T12:00:00Z"
+      },
+      {
+        "id": "47615811-4a8b-4ec1-8812-5b0cb2c6b844",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T18:15:00Z"
+      },
+      {
+        "id": "07319477-707f-45c9-938e-94cd16ed6a67",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T06:30:00Z"
+      },
+      {
+        "id": "411dc918-b7c4-4596-9e76-9c23e1dc8b32",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T20:50:00Z"
+      },
+      {
+        "id": "191a7510-aac7-4107-9e28-1446be50b131",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T17:15:00Z"
+      },
+      {
+        "id": "ac7d55e5-3878-4540-9349-7c6e63161116",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T21:50:00Z"
+      },
+      {
+        "id": "5ea4c6a4-d658-49f3-a45c-78009151d064",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T22:40:00Z"
+      },
+      {
+        "id": "35c4a9cd-e4b9-4ba8-b6c0-1d79e977b314",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T19:10:00Z"
+      },
+      {
+        "id": "b8f704fb-5473-42df-a96a-b4ca4f8c6c13",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-01",
+        "completedAt": "2025-07-01T18:05:00Z"
+      },
+      {
+        "id": "ca8787cd-aca5-46a3-b702-e44ada333247",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T22:00:00Z"
+      },
+      {
+        "id": "90ebfae2-d5e4-4138-b211-0baa46388c51",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T12:10:00Z"
+      },
+      {
+        "id": "06b32669-ba89-4d2f-a903-4b4f241c7b46",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T22:50:00Z"
+      },
+      {
+        "id": "c45fcded-5996-4300-9b7b-fc15ae0eabd1",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T21:30:00Z"
+      },
+      {
+        "id": "d8fc8f0c-0c8b-4e37-84f6-b8ade518c9d1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T22:30:00Z"
+      },
+      {
+        "id": "08aa819f-e683-41e6-ae2f-4253b8491ca9",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T19:40:00Z"
+      },
+      {
+        "id": "438656f4-b36f-46d5-9663-5eb1a86a329b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T17:40:00Z"
+      },
+      {
+        "id": "a9ab6ac0-5da7-4e6f-b0b0-4298ab277508",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T19:10:00Z"
+      },
+      {
+        "id": "375e540d-db33-4835-87a6-2d4ab08c5f6e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T17:20:00Z"
+      },
+      {
+        "id": "ac739aea-3010-4ca9-8e71-4f4bd12d71ba",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T17:15:00Z"
+      },
+      {
+        "id": "ea3ee1be-51e4-487e-b912-c8f0447fc4a4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T19:45:00Z"
+      },
+      {
+        "id": "ea31b3d9-c62e-41ef-9e5a-636661508107",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T12:10:00Z"
+      },
+      {
+        "id": "413896fc-c627-4c06-b754-ca89a8707357",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-02",
+        "completedAt": "2025-07-02T06:50:00Z"
+      },
+      {
+        "id": "88cb2e70-6fb7-4a77-aefb-22a758b682ce",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T07:40:00Z"
+      },
+      {
+        "id": "c0e2b819-0850-4ef3-9ac1-10591a8f291d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T08:05:00Z"
+      },
+      {
+        "id": "34864c5f-8d93-4639-bf6c-9c4f288ff5e9",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T18:40:00Z"
+      },
+      {
+        "id": "d1fdfdc2-f5fa-4b93-9831-fd26aae24a04",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T06:20:00Z"
+      },
+      {
+        "id": "f91f3181-8f72-446e-b831-11f1f10bb1d7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T18:45:00Z"
+      },
+      {
+        "id": "20971b9b-a372-47a3-bf33-624457801ba0",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T07:20:00Z"
+      },
+      {
+        "id": "e12899a6-1809-450e-bc5f-531e5943f53a",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T17:20:00Z"
+      },
+      {
+        "id": "6ad63dcc-2395-49c6-b567-8b8783a7cde0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T17:20:00Z"
+      },
+      {
+        "id": "8b40cf5a-fb34-4b85-8a08-1ee863dec459",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T12:15:00Z"
+      },
+      {
+        "id": "4b11dbae-8f6c-4407-b846-c63c6a74f21a",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T12:15:00Z"
+      },
+      {
+        "id": "8e6d87af-5e98-40c4-8782-ba902c736191",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T08:40:00Z"
+      },
+      {
+        "id": "1f1cfa67-874f-4c42-b169-83315c51ae15",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T08:40:00Z"
+      },
+      {
+        "id": "b57470a4-3fbe-46fc-9178-1dc78691ea87",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-03",
+        "completedAt": "2025-07-03T08:40:00Z"
+      },
+      {
+        "id": "9505cc79-3b39-49ba-b0ae-0784059b487d",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T07:40:00Z"
+      },
+      {
+        "id": "69edb4f7-5125-4209-8485-fb86bd58b45a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T12:20:00Z"
+      },
+      {
+        "id": "2b7e7b3e-48b5-4bd9-9763-73a44cd8894e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T12:45:00Z"
+      },
+      {
+        "id": "e6b3a4f1-7c27-45ff-b3d6-0f5aec4909b0",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T21:45:00Z"
+      },
+      {
+        "id": "76e2392a-63ca-4e21-a464-7d74d70fcf53",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T08:10:00Z"
+      },
+      {
+        "id": "02515e63-3bc6-4f50-bbaf-5bf59bf86415",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T20:40:00Z"
+      },
+      {
+        "id": "a647fb8f-3ab8-4fc1-a807-d844a6892b71",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T17:50:00Z"
+      },
+      {
+        "id": "e95e55c1-8a99-4e8f-979d-8e9fc047c5b3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T08:40:00Z"
+      },
+      {
+        "id": "3776e651-bc84-4b81-a6cb-5eb67892acdf",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T19:15:00Z"
+      },
+      {
+        "id": "0d300f7f-de8a-4435-93d4-47bf7a93e07e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T19:30:00Z"
+      },
+      {
+        "id": "8e608e7f-ebf3-423a-8d6e-3baab7582567",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T19:05:00Z"
+      },
+      {
+        "id": "07739ccf-8c9f-4358-9fc0-21b3d70593fb",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-04",
+        "completedAt": "2025-07-04T17:50:00Z"
+      },
+      {
+        "id": "ddef6756-f539-4566-9495-4c23902a789d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T21:50:00Z"
+      },
+      {
+        "id": "e852455a-3de0-46d6-addc-f93c1ab70c95",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T06:10:00Z"
+      },
+      {
+        "id": "0cd5f6fe-d9d3-4e49-ae1c-c0bf1e11f49a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T12:20:00Z"
+      },
+      {
+        "id": "200d69ab-553d-4d8d-9ac0-0ccf8de00d2d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T06:40:00Z"
+      },
+      {
+        "id": "fb48f568-a66b-4632-9038-3162443804e2",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T22:45:00Z"
+      },
+      {
+        "id": "efcc925f-5bc9-43dc-af3f-73de795a4845",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-05",
+        "completedAt": "2025-07-05T18:30:00Z"
+      },
+      {
+        "id": "0382e2d1-dc3c-4942-b258-604afff0df70",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T19:05:00Z"
+      },
+      {
+        "id": "257c2c8e-8eba-4e4f-aea0-688cebc66344",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T12:05:00Z"
+      },
+      {
+        "id": "17bf3d43-2f86-46ba-9847-b77460701aad",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T19:05:00Z"
+      },
+      {
+        "id": "ae88ca47-ed1e-47d9-b2a1-036680186381",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T21:10:00Z"
+      },
+      {
+        "id": "f21e939c-db66-466e-955e-dcd7e870080e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T08:00:00Z"
+      },
+      {
+        "id": "69ef4abb-f5c3-4281-a501-7c5576c1722e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T08:20:00Z"
+      },
+      {
+        "id": "ba5f74b7-ba34-4508-9836-9ab80d8ce51d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-06",
+        "completedAt": "2025-07-06T19:00:00Z"
+      },
+      {
+        "id": "31b7cc2f-a298-461a-8467-6688208371fb",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T19:00:00Z"
+      },
+      {
+        "id": "c04ec818-7353-4e34-b9d8-9610a138106d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T06:30:00Z"
+      },
+      {
+        "id": "a00afd93-cb91-4c15-a69f-30f91a42b671",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T18:10:00Z"
+      },
+      {
+        "id": "557b9c0d-46e5-4e97-9cda-3905d195c8eb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T08:00:00Z"
+      },
+      {
+        "id": "f45a02a5-de9e-4985-a6a3-16a9fbb2601d",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T22:00:00Z"
+      },
+      {
+        "id": "c3423667-bd3a-40ee-9184-618cd2559a30",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T21:00:00Z"
+      },
+      {
+        "id": "88fc48ad-caa0-4032-948c-897b25a67b92",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T08:30:00Z"
+      },
+      {
+        "id": "788f757b-09da-46f9-bd44-60ea590c0e35",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T18:40:00Z"
+      },
+      {
+        "id": "ff0e451b-222b-431a-a139-d14f1d7f9db5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T08:45:00Z"
+      },
+      {
+        "id": "b42c0df2-7b8f-47d3-ab12-07353fa0d52f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T20:10:00Z"
+      },
+      {
+        "id": "4db07416-5ca4-4de4-a6ad-8eebd19c11ce",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T06:45:00Z"
+      },
+      {
+        "id": "daa20b02-fc88-4a71-b293-bacebde73606",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T22:45:00Z"
+      },
+      {
+        "id": "a594167a-799d-4909-a9e4-3aab4e412f69",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T21:15:00Z"
+      },
+      {
+        "id": "810c71dd-8c04-44f1-9922-354763188e32",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T12:45:00Z"
+      },
+      {
+        "id": "69e6c7cb-d6b4-4528-b9b8-5becb1738cba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T19:05:00Z"
+      },
+      {
+        "id": "a0389a6c-661d-48f8-a6b5-6975b661f260",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-07",
+        "completedAt": "2025-07-07T19:05:00Z"
+      },
+      {
+        "id": "bd18985f-f212-40d9-b210-f537f444adf0",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T12:15:00Z"
+      },
+      {
+        "id": "4e9915d4-24a7-46cd-a1fc-c08bce51d6fe",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T21:20:00Z"
+      },
+      {
+        "id": "9bbd6217-d802-409e-b353-af9226bb5997",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T19:30:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "8a7ce976-9de2-4f8f-a460-97563b4e4d36",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T17:50:00Z"
+      },
+      {
+        "id": "2f35b6f8-5c97-45a3-86df-894d30a6a4c7",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T20:00:00Z"
+      },
+      {
+        "id": "cfe7822c-015e-4971-bd7b-2400188eddce",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T21:15:00Z"
+      },
+      {
+        "id": "54df67c0-5c38-475d-83cf-52139ba334db",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T06:20:00Z"
+      },
+      {
+        "id": "7c152737-4274-40f3-bddc-54264b0fde90",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T17:15:00Z"
+      },
+      {
+        "id": "d15cb0dd-fc42-4d0a-bb29-428dcec464cd",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T06:20:00Z"
+      },
+      {
+        "id": "59ec74e6-3cb7-4d5c-b989-447a706ef048",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T22:05:00Z"
+      },
+      {
+        "id": "d3000ce2-a8aa-4992-a38d-2c901b38240d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T07:15:00Z"
+      },
+      {
+        "id": "38d3f238-b472-4c86-a9ee-d339a1fa3e39",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-08",
+        "completedAt": "2025-07-08T08:20:00Z"
+      },
+      {
+        "id": "3175567b-6360-4f1a-a068-6b61108d926c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T18:40:00Z"
+      },
+      {
+        "id": "a10f7647-1919-4270-a29a-13a6e1fbeb26",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T06:45:00Z"
+      },
+      {
+        "id": "3b1ec2f1-d442-407b-bf7a-9c8a1dd93456",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T20:15:00Z"
+      },
+      {
+        "id": "3adcf04c-9406-4de0-b68e-d7b2d68049fd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T19:05:00Z"
+      },
+      {
+        "id": "dc0b91dd-a5aa-4a82-a165-bc96376f999e",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T19:10:00Z"
+      },
+      {
+        "id": "566978dc-0efb-40e3-8b0b-18948cfff549",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T06:30:00Z"
+      },
+      {
+        "id": "825bd0fc-84e2-4772-a3ee-3494f92f6135",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T17:45:00Z"
+      },
+      {
+        "id": "4ce5eb50-2c21-4c12-a2c7-f71871334cfe",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T20:45:00Z"
+      },
+      {
+        "id": "4152b0da-898a-489a-a65b-14b83f890da8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T12:10:00Z"
+      },
+      {
+        "id": "da7c3fb5-7fe1-481a-a64a-69f720185aae",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T17:00:00Z"
+      },
+      {
+        "id": "5a6e8093-9638-4740-a129-363aa7a5be49",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T06:20:00Z"
+      },
+      {
+        "id": "e998d7ab-c0ca-477b-90b6-f03a862efb21",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T07:15:00Z"
+      },
+      {
+        "id": "5556c583-b891-4662-8a1d-042e714f5c45",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T06:30:00Z"
+      },
+      {
+        "id": "e1f4adc5-57d1-4855-9ba9-772d9998279a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-09",
+        "completedAt": "2025-07-09T20:50:00Z"
+      },
+      {
+        "id": "e2d99dee-3263-41e9-a7cb-d852024df6d7",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T19:30:00Z"
+      },
+      {
+        "id": "e5cb40bf-2fde-4d50-9c26-771173bd0e9f",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T06:45:00Z"
+      },
+      {
+        "id": "878bb3d9-3cb9-4b40-80e4-acf14d29d619",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T06:00:00Z"
+      },
+      {
+        "id": "5f45b99b-8e0b-499a-9c07-4a396672f6ad",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T21:15:00Z"
+      },
+      {
+        "id": "c2609e1f-12f2-4388-acaa-915b551b6bf1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T18:15:00Z"
+      },
+      {
+        "id": "e2137490-0531-4f8b-b106-299de3602fc6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T20:50:00Z"
+      },
+      {
+        "id": "cb87ff1e-4f5f-4bfc-85e4-efa20fa36ac2",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T06:00:00Z"
+      },
+      {
+        "id": "a7ea50b8-1f3d-4c93-aefa-ea9586970459",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T08:10:00Z"
+      },
+      {
+        "id": "abaf9b18-4108-4ef0-b8b8-e37ffec7929f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T18:30:00Z"
+      },
+      {
+        "id": "10119368-5279-4a20-a218-24bce9f11ca1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T21:10:00Z"
+      },
+      {
+        "id": "2ef55430-53ff-4aef-8d44-724f803abe09",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T20:50:00Z"
+      },
+      {
+        "id": "431190a4-a795-4fd9-a1f1-6a4ae35b979a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T12:30:00Z"
+      },
+      {
+        "id": "0ad8c28d-edae-471a-a935-9823ed87a7ed",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T20:50:00Z"
+      },
+      {
+        "id": "b6124d00-13ac-4f72-b9fc-a9192b48eeeb",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T20:40:00Z"
+      },
+      {
+        "id": "e01750a8-3bf5-4093-aac7-a3a77fbde81a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-10",
+        "completedAt": "2025-07-10T06:40:00Z"
+      },
+      {
+        "id": "4daa60c7-e320-4df5-8f8a-587aa16c5fab",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T21:05:00Z"
+      },
+      {
+        "id": "5f3a7997-898d-47ff-bfa5-eacd40013592",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T19:50:00Z"
+      },
+      {
+        "id": "29bf5728-4da8-407a-ad54-30b475849c96",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T06:40:00Z"
+      },
+      {
+        "id": "f2beafe7-0604-48ea-ab49-fef4d69a0ca4",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T19:40:00Z"
+      },
+      {
+        "id": "a9e8b405-ec03-45db-be2b-b886daac4087",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T21:50:00Z"
+      },
+      {
+        "id": "6065b991-7eab-463e-8ed1-06555b545e75",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T17:45:00Z"
+      },
+      {
+        "id": "913bd023-98f9-47f5-9bcc-c6343b49f3a9",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T18:00:00Z"
+      },
+      {
+        "id": "1c4197d4-31d6-46ad-8068-bcce5bf297eb",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T22:20:00Z"
+      },
+      {
+        "id": "43b2508e-ff12-468e-9e2b-cf58826f5a03",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-11",
+        "completedAt": "2025-07-11T20:50:00Z"
+      },
+      {
+        "id": "0adb37c1-52f7-41b2-8717-5e1d94230fcb",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T06:20:00Z"
+      },
+      {
+        "id": "97bbae39-a6ba-440f-93c3-af355508cf2d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T12:50:00Z"
+      },
+      {
+        "id": "e4cbaf20-e747-4aeb-ab9f-91c6203e674f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T21:40:00Z"
+      },
+      {
+        "id": "5c1b789c-982a-4659-99c6-bb4aae085cc7",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T07:50:00Z"
+      },
+      {
+        "id": "2da23a7b-389c-4efb-bb76-a6c3f3b366dd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T18:40:00Z"
+      },
+      {
+        "id": "e96674ae-5b08-4f8a-9d33-d4ada70eb983",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T20:45:00Z"
+      },
+      {
+        "id": "a851389f-0aac-48a1-be53-699cc550f0ea",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T22:45:00Z"
+      },
+      {
+        "id": "ae5610fb-166a-4906-8207-4830a18b44b8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T06:05:00Z"
+      },
+      {
+        "id": "661d0ab2-e1bd-4604-96da-5f68f0af0538",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-12",
+        "completedAt": "2025-07-12T08:50:00Z"
+      },
+      {
+        "id": "d15158b0-2dce-469c-90dd-1f5f81c5bbde",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T21:10:00Z"
+      },
+      {
+        "id": "bee3cf61-0f78-48b1-8867-792036dec948",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T18:30:00Z"
+      },
+      {
+        "id": "a9723f1b-d998-4c10-ad54-cad6546f8f66",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T19:20:00Z"
+      },
+      {
+        "id": "a0cdcd1f-1be0-464d-b84c-188c8d2720a4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T08:10:00Z"
+      },
+      {
+        "id": "86ee19c2-18e2-4093-bbc7-92843da1a18a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T17:15:00Z"
+      },
+      {
+        "id": "b139232f-4c0a-47a3-828f-aa04b972ee5a",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T20:50:00Z"
+      },
+      {
+        "id": "c3b7a08e-4c89-4758-b712-dec8a3bc43f2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T06:00:00Z"
+      },
+      {
+        "id": "be3a96fe-70f5-4bc8-9541-a87ef129e5c9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T07:30:00Z"
+      },
+      {
+        "id": "a31eb20b-49a9-4ea5-8e1a-4a70c943bea9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T19:20:00Z"
+      },
+      {
+        "id": "b2a8e536-f8f0-4859-b568-0a44208920e8",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T20:40:00Z"
+      },
+      {
+        "id": "f9a12306-e4a1-4476-b946-ec0dea716161",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-13",
+        "completedAt": "2025-07-13T08:00:00Z"
+      },
+      {
+        "id": "4a5ae067-3c07-40a1-9a50-9dc8a0e37b8d",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T18:20:00Z"
+      },
+      {
+        "id": "3f334884-da2a-4056-85e5-a9bda3b5d921",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T07:40:00Z"
+      },
+      {
+        "id": "4f1a8813-c137-441a-99c5-5e5ed63ea124",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T21:05:00Z"
+      },
+      {
+        "id": "25bb57ff-0942-46d8-98a1-35908dbfe679",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T19:20:00Z"
+      },
+      {
+        "id": "58e196bc-abd2-41c1-9487-22462383f303",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T06:30:00Z"
+      },
+      {
+        "id": "70eff193-8fde-4d50-a09b-ad7e0a5006b3",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T22:45:00Z"
+      },
+      {
+        "id": "f5399ae2-6098-4e49-87d0-0bc6c8083666",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T08:00:00Z"
+      },
+      {
+        "id": "bbb0ab7b-b990-460c-ae04-4390037f1efe",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T19:40:00Z"
+      },
+      {
+        "id": "49479203-a8af-4f9e-a2ea-b51a88b650a4",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T21:20:00Z"
+      },
+      {
+        "id": "143dee29-3689-417c-bdda-7c3c639b3a52",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T22:00:00Z"
+      },
+      {
+        "id": "1c286909-f01f-4c54-bea1-441d647aeaa5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T19:45:00Z"
+      },
+      {
+        "id": "95d44ab0-9da7-4ae7-a9a2-6c47a2e9539d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T06:45:00Z"
+      },
+      {
+        "id": "6afa8f07-2b0a-4381-b166-5394ab80a53a",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T17:20:00Z"
+      },
+      {
+        "id": "2eee57d4-0425-4bb3-aee7-a8fb6d362f04",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-14",
+        "completedAt": "2025-07-14T12:30:00Z"
+      },
+      {
+        "id": "9b35d105-207c-47f6-9b4f-89ae56594658",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T21:00:00Z"
+      },
+      {
+        "id": "6cb8cf2c-c294-4240-a4e6-75f9a03ec296",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T22:10:00Z"
+      },
+      {
+        "id": "d46f24fd-db46-4d50-b75a-b6753716fd53",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T17:15:00Z"
+      },
+      {
+        "id": "97acd68d-aeac-475c-8ff5-36311d00c4a9",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T17:00:00Z"
+      },
+      {
+        "id": "a12e42b7-8638-474b-b650-f4f7c03b4c20",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T20:45:00Z"
+      },
+      {
+        "id": "86671876-806a-44f7-83ca-64477345bcfe",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T21:40:00Z"
+      },
+      {
+        "id": "7fdc239c-dc8f-4009-b79f-6ffe0d3bc13b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T17:40:00Z"
+      },
+      {
+        "id": "721584c7-7362-4545-805c-3a78515c394a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T20:10:00Z"
+      },
+      {
+        "id": "3a404ee5-73a5-48b8-bda8-7ffb66931686",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T20:45:00Z"
+      },
+      {
+        "id": "aaaa3d96-85e3-4101-ba7c-13130fd4b789",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T07:00:00Z"
+      },
+      {
+        "id": "152d367d-325a-4c00-97db-9bf7d73847ee",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T08:10:00Z"
+      },
+      {
+        "id": "e88c0d51-fdeb-4bee-ba32-351ba4bb8e11",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T22:00:00Z"
+      },
+      {
+        "id": "18e3f9f4-5e62-4009-8032-17769e0c05cc",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-15",
+        "completedAt": "2025-07-15T08:40:00Z"
+      },
+      {
+        "id": "5dab80e0-95a5-436f-9002-ec17fa95c19b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T19:40:00Z"
+      },
+      {
+        "id": "b9d57758-73d9-4f90-9372-8c469b5a4add",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T07:10:00Z"
+      },
+      {
+        "id": "33b7327e-1501-448c-baf4-c7c90cc6323d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T07:30:00Z"
+      },
+      {
+        "id": "23c1dd30-0eca-487e-af29-d0c26f035562",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T19:00:00Z"
+      },
+      {
+        "id": "5f53172c-bb0b-4510-8dd1-3af56db4d17b",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T08:50:00Z"
+      },
+      {
+        "id": "3fdf6806-aacc-4e06-b1ad-a2c27c0abb36",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T19:15:00Z"
+      },
+      {
+        "id": "4cd6b016-7fb9-4220-bd1d-895db23f2985",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T17:45:00Z"
+      },
+      {
+        "id": "a3f72afb-01c0-48e7-8f12-65dbe848e803",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T19:15:00Z"
+      },
+      {
+        "id": "460d36cc-1f7a-49bc-9c64-245f766e54e0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T22:30:00Z"
+      },
+      {
+        "id": "ec3b3bf5-f0ed-4c14-b76a-a00e08028c1b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T21:45:00Z"
+      },
+      {
+        "id": "a793f776-ffc7-4203-9e10-97df92f08cbb",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T12:10:00Z"
+      },
+      {
+        "id": "78867c38-da3f-4584-9afb-d106ad555c01",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-16",
+        "completedAt": "2025-07-16T08:20:00Z"
+      },
+      {
+        "id": "6bf52803-cb09-45bf-9da4-58d86e2a2869",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T19:10:00Z"
+      },
+      {
+        "id": "89d987fc-b4ed-45e2-a87e-bc10e1a4c5df",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T20:15:00Z"
+      },
+      {
+        "id": "6fbc0e23-f363-471d-8205-019953e7a48d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T18:15:00Z"
+      },
+      {
+        "id": "01ad350b-cde2-4bfd-8337-4291208d3bb6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T22:15:00Z"
+      },
+      {
+        "id": "513558f0-9d2c-45b6-8850-14ea833b186b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T22:40:00Z"
+      },
+      {
+        "id": "2b7fef93-884a-4fe1-bf19-9f1d7c3d5fa6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T22:40:00Z"
+      },
+      {
+        "id": "6c96521f-208b-4cb6-93b1-d189b01c1c4a",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T20:50:00Z"
+      },
+      {
+        "id": "64e27278-8c73-4ce0-807f-176d4ac441de",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T18:20:00Z"
+      },
+      {
+        "id": "f5844e63-2cdb-4928-b743-6947f16fad84",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T17:05:00Z"
+      },
+      {
+        "id": "3ff2a39b-5401-4917-b7fb-b6e0c7176bf6",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T08:15:00Z"
+      },
+      {
+        "id": "fc006b77-ee87-459c-96ba-0e401df9a3e4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T07:40:00Z"
+      },
+      {
+        "id": "35da4acb-c5bf-442d-ae39-26ff909590d6",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T22:20:00Z"
+      },
+      {
+        "id": "9ecf1555-a8a5-42de-9d8f-f1ef7e36bed0",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T19:00:00Z"
+      },
+      {
+        "id": "9588e02c-0523-4331-93b4-f4855b6730d2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-17",
+        "completedAt": "2025-07-17T08:45:00Z"
+      },
+      {
+        "id": "3bfd8e41-d31d-49f5-9ac7-79682cd55c2d",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T20:20:00Z"
+      },
+      {
+        "id": "bdca14f4-75fd-47f2-8c08-8318af72d3aa",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T20:10:00Z"
+      },
+      {
+        "id": "cd756e95-2619-4356-aff5-75b3897ab600",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T18:15:00Z"
+      },
+      {
+        "id": "d41474c2-4168-4db6-a614-5f17a6092dde",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T08:50:00Z"
+      },
+      {
+        "id": "8bffb9d6-6cb2-4003-af7f-133369987a27",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T12:05:00Z"
+      },
+      {
+        "id": "a7a75afe-ea34-42fb-be36-4b4bbab68ce8",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T20:20:00Z"
+      },
+      {
+        "id": "fc912c48-c31c-47d8-81ab-68b4aff95fbc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T12:40:00Z"
+      },
+      {
+        "id": "aff8b395-8e11-4d1b-95ae-f6d9993b528f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T19:50:00Z"
+      },
+      {
+        "id": "17b62733-b93b-4e03-95b2-086bac8de166",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T21:00:00Z"
+      },
+      {
+        "id": "997ead84-3b8a-444d-8510-341a8732a50d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T17:00:00Z"
+      },
+      {
+        "id": "81d04c64-a8d8-447a-b64d-6683d8f1973a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T12:40:00Z"
+      },
+      {
+        "id": "56888d9c-1641-4c06-9c1e-781c170ea5f6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T21:30:00Z"
+      },
+      {
+        "id": "1aadd0e9-82af-455e-bd8f-f7c4d359850b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-18",
+        "completedAt": "2025-07-18T12:50:00Z"
+      },
+      {
+        "id": "9590e4ed-7193-4d0c-8bfd-066068dc6e7e",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T12:30:00Z"
+      },
+      {
+        "id": "36025b6a-e48f-44e9-914e-7ad921de273e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T20:15:00Z"
+      },
+      {
+        "id": "66a4967c-8397-450b-940e-df763c07fa42",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T18:00:00Z"
+      },
+      {
+        "id": "baac97fa-fc4f-47e3-bfcc-44a6e09d0470",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T18:40:00Z"
+      },
+      {
+        "id": "53dfadf0-6f6c-4eef-955d-2c3357e983bb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T07:30:00Z"
+      },
+      {
+        "id": "6a3601d7-8e94-4502-86b1-331be7135e49",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T22:40:00Z"
+      },
+      {
+        "id": "806dac2c-d3b3-478f-a119-1265211b4a18",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T07:20:00Z"
+      },
+      {
+        "id": "2033479f-818c-47f4-b7ac-3d0b50726bea",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T19:50:00Z"
+      },
+      {
+        "id": "8eda51aa-5521-4ab1-bfa2-b1230ef7dd1d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T21:40:00Z"
+      },
+      {
+        "id": "74f3d5fb-31ec-4488-a22e-cd7ff6b00445",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-19",
+        "completedAt": "2025-07-19T21:05:00Z"
+      },
+      {
+        "id": "54f6b13b-84cd-4e76-8840-c1e5c7947eee",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T19:10:00Z"
+      },
+      {
+        "id": "cc075748-48f3-444a-93c2-f9c566199719",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T17:05:00Z"
+      },
+      {
+        "id": "964cb31d-54e2-4043-9bf0-4c41ff8ac705",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T19:05:00Z"
+      },
+      {
+        "id": "178d0053-b9da-4b31-8f2a-02828a4fb4b3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T18:05:00Z"
+      },
+      {
+        "id": "58dc971b-afcf-480c-a891-590335f34c9b",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T19:30:00Z"
+      },
+      {
+        "id": "1039c929-7cc9-4e6a-950d-4687a649da28",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T19:15:00Z"
+      },
+      {
+        "id": "74a01cee-f3dd-4c54-a2ea-a821a2893ae3",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T12:00:00Z"
+      },
+      {
+        "id": "6684582c-cb7b-4a52-8d5d-d759243de739",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-20",
+        "completedAt": "2025-07-20T08:00:00Z"
+      },
+      {
+        "id": "8d3228ec-2cad-4b23-bb51-8cf32b9b4039",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T21:40:00Z"
+      },
+      {
+        "id": "949269ef-e64b-4284-a751-46b99aeb3c16",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T17:20:00Z"
+      },
+      {
+        "id": "1fac1c50-5b9c-42b5-81b3-94b5b3239b0f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T12:20:00Z"
+      },
+      {
+        "id": "b1ddd224-9a21-4da0-97d4-4a71e1a0df78",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T19:00:00Z"
+      },
+      {
+        "id": "33b06dc0-3559-4252-b1f0-4710b9a731db",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T08:05:00Z"
+      },
+      {
+        "id": "e56319ce-ee72-4e16-b09b-affdbc85a670",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T12:30:00Z"
+      },
+      {
+        "id": "f51e7fc5-e53d-4979-8ab7-6aa56fde54de",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T08:10:00Z"
+      },
+      {
+        "id": "e23ca5ef-cbb2-43b5-936f-ad1a49d81ba3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T22:00:00Z"
+      },
+      {
+        "id": "0ab469cc-1b86-4742-84d5-546d2455c1a2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T07:50:00Z"
+      },
+      {
+        "id": "c6f3d8b4-ccf9-494c-9fb2-ed92ca702b10",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T06:15:00Z"
+      },
+      {
+        "id": "fc819a83-e21d-4fa6-bacc-2c268d5637e8",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T17:00:00Z"
+      },
+      {
+        "id": "cb8e089a-31f1-4369-b0d1-b3de0d556fb7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T12:15:00Z"
+      },
+      {
+        "id": "db6aa437-5e7a-475d-9ee9-2fc9d01cbdb8",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T19:50:00Z"
+      },
+      {
+        "id": "b6c38931-b9cc-4a35-942e-91d7d5398627",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T22:05:00Z"
+      },
+      {
+        "id": "f90ddd48-44c8-43ca-8f1f-491c47ca8a24",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-21",
+        "completedAt": "2025-07-21T07:00:00Z"
+      },
+      {
+        "id": "5eecce60-391d-49fc-9b25-1b7f4ea3b0e1",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T20:00:00Z"
+      },
+      {
+        "id": "89ec649e-415c-4bb8-a512-0e84d60e4d3c",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T19:05:00Z"
+      },
+      {
+        "id": "d3c10f74-c40c-4bf6-98cc-6439fe36602c",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T18:40:00Z"
+      },
+      {
+        "id": "8855e3ef-c746-4120-8cba-dd5d08cb1e71",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T18:45:00Z"
+      },
+      {
+        "id": "3d466cf3-6315-4b81-b5f8-ad34a48b22e8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T20:10:00Z"
+      },
+      {
+        "id": "8611cf07-fc9f-45c9-891b-c99b36f2ef2e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T08:45:00Z"
+      },
+      {
+        "id": "2034f430-a276-4c10-bca6-cd5f8353add8",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T12:20:00Z"
+      },
+      {
+        "id": "bfc50b40-ff97-44bb-9c1f-a753650ee792",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T07:05:00Z"
+      },
+      {
+        "id": "3abaf0ac-719f-4cc3-8e89-1d35df141ddc",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T12:05:00Z"
+      },
+      {
+        "id": "77abafe0-03aa-4f91-8456-9b33d295cd69",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T17:50:00Z"
+      },
+      {
+        "id": "bebd1c6a-dd88-498c-b15a-8264528052f4",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T20:40:00Z"
+      },
+      {
+        "id": "3f5abb22-97aa-4c36-98d7-c294ad71d1b9",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T06:05:00Z"
+      },
+      {
+        "id": "94287edb-be3b-4fcd-aef5-5a9219bdfb13",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-22",
+        "completedAt": "2025-07-22T22:15:00Z"
+      },
+      {
+        "id": "445f71e5-965d-40ce-94be-9726ba52bf87",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T21:10:00Z"
+      },
+      {
+        "id": "1d4ffa3d-9a9e-40f5-bee1-9ecedb844869",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:20:00Z"
+      },
+      {
+        "id": "6e422984-21a1-4227-b941-c1992ba09df3",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:15:00Z"
+      },
+      {
+        "id": "370d4901-7fef-41d7-b40f-1e8a881f1896",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:20:00Z"
+      },
+      {
+        "id": "f1a7ded2-8c23-47d7-b294-6e97c70c6d32",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:40:00Z"
+      },
+      {
+        "id": "c605caa6-3e2c-482c-a714-6c14c970b316",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:50:00Z"
+      },
+      {
+        "id": "c8c76c5f-74b5-4871-a2f4-749f308a958d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:45:00Z"
+      },
+      {
+        "id": "4e701541-cfd2-4159-976d-fc3db163377a",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T20:15:00Z"
+      },
+      {
+        "id": "fe4423c9-9450-44f3-8d3a-668ece576a51",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T06:20:00Z"
+      },
+      {
+        "id": "a728d971-a4e9-447f-a33e-346c584509d6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T08:45:00Z"
+      },
+      {
+        "id": "19f9fc99-1bc7-4058-ae22-2cf850db57d2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T20:50:00Z"
+      },
+      {
+        "id": "2ef2fea5-3530-42aa-be01-51e7520b540f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-23",
+        "completedAt": "2025-07-23T22:45:00Z"
+      },
+      {
+        "id": "99c118c8-27de-471a-a130-09701f3e9bd2",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T06:50:00Z"
+      },
+      {
+        "id": "0e07a198-e9c8-43d2-8e39-83b04f29f064",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T18:30:00Z"
+      },
+      {
+        "id": "2d96ca68-57d7-498a-82da-48fd7a93ac8a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T21:05:00Z"
+      },
+      {
+        "id": "7ffb5f0a-6a47-4741-bd11-260e8bd27895",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T06:50:00Z"
+      },
+      {
+        "id": "1a8346f7-1192-4b41-8656-9deeae88ca06",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T21:30:00Z"
+      },
+      {
+        "id": "a74c90fa-2557-48a7-b85f-70e66e24b582",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T20:40:00Z"
+      },
+      {
+        "id": "93a65284-b63d-4a92-99df-2aa5cf7263a8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T08:10:00Z"
+      },
+      {
+        "id": "82af320d-3f68-4fea-bc72-6318990a3b90",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T20:05:00Z"
+      },
+      {
+        "id": "33c16001-7d49-4254-baf7-4bfb843dd872",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T17:15:00Z"
+      },
+      {
+        "id": "15146a9d-51b8-456b-a68d-fc62c0b07f6d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T07:20:00Z"
+      },
+      {
+        "id": "effd9c83-d764-4b21-9cef-f499e465101d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T19:40:00Z"
+      },
+      {
+        "id": "a075a540-551a-4952-9dfe-3fc6d73731c8",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-24",
+        "completedAt": "2025-07-24T19:00:00Z"
+      },
+      {
+        "id": "96137194-f3c8-4625-843b-5ff33f89f01e",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T06:20:00Z"
+      },
+      {
+        "id": "1dd794cc-8a8f-4466-879f-19732d9ca3e3",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T17:20:00Z"
+      },
+      {
+        "id": "4f25ec25-012b-48c4-8c49-ecb84fcf4689",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T21:10:00Z"
+      },
+      {
+        "id": "4594ad29-9aa1-45eb-af0f-469b25443fb0",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T22:00:00Z"
+      },
+      {
+        "id": "49d943b5-bab1-4bdc-93c1-c6f9251fd87b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T17:00:00Z"
+      },
+      {
+        "id": "b99ee100-ad52-4353-8f8a-174798a13fd1",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T22:00:00Z"
+      },
+      {
+        "id": "acc5fdc5-2f4d-407a-9de2-325c572ef76e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T18:15:00Z"
+      },
+      {
+        "id": "b7fc3a9c-8731-445e-8260-af38f6062e85",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T19:05:00Z"
+      },
+      {
+        "id": "898e62b0-294b-4de6-85bd-05377487385d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T08:30:00Z"
+      },
+      {
+        "id": "2bba574e-f3d2-4dac-a7b8-06ab4144ad18",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T12:15:00Z"
+      },
+      {
+        "id": "e1bc9b02-e0bd-466f-b993-239b607cdc62",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T22:00:00Z"
+      },
+      {
+        "id": "af7f605e-76e0-49ed-8d34-f8a7fbb73354",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-25",
+        "completedAt": "2025-07-25T06:05:00Z"
+      },
+      {
+        "id": "b4a4f06d-3a7e-4c53-92a8-72950f9ddb3e",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T21:20:00Z"
+      },
+      {
+        "id": "f8aab6aa-7745-4f70-bbc4-9e56d1b7fb9d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T12:15:00Z"
+      },
+      {
+        "id": "4a26a0a2-1fec-4b95-98e2-c14cc5bef065",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T22:20:00Z"
+      },
+      {
+        "id": "b0542e37-3274-4792-925c-371ad375435d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T07:05:00Z"
+      },
+      {
+        "id": "5a4da3a2-1a1a-4134-84c2-b2b05691f3c2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T22:00:00Z"
+      },
+      {
+        "id": "65a52490-96c8-4ef4-85b2-00bfd7bc0afb",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T18:50:00Z",
+        "note": "Low energy but showed up"
+      },
+      {
+        "id": "264eac75-bc4a-45c0-94f4-a7acf5b82ce7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T18:20:00Z"
+      },
+      {
+        "id": "924357f5-7488-4583-b731-225b8224dc63",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T21:45:00Z"
+      },
+      {
+        "id": "142acac2-ddfb-47d0-8aa4-ad8bcc82b13b",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T20:15:00Z"
+      },
+      {
+        "id": "2d23c67b-d207-4f8c-9a39-d033615bbd1c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-26",
+        "completedAt": "2025-07-26T21:05:00Z"
+      },
+      {
+        "id": "02cc5290-0893-41fb-b815-9296efaf188e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T06:10:00Z"
+      },
+      {
+        "id": "3fe7bad7-d116-4dbf-94af-e489b7f56f75",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T08:00:00Z"
+      },
+      {
+        "id": "86dbbf2f-2d41-4c9f-9a80-e6fb71fb7526",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T08:10:00Z"
+      },
+      {
+        "id": "6c1e8024-edaf-49cb-8c02-fed447052ccd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T18:30:00Z"
+      },
+      {
+        "id": "f4d46257-8702-408b-81a9-27bf7ec829f8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T21:40:00Z"
+      },
+      {
+        "id": "87deb7bf-39ec-4dca-bdb3-1e23bcfe25e5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T21:15:00Z"
+      },
+      {
+        "id": "6d4fdaa4-b1e3-44d3-a29d-6e42aa151988",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T12:40:00Z"
+      },
+      {
+        "id": "b1ee034c-01a0-4f1b-b84e-6d9a0974eeb7",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T17:45:00Z"
+      },
+      {
+        "id": "4184bf15-d70c-417d-940f-a9107e179d73",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-27",
+        "completedAt": "2025-07-27T18:05:00Z"
+      },
+      {
+        "id": "6f862f7a-9917-45fa-b80a-22701cc9e517",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T07:40:00Z"
+      },
+      {
+        "id": "fcba61d5-5758-4e7c-a35b-bebb12565d7d",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T12:45:00Z"
+      },
+      {
+        "id": "cdc3d90c-7adf-4754-8a94-96aefb058ee3",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T20:45:00Z"
+      },
+      {
+        "id": "4428e081-6aaf-4266-bd58-5fa327c7c61d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T22:00:00Z"
+      },
+      {
+        "id": "ef487024-7590-4e87-861f-71e616d7c4d1",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T18:10:00Z"
+      },
+      {
+        "id": "77ad556a-aa4d-47d8-aa1a-5c214a5a3024",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T19:45:00Z"
+      },
+      {
+        "id": "92a41c74-941c-4ce5-b8a7-9fd32f9fed04",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T12:30:00Z"
+      },
+      {
+        "id": "11984e77-f861-4529-9834-d8e259d86681",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T12:15:00Z"
+      },
+      {
+        "id": "11ad645f-0ee0-41c1-90b5-a37c38ba4d4e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T06:40:00Z"
+      },
+      {
+        "id": "b8e11c31-3676-4ae3-9ab9-443b48d49e2b",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T08:20:00Z"
+      },
+      {
+        "id": "edfaaddb-477d-43ad-8277-4ebdbe2547f6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-07-28",
+        "completedAt": "2025-07-28T19:50:00Z"
+      },
+      {
+        "id": "a3dc2aed-e87b-40fe-8bca-de49b8d0ddf9",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T17:50:00Z"
+      },
+      {
+        "id": "c40c1469-2e83-4940-b208-55dc22b0d7e2",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T17:30:00Z"
+      },
+      {
+        "id": "76b89dc0-85ae-4fe0-9cbb-44514bdfdc73",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T12:00:00Z"
+      },
+      {
+        "id": "95513fff-2fa3-4737-9a0d-6b164d4580a4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T20:00:00Z"
+      },
+      {
+        "id": "e76038c4-5426-4ca6-8775-00e08894d03c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T18:15:00Z"
+      },
+      {
+        "id": "d2e8d359-26fe-48ee-9125-7d6013b0459b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T06:45:00Z"
+      },
+      {
+        "id": "1b52c380-82b8-4b35-bf82-1835224c3941",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T08:45:00Z"
+      },
+      {
+        "id": "1dafc2dd-4e9b-40d0-ba78-c0fb9f4a7b1b",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T12:00:00Z"
+      },
+      {
+        "id": "ab51062d-d1bf-4dd6-bedc-7a09d3d4137e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T06:00:00Z"
+      },
+      {
+        "id": "e69c7f66-b1fb-41bf-8c1e-6b3cb6f35a55",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T20:15:00Z"
+      },
+      {
+        "id": "1b61be5c-3eee-4a62-b7a1-56b64e3473b0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-29",
+        "completedAt": "2025-07-29T18:10:00Z"
+      },
+      {
+        "id": "3f3046c6-2d18-422c-9c75-b3a8f02d63ed",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T20:30:00Z"
+      },
+      {
+        "id": "977fcca5-b08d-4349-8dee-7a0a5661bcb2",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T18:00:00Z"
+      },
+      {
+        "id": "46d006be-37f5-4542-abb5-cdb68bbffcab",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T18:30:00Z"
+      },
+      {
+        "id": "79cbacee-c3e9-41f6-8f94-230650f64067",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T18:40:00Z"
+      },
+      {
+        "id": "1200ab35-e519-4310-8771-f9d46e15f351",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T19:05:00Z"
+      },
+      {
+        "id": "75ae15fb-22f1-4315-b000-671939bec66d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T07:45:00Z"
+      },
+      {
+        "id": "ed1e7806-9081-4e77-8145-6b4ae8311cfc",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T08:00:00Z"
+      },
+      {
+        "id": "445f6827-a228-467c-b016-a4fe36a2948a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T17:05:00Z"
+      },
+      {
+        "id": "14e62de8-939a-4654-a7da-85ae8d6584bb",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T20:50:00Z",
+        "note": "Low energy but showed up"
+      },
+      {
+        "id": "7c2a18f2-936e-48f0-b845-c9ad5180ce4c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T17:00:00Z"
+      },
+      {
+        "id": "44439c47-e298-4a20-b51e-5d20a096c446",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T21:45:00Z"
+      },
+      {
+        "id": "dbfb8bcb-0b1a-4001-b2f7-b51605567179",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-30",
+        "completedAt": "2025-07-30T18:05:00Z"
+      },
+      {
+        "id": "4d78304e-60f6-4e42-a210-aaa38d694dc8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T12:45:00Z"
+      },
+      {
+        "id": "d581c73f-908f-49ee-b3d4-80d9f7d5bb08",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T07:40:00Z"
+      },
+      {
+        "id": "56569bd0-2d64-4579-bde6-a0d7784ee949",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T08:45:00Z"
+      },
+      {
+        "id": "c6e75fa0-e041-4e89-aa2f-d1768320f1ba",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T06:50:00Z"
+      },
+      {
+        "id": "058a7bb1-8fc4-48ab-bde3-5f5ffce42ade",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T12:40:00Z"
+      },
+      {
+        "id": "07c144a2-7141-408f-8402-444c0a7f8fd3",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T12:40:00Z"
+      },
+      {
+        "id": "5aea31c3-bb9d-4b4d-9152-004f82560bca",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T07:05:00Z"
+      },
+      {
+        "id": "50f78cfe-5577-473e-95c2-2b17c11f7797",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T06:10:00Z"
+      },
+      {
+        "id": "8e2d257f-b42f-4fbf-ad9e-460e6adcaf52",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T06:20:00Z"
+      },
+      {
+        "id": "806fb71d-5c84-467a-be99-7baac3548368",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T17:00:00Z"
+      },
+      {
+        "id": "9e2727e9-ebec-44e3-9b5e-1f11bd519b4a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T07:50:00Z"
+      },
+      {
+        "id": "12afdc15-b732-489e-a3a5-3642a078ff97",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T21:20:00Z"
+      },
+      {
+        "id": "39552bf1-dfcc-4771-a9c3-e582f0b40669",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-07-31",
+        "completedAt": "2025-07-31T21:05:00Z"
+      },
+      {
+        "id": "06534309-1a66-473a-bef0-45bd6aa7ceac",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T21:10:00Z"
+      },
+      {
+        "id": "0aebe975-32c6-4b82-813d-266c0189b964",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T17:15:00Z"
+      },
+      {
+        "id": "c2f02686-01a5-4bf2-ae30-a97b49d1083f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T20:20:00Z"
+      },
+      {
+        "id": "34f987b0-5101-4aaa-a943-d3e151d43783",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T12:05:00Z"
+      },
+      {
+        "id": "40b7909b-0910-4eee-808e-523de7dc3f4e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T20:10:00Z"
+      },
+      {
+        "id": "36e6aaa0-1ebb-4e99-bf06-9705e044b567",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T19:00:00Z"
+      },
+      {
+        "id": "24867689-83a3-49bc-a177-3d0015779dee",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T19:40:00Z"
+      },
+      {
+        "id": "e0401969-bc21-4d80-a9ab-47f5d956dfff",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-01",
+        "completedAt": "2025-08-01T07:30:00Z"
+      },
+      {
+        "id": "5140e3b8-7846-45d1-acdb-dbaeb9632392",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T18:05:00Z"
+      },
+      {
+        "id": "34ec1817-9ef6-4785-8b5f-c9b0c7a5d97c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T18:00:00Z"
+      },
+      {
+        "id": "ef4f4c55-5384-43d3-a771-376419ba9be0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T20:45:00Z"
+      },
+      {
+        "id": "becbfa86-2f10-4c19-83b0-80c97e09fac5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T20:05:00Z"
+      },
+      {
+        "id": "0eead8a6-c626-4ce9-b2a9-e7d294c326b8",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T07:15:00Z"
+      },
+      {
+        "id": "b03fa00d-be8d-4d98-b9bb-800a14db3bb5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T17:20:00Z"
+      },
+      {
+        "id": "a2f639a1-0464-4ccf-9821-59efb3aad924",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T08:00:00Z"
+      },
+      {
+        "id": "f3c4f78e-9fe4-412a-8a2c-51a3057872a6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-02",
+        "completedAt": "2025-08-02T07:00:00Z"
+      },
+      {
+        "id": "54bdbfb2-b0ea-46f5-b5d1-64f97e26d142",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T18:40:00Z"
+      },
+      {
+        "id": "25258419-ab9a-4ce4-a98e-b69d01c60ecb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T20:05:00Z"
+      },
+      {
+        "id": "b762db09-29d3-46f9-ab56-1403226fc07f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T20:40:00Z"
+      },
+      {
+        "id": "36d35ef0-82f9-44da-ab24-ed340dcf34af",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T12:20:00Z"
+      },
+      {
+        "id": "7001b3e7-ee3b-49bb-86fc-3a6503e06cd9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T21:00:00Z"
+      },
+      {
+        "id": "a326b96e-b57f-4881-8d67-5bffc4fafb90",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T18:30:00Z"
+      },
+      {
+        "id": "68aae49d-cbb9-4261-8ff5-75c66015b0f3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T06:05:00Z"
+      },
+      {
+        "id": "6f63d836-4298-4f31-9986-6292e5ba84cc",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T20:40:00Z"
+      },
+      {
+        "id": "fcbff174-4364-451c-813d-505542e42242",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T20:45:00Z"
+      },
+      {
+        "id": "d3ec50bc-0833-43b8-adaa-3052a163fd9e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-03",
+        "completedAt": "2025-08-03T21:05:00Z"
+      },
+      {
+        "id": "6ec32eb8-e913-4f71-b864-bec2ee233c8f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T18:50:00Z"
+      },
+      {
+        "id": "c62178f6-b549-4afa-8d79-904898c67b59",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T19:00:00Z"
+      },
+      {
+        "id": "1eceb6a1-f5b3-49dc-a479-6e3627d6eec2",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T06:30:00Z"
+      },
+      {
+        "id": "49a77364-08a7-4a3c-8e97-92cf2edc3303",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T20:00:00Z"
+      },
+      {
+        "id": "f5259553-257f-4231-b101-dbcff9aefb3e",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T06:10:00Z"
+      },
+      {
+        "id": "455e2fb8-fddc-4a79-9e6a-c3ea2ac46f20",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T20:30:00Z"
+      },
+      {
+        "id": "2099918a-efac-49ab-a2a4-6cc7e9b6b5be",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T06:00:00Z"
+      },
+      {
+        "id": "c38bc55e-e472-4191-84fd-0d1cfd2b9b6c",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T12:50:00Z"
+      },
+      {
+        "id": "3371797c-4961-4ccc-9ddc-790110218100",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T20:10:00Z"
+      },
+      {
+        "id": "c61147ad-c94c-4b57-8ffc-f20f265c1d8b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T22:40:00Z"
+      },
+      {
+        "id": "58f0d416-fcd0-45cc-8fc0-79942f9230ea",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T22:45:00Z"
+      },
+      {
+        "id": "42efe68b-51b3-46b6-9e4d-cfbf3a4c409f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T08:50:00Z"
+      },
+      {
+        "id": "ac233a18-33a3-4e92-8899-11153da34c0d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-04",
+        "completedAt": "2025-08-04T07:50:00Z"
+      },
+      {
+        "id": "d34bc965-b664-4680-abe8-607b9990c6a5",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T08:40:00Z"
+      },
+      {
+        "id": "49b01f3d-4451-4472-be3a-ee7865c98170",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T17:30:00Z"
+      },
+      {
+        "id": "7e2281b6-5c10-426e-9408-27e85113703a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T18:30:00Z"
+      },
+      {
+        "id": "0578c4d1-2d0a-4992-ac5d-c81960865caf",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T20:05:00Z"
+      },
+      {
+        "id": "30a19eb4-3b3f-440d-a69c-a3ded04ae31a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T18:20:00Z"
+      },
+      {
+        "id": "ac92ff1d-e86b-4a54-bfb7-a460603185ff",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T06:45:00Z"
+      },
+      {
+        "id": "5dda2aaf-3922-4d54-afb5-5ed877b5024e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T20:20:00Z"
+      },
+      {
+        "id": "75129852-9f0f-412c-9605-6e8d1e314b31",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T20:00:00Z"
+      },
+      {
+        "id": "1c661b59-f867-489d-91e3-b414c0a1a820",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T22:45:00Z"
+      },
+      {
+        "id": "2fe9c701-1f04-492d-8636-9d84080a4eec",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T20:45:00Z"
+      },
+      {
+        "id": "baef5729-be9f-4295-bc60-0d45ea3e8119",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T17:40:00Z"
+      },
+      {
+        "id": "538a47aa-e5d3-4f19-b029-6adb06932e79",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-05",
+        "completedAt": "2025-08-05T18:10:00Z"
+      },
+      {
+        "id": "c8e8681d-89f7-4c75-8908-857bcd6f5f9b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T17:40:00Z"
+      },
+      {
+        "id": "4f75858b-3f30-4ec9-bb8b-bd634a780e45",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T07:40:00Z"
+      },
+      {
+        "id": "b1abf034-de03-41a6-9890-453a12c6582d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T21:45:00Z"
+      },
+      {
+        "id": "5bac6a30-6a86-432f-bd5a-f4d91379c3c2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T19:00:00Z"
+      },
+      {
+        "id": "f9612fa8-7430-4e8c-bf75-9ced90f9d950",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T20:40:00Z"
+      },
+      {
+        "id": "74be1595-8948-4fa3-b316-e94e7a6130c2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T18:15:00Z"
+      },
+      {
+        "id": "f3bc1b8d-3e50-49a4-a820-30aca6cc3568",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T12:40:00Z"
+      },
+      {
+        "id": "0e617ea8-1b90-4f60-9ce8-e5ef3470cc01",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T21:40:00Z"
+      },
+      {
+        "id": "9938ca27-9a20-4100-8723-48d5dc52801b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-06",
+        "completedAt": "2025-08-06T22:30:00Z"
+      },
+      {
+        "id": "cd6b75f2-686e-403a-a2fb-4738950cdea4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T22:30:00Z"
+      },
+      {
+        "id": "0d71d27e-ada0-4796-86e9-5854530f6167",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T22:10:00Z"
+      },
+      {
+        "id": "abaf9482-fd9e-4680-8ffd-2548fe234b26",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T19:30:00Z"
+      },
+      {
+        "id": "1ab3088f-6c6e-43b8-8e94-301c4f696de0",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T17:50:00Z"
+      },
+      {
+        "id": "21e13e66-fbb9-461d-a8ea-2bedbc203670",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T20:10:00Z"
+      },
+      {
+        "id": "317f8f44-206c-4a2b-a157-061dea302255",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T18:30:00Z"
+      },
+      {
+        "id": "addaf1e4-9a68-4134-adca-8d64275e7fa3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T19:40:00Z"
+      },
+      {
+        "id": "600043d9-e312-4d10-855a-f27c84fb533e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T07:30:00Z"
+      },
+      {
+        "id": "29ac3ba5-b050-4ee2-a886-91650be39288",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T21:40:00Z"
+      },
+      {
+        "id": "28aa3420-ca7e-4d12-adfd-2602de9c47ef",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T19:50:00Z"
+      },
+      {
+        "id": "05b14b4f-1de4-4fdf-a497-30df28570421",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T07:05:00Z"
+      },
+      {
+        "id": "c25bb240-0fe0-46f8-80d6-9b8e1305c8fb",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T21:10:00Z"
+      },
+      {
+        "id": "c80b52c1-adb5-4f61-82c4-e42812b76aa1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-07",
+        "completedAt": "2025-08-07T06:00:00Z"
+      },
+      {
+        "id": "f170e042-5491-4307-8a11-c8b48ed04938",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T22:20:00Z"
+      },
+      {
+        "id": "b9867aa5-90be-453f-a411-3d392c11ee8c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T21:40:00Z"
+      },
+      {
+        "id": "941969cc-a6f9-480f-83e5-0976019bcf60",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T21:15:00Z"
+      },
+      {
+        "id": "bda9d0cc-f41c-44e0-8a04-d659a34f221f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T07:50:00Z"
+      },
+      {
+        "id": "6ba107ec-57e8-4c22-8dd4-c6e8bbeb320d",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T19:00:00Z"
+      },
+      {
+        "id": "d85095b9-6f80-449e-9ea2-918f5aa9d154",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T20:10:00Z"
+      },
+      {
+        "id": "0b9bceeb-89b8-44c6-9e26-43681f77ff59",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T22:20:00Z"
+      },
+      {
+        "id": "64078ed7-aff2-4762-9dc4-4c7216e3d9f0",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T08:05:00Z"
+      },
+      {
+        "id": "696b5752-1a51-4093-a97a-40bb736cd480",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T21:50:00Z"
+      },
+      {
+        "id": "e559c768-cab5-4b1a-b64b-e9453a46b6c0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T19:10:00Z"
+      },
+      {
+        "id": "465fed2f-fa82-4b12-ada9-ead3ea938b5f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T19:10:00Z"
+      },
+      {
+        "id": "32e39dc0-8d62-4c80-a78c-bf3648464318",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-08",
+        "completedAt": "2025-08-08T17:15:00Z"
+      },
+      {
+        "id": "59fc2407-0345-4567-ba79-622a53313099",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T19:10:00Z"
+      },
+      {
+        "id": "3ce55e80-0f22-4c73-a33b-3102c1a6a16a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T07:50:00Z"
+      },
+      {
+        "id": "d553568b-f2d7-4472-9519-2295420284e9",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T06:45:00Z"
+      },
+      {
+        "id": "58971f08-eff8-44a3-8f7c-a6944d9a6581",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T20:20:00Z"
+      },
+      {
+        "id": "65902361-ca39-403e-a347-f06767338598",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T06:45:00Z"
+      },
+      {
+        "id": "81509e03-89f1-42de-a099-3590c96993e8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T22:20:00Z"
+      },
+      {
+        "id": "459f4e4a-32d7-4eb5-b7b7-55d1c838f471",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T07:20:00Z"
+      },
+      {
+        "id": "c4706d47-eb10-493d-95f3-ccf7a80e6e2e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T20:45:00Z"
+      },
+      {
+        "id": "50daabea-5edf-485d-8f71-e0bfe78afce2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-09",
+        "completedAt": "2025-08-09T17:20:00Z"
+      },
+      {
+        "id": "98ffed9e-557e-46c5-9177-6daff796b06b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T21:20:00Z"
+      },
+      {
+        "id": "81c9182e-b3b3-4bf4-a8e9-9641fc324645",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T21:20:00Z"
+      },
+      {
+        "id": "74e92951-52ae-436d-91b7-19a36d7458b2",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T17:50:00Z"
+      },
+      {
+        "id": "8d82193f-24bf-442c-b893-5992a30ba7f4",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T08:30:00Z"
+      },
+      {
+        "id": "c59d95c4-b5d8-41f5-9413-d3c0c78b7e08",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T21:10:00Z"
+      },
+      {
+        "id": "bc2b1163-6f8a-420e-ab8b-985c4742db4a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T21:40:00Z"
+      },
+      {
+        "id": "4209dd9a-7f79-4184-9641-d571321f75c2",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T12:45:00Z"
+      },
+      {
+        "id": "b35c73b1-3e77-462b-939b-4f1b1d27025c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-10",
+        "completedAt": "2025-08-10T07:50:00Z"
+      },
+      {
+        "id": "9d55353b-4287-41f1-98c1-05bb9d50f238",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T19:00:00Z"
+      },
+      {
+        "id": "6a65f7ba-977c-4ea4-aaab-7462e33b05a8",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T17:45:00Z"
+      },
+      {
+        "id": "312cd0af-02ca-4d11-ab2a-1388efc26508",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T21:20:00Z"
+      },
+      {
+        "id": "83cf83c1-49dc-4a34-afa4-94048a7e4e03",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T21:30:00Z"
+      },
+      {
+        "id": "87d9929b-41cf-433f-8ba9-cd0be02945bb",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T08:10:00Z"
+      },
+      {
+        "id": "0ddfee9a-441f-491c-9098-beac6f71c9e4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T20:45:00Z"
+      },
+      {
+        "id": "95c4d44d-1cae-43ea-b3f2-4a1dd46536c4",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T18:45:00Z"
+      },
+      {
+        "id": "2260c001-1b35-4e07-905f-4e158fc92968",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T20:50:00Z"
+      },
+      {
+        "id": "c925e400-6091-4267-b167-9861aa0fb084",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T20:50:00Z"
+      },
+      {
+        "id": "bc583cd5-cfa4-4f99-85fb-cffd1ca3b153",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T06:45:00Z"
+      },
+      {
+        "id": "f8ab31ed-1326-46a5-8566-1b5d75ce93db",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T21:45:00Z"
+      },
+      {
+        "id": "0a4834a3-44c0-4ae1-9406-47a3c5793c9e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-11",
+        "completedAt": "2025-08-11T12:20:00Z"
+      },
+      {
+        "id": "be833da6-e7bd-4385-be7a-42861be1cabc",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T22:15:00Z"
+      },
+      {
+        "id": "c9eaf9d9-9478-48ff-a9ea-046377e86bd4",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T06:45:00Z"
+      },
+      {
+        "id": "1298a47f-0e75-4759-81b6-f0719814a18e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T06:30:00Z"
+      },
+      {
+        "id": "1d111357-f091-44de-9eb9-75e4452db9d5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T17:05:00Z"
+      },
+      {
+        "id": "7d51d663-76f6-43da-86cc-e1b7b965d91f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T19:10:00Z"
+      },
+      {
+        "id": "8f209a2b-5235-4238-b99a-43349d568f93",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T08:10:00Z"
+      },
+      {
+        "id": "ec8b775b-58c8-42ba-8d86-de06afe2ee94",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T06:30:00Z"
+      },
+      {
+        "id": "c9361061-1095-4688-9fa6-9d8dcf8bb804",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T07:30:00Z"
+      },
+      {
+        "id": "6fb92d70-05fe-4ed9-b04f-0215df7e5095",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T08:10:00Z"
+      },
+      {
+        "id": "5c294dd6-4e03-47cc-ba74-ecbe367fd315",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T19:45:00Z"
+      },
+      {
+        "id": "d8f1b5fc-3019-4c91-bb80-d88b87747654",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T22:50:00Z"
+      },
+      {
+        "id": "19354c80-457b-4db9-9215-299ff6afe568",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-12",
+        "completedAt": "2025-08-12T08:30:00Z"
+      },
+      {
+        "id": "37455e14-2376-4083-be0b-7738c881881e",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T07:20:00Z"
+      },
+      {
+        "id": "56ce9449-34bd-46a1-b7e5-4c8772ce579c",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T06:50:00Z"
+      },
+      {
+        "id": "f5cb4ed7-74fd-4593-af1c-12b8b855849b",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T06:15:00Z"
+      },
+      {
+        "id": "a1fd90e0-8250-4867-bd4e-5d897a854eed",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T22:30:00Z"
+      },
+      {
+        "id": "9f76a8e3-88d5-4ddc-a9a0-64f12a24e174",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T22:20:00Z"
+      },
+      {
+        "id": "67c01e4d-8323-41c4-abad-c18160c0dc8e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T22:15:00Z"
+      },
+      {
+        "id": "9e5a631a-938b-4b59-a2cc-ba15bda83750",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T08:00:00Z"
+      },
+      {
+        "id": "506dda6b-dbf0-4518-9733-4eaaf1e38934",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T18:15:00Z"
+      },
+      {
+        "id": "d74c957d-02ea-419c-acec-6504cb50b056",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T21:45:00Z"
+      },
+      {
+        "id": "2a23f24f-d6a4-4d9e-8851-0ebd29891a7b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T21:45:00Z"
+      },
+      {
+        "id": "765872f8-1b98-418e-ba63-ec40d8cb222e",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T06:40:00Z"
+      },
+      {
+        "id": "a85259f5-7cce-4886-83e4-35e887f990a9",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T07:10:00Z"
+      },
+      {
+        "id": "d10bee79-46fb-40ae-b320-88566f64bb5e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-13",
+        "completedAt": "2025-08-13T20:00:00Z"
+      },
+      {
+        "id": "a25d4f47-7d5e-4a76-8396-2d66a97efa5f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T17:45:00Z"
+      },
+      {
+        "id": "6995f3d5-9563-4466-b061-4024ce8be64a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T21:40:00Z"
+      },
+      {
+        "id": "51df063c-a958-4ae6-afbe-42a5b584e918",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T17:30:00Z"
+      },
+      {
+        "id": "9df384d0-267c-4251-b8b3-341374563439",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T12:15:00Z"
+      },
+      {
+        "id": "e502974c-d2c4-4c41-a15b-e96a581a9426",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T22:10:00Z"
+      },
+      {
+        "id": "3cb55204-2495-4520-a1fc-4cc732b0b025",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T07:50:00Z"
+      },
+      {
+        "id": "e575e9b1-5678-47dc-940e-201fde639046",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T20:20:00Z"
+      },
+      {
+        "id": "20870157-d30c-4187-aeb9-c1409addd341",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T20:50:00Z"
+      },
+      {
+        "id": "13d0a440-386a-4c31-afc1-2a2d0a416ab8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T18:05:00Z"
+      },
+      {
+        "id": "deaff77e-0534-4aec-b75f-0e729b76859c",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T21:20:00Z"
+      },
+      {
+        "id": "01a74190-baf8-48c2-abcd-3ab50f8cfd72",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T21:20:00Z"
+      },
+      {
+        "id": "3926574f-d338-426a-9383-9b4d6905433e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T19:10:00Z"
+      },
+      {
+        "id": "de05cdbf-70e8-412f-a5d0-651a497c8252",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-14",
+        "completedAt": "2025-08-14T06:45:00Z"
+      },
+      {
+        "id": "b1e64db2-4b88-42af-9a8b-1582144099d6",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T06:45:00Z"
+      },
+      {
+        "id": "f6b6ea07-8bd4-4b29-9ddb-35126be2426c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T08:10:00Z"
+      },
+      {
+        "id": "d548985e-2f78-4bec-bc4e-4be9905eff73",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T20:40:00Z"
+      },
+      {
+        "id": "b75654ea-05db-431e-9817-b74cb0d514b1",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T17:05:00Z"
+      },
+      {
+        "id": "b3c166e6-f748-4259-a0d3-52c525fd15d2",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T20:05:00Z"
+      },
+      {
+        "id": "fac328e7-d1a7-4886-9401-b4ab29e9ee73",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T12:10:00Z"
+      },
+      {
+        "id": "ec83adc3-df57-401b-9117-5fe5a466a4c8",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T17:00:00Z"
+      },
+      {
+        "id": "24420272-f94c-4fcb-9c33-e317d7e26375",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T12:15:00Z"
+      },
+      {
+        "id": "c0d766dd-eac9-4046-9a44-16ece313c8a6",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T08:20:00Z"
+      },
+      {
+        "id": "9ae24877-25f1-4950-a87c-ba26c2ba87f7",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T07:00:00Z"
+      },
+      {
+        "id": "a9d63546-b5b1-4e5c-9d0e-4ae5df01c050",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-15",
+        "completedAt": "2025-08-15T21:15:00Z"
+      },
+      {
+        "id": "06c18f12-1a27-4ca6-8d62-e59059e55f0a",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T07:05:00Z"
+      },
+      {
+        "id": "c3d52f15-32f0-4f33-81a1-fa4db71a6304",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T17:45:00Z"
+      },
+      {
+        "id": "90ffd309-e070-409f-87f6-afcacaab9ed4",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T18:30:00Z"
+      },
+      {
+        "id": "5de7642b-ad5f-4e3b-b17a-fa3a54779ea6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T21:15:00Z"
+      },
+      {
+        "id": "c8e9aa6a-cb43-4b42-b1df-51a0183aab6d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T19:10:00Z"
+      },
+      {
+        "id": "df06c638-cab5-4777-a3b4-7afa15eee941",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T22:20:00Z"
+      },
+      {
+        "id": "edbc25a6-07d5-4fac-bf83-b5bf4e6c93d1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T19:00:00Z"
+      },
+      {
+        "id": "058c0eab-e31f-4a9d-afe2-20710dd5a273",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T06:10:00Z"
+      },
+      {
+        "id": "569adcce-aa6e-4cb4-9ab1-cd2c62de59e1",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T22:20:00Z"
+      },
+      {
+        "id": "bc8ac27a-bb2d-4d08-8479-22e76e600807",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T17:05:00Z"
+      },
+      {
+        "id": "629e4a95-0d37-4516-adbd-69001fad2b9d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T06:30:00Z"
+      },
+      {
+        "id": "0b955c47-2c95-4e64-a3f9-780b95b23603",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-16",
+        "completedAt": "2025-08-16T17:20:00Z"
+      },
+      {
+        "id": "da1e48f6-434e-464c-92a9-9367d170de88",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T18:10:00Z"
+      },
+      {
+        "id": "e8729de1-8b7d-424b-ba5a-09baeba24943",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T08:40:00Z"
+      },
+      {
+        "id": "58f34bbb-1877-4beb-a59c-58e6024a6436",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T22:50:00Z"
+      },
+      {
+        "id": "b8a43a8a-55e6-4e94-a9fc-edbbb446194d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T08:05:00Z"
+      },
+      {
+        "id": "6b2b450a-501c-4704-b08d-ee2072dcac40",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T08:05:00Z"
+      },
+      {
+        "id": "36ad4eb6-06b3-4e34-910f-a264be60a88f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T22:50:00Z"
+      },
+      {
+        "id": "cf179bfd-867c-4507-bc9b-1a7f777bd923",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T06:15:00Z"
+      },
+      {
+        "id": "37930620-eba2-4ebe-bb2a-c69a70653045",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T12:00:00Z"
+      },
+      {
+        "id": "cc48ce03-bca7-4a56-8804-ee52f3903111",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T22:15:00Z"
+      },
+      {
+        "id": "6d6fb44e-9fbc-4735-ad2b-483e2c3b1e65",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T18:10:00Z"
+      },
+      {
+        "id": "e3e3bf90-5462-4af2-8818-739a98b890d0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-17",
+        "completedAt": "2025-08-17T22:30:00Z"
+      },
+      {
+        "id": "5ea0b55a-8b40-435d-9ba8-a5fbaada1084",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T20:20:00Z"
+      },
+      {
+        "id": "2473435a-6918-47d8-9b83-7b84ca1f827f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T12:00:00Z"
+      },
+      {
+        "id": "76d21e2b-a473-4422-b1ad-4d7c6dff2b28",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T06:50:00Z"
+      },
+      {
+        "id": "a2d6a2b3-10ec-4425-a849-cbb351b8164e",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T21:05:00Z"
+      },
+      {
+        "id": "92f2d621-d601-4144-b90d-4d91842baffa",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T17:15:00Z"
+      },
+      {
+        "id": "a459d95b-cde8-4b14-a956-bd33ab08bb5a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T22:20:00Z"
+      },
+      {
+        "id": "0d00521b-2545-40e4-b17d-23400fcae0c0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T06:15:00Z"
+      },
+      {
+        "id": "8f5a46d3-263b-4b52-882b-282690ac6fef",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-18",
+        "completedAt": "2025-08-18T22:50:00Z"
+      },
+      {
+        "id": "89682a45-d291-455d-b5fe-cd6bd1a73943",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T18:50:00Z"
+      },
+      {
+        "id": "04bf7d26-f9f5-435d-8dc4-789fa839e314",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T12:45:00Z"
+      },
+      {
+        "id": "ed2494b2-bb8c-40aa-a230-3ba265f753dd",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T21:05:00Z"
+      },
+      {
+        "id": "2941380f-b865-4f3b-b269-53452c761267",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T21:00:00Z"
+      },
+      {
+        "id": "de29151b-59a2-44c1-b248-fa3668b40f57",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T08:10:00Z"
+      },
+      {
+        "id": "7f775f8c-2abb-4161-a0c2-df50433d7cbf",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T12:05:00Z"
+      },
+      {
+        "id": "923ec21a-616a-4c92-96da-27348df07119",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T19:20:00Z"
+      },
+      {
+        "id": "cc33f323-cf36-472b-91b2-1efd38caa388",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T08:45:00Z"
+      },
+      {
+        "id": "6506bd60-b0de-4a3d-af8f-e7c4700f4c55",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T20:00:00Z"
+      },
+      {
+        "id": "bfc47af4-e2ca-4cdf-bcff-a3376efd0c1a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T06:00:00Z"
+      },
+      {
+        "id": "a7844e55-e77c-4f0b-a182-05c1d4b9bb94",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T07:15:00Z"
+      },
+      {
+        "id": "0534fa27-2084-4e43-9191-248846122722",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T07:50:00Z"
+      },
+      {
+        "id": "425f3984-8339-4b73-a85d-0c9b61de2f13",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T21:15:00Z"
+      },
+      {
+        "id": "d2acb71b-c3db-4347-9e5e-cb90d9f2a7e3",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T19:15:00Z"
+      },
+      {
+        "id": "11f9adb0-2bb7-4bf9-b260-287ab5a7145d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-19",
+        "completedAt": "2025-08-19T20:50:00Z"
+      },
+      {
+        "id": "4b866f34-05c5-4504-9213-3d92fa968594",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T06:45:00Z"
+      },
+      {
+        "id": "5b2c1c06-d8ed-4f19-84cf-0abf8e254747",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T17:05:00Z"
+      },
+      {
+        "id": "91d443b4-e315-4324-ab8b-0dd59e85bd68",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T08:40:00Z"
+      },
+      {
+        "id": "e121960b-e84a-4901-8a14-7bff4aac3540",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T06:15:00Z"
+      },
+      {
+        "id": "6df6736c-fb9b-44e2-93ee-2c25eb8abb0a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T22:15:00Z"
+      },
+      {
+        "id": "190a6bbd-70e2-42ef-a557-0168f34e7f45",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T21:20:00Z"
+      },
+      {
+        "id": "424988b1-4b94-465d-8596-76a457afa6d7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T17:30:00Z"
+      },
+      {
+        "id": "a88acaa9-811e-45af-8d30-5356260c5800",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T20:05:00Z"
+      },
+      {
+        "id": "6b0d53c3-1f8e-49eb-a9f2-1f8c6fe85b6b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T17:40:00Z"
+      },
+      {
+        "id": "469ec626-a702-4f21-97e5-2b45998b37e1",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T07:15:00Z"
+      },
+      {
+        "id": "30920ee8-e15a-49bd-9406-021258271e64",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T06:00:00Z"
+      },
+      {
+        "id": "f3e516f7-d9b4-4107-b177-25cc9887b7e6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T17:00:00Z"
+      },
+      {
+        "id": "396488b4-c8b0-4c1f-a1d5-87ffa55f4cb8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T21:30:00Z"
+      },
+      {
+        "id": "f7fb474a-a2ff-4894-938e-4fa46a923179",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-20",
+        "completedAt": "2025-08-20T22:40:00Z"
+      },
+      {
+        "id": "553abd61-deaf-45d0-bb61-0b6476f47689",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T07:45:00Z"
+      },
+      {
+        "id": "997f5e9f-ce7c-4364-9e7f-05a66e01d0a0",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T22:15:00Z"
+      },
+      {
+        "id": "77450fd6-1124-4ead-ba81-0104ed40cbc6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T06:50:00Z"
+      },
+      {
+        "id": "6b05fe11-8978-4b46-8b50-05a5947c1275",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T06:15:00Z"
+      },
+      {
+        "id": "5039cd6c-dad8-453d-a8ca-cb319b2d230d",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T20:00:00Z"
+      },
+      {
+        "id": "7a759d4f-0a11-4e50-991c-1a0338fd625f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T19:10:00Z"
+      },
+      {
+        "id": "bcf01ea7-a80e-4a99-94eb-56b2d44e1107",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T06:40:00Z"
+      },
+      {
+        "id": "ef7d770b-99c2-4eb8-90c2-b9e867591719",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T18:20:00Z"
+      },
+      {
+        "id": "1cc94b32-74af-407d-9b62-5b08b4937693",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T18:40:00Z"
+      },
+      {
+        "id": "aa07218a-8ae8-4587-a82a-b798a34211e0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T20:50:00Z"
+      },
+      {
+        "id": "8ab32628-9f8d-4cfb-8cb3-c6d459e8cc82",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T12:15:00Z"
+      },
+      {
+        "id": "08669c33-577f-487f-9b5d-baaa56047ee4",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T12:15:00Z"
+      },
+      {
+        "id": "c9d38ae6-2a78-4be9-ba0e-b5b922c1ef75",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T08:50:00Z"
+      },
+      {
+        "id": "18fa6cc7-0ed8-4950-95b6-ae984a358302",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-21",
+        "completedAt": "2025-08-21T19:00:00Z"
+      },
+      {
+        "id": "5ed73d71-b2f9-472b-9429-b72e98d2f09e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T12:45:00Z"
+      },
+      {
+        "id": "d0eb2860-963e-4382-9c55-44e69a9ad6f8",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T21:40:00Z"
+      },
+      {
+        "id": "608ef150-775f-4890-b086-5a74bf53d2fc",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T17:00:00Z"
+      },
+      {
+        "id": "2170c29b-b5ef-4dea-baaa-4eb38e72b6f3",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T17:00:00Z"
+      },
+      {
+        "id": "08046275-d2ed-4338-895f-94aa2ba58c9b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T17:50:00Z"
+      },
+      {
+        "id": "0dd616fa-317b-4914-801b-e3ba1f3806cc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T19:10:00Z"
+      },
+      {
+        "id": "a7c0fb6b-de09-4fa8-97b8-2369480b22b6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T19:50:00Z"
+      },
+      {
+        "id": "97bc0ddb-f288-47d8-b37c-daa094f5a2f5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T17:05:00Z"
+      },
+      {
+        "id": "0dcdda33-7e81-4e81-a198-84a128fcee81",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-22",
+        "completedAt": "2025-08-22T17:05:00Z"
+      },
+      {
+        "id": "b7e3e410-2849-4c56-9c80-34c5473e15d2",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T22:10:00Z"
+      },
+      {
+        "id": "18102104-7121-4c5b-93a0-013e00d11c81",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T07:05:00Z"
+      },
+      {
+        "id": "c99597cb-7b0c-4315-a12d-f574ef7ab98c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T07:20:00Z"
+      },
+      {
+        "id": "b0282ffd-1100-4435-ae91-6f0642f59f41",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T17:30:00Z"
+      },
+      {
+        "id": "99edf23d-c330-476c-8993-61c41a25f5a6",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T08:10:00Z"
+      },
+      {
+        "id": "e0797192-f04d-403e-93eb-4ed60839d860",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T22:00:00Z"
+      },
+      {
+        "id": "2a013138-c263-4a7d-b320-eac0fe44c000",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T17:30:00Z"
+      },
+      {
+        "id": "d02b1137-fd70-47c0-a60d-4075c54db86d",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T21:15:00Z"
+      },
+      {
+        "id": "666d5319-6494-49f1-89df-68c5827a25d6",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T22:10:00Z"
+      },
+      {
+        "id": "54f34cec-2630-4e7c-a35c-fda3ab603820",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T17:45:00Z"
+      },
+      {
+        "id": "20043833-09d0-483f-a557-774a5f8fb0b1",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-23",
+        "completedAt": "2025-08-23T06:40:00Z"
+      },
+      {
+        "id": "a81bdd9e-9a1c-4ec9-9b02-1c3bedce83ca",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T08:00:00Z"
+      },
+      {
+        "id": "41b5b66a-0967-48d0-b34d-9e1adc457aac",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T08:30:00Z"
+      },
+      {
+        "id": "56f96164-ad7c-412e-9512-37e84bee3cb5",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T06:50:00Z"
+      },
+      {
+        "id": "00fcca91-4988-40a9-b1e6-fa88b5973cff",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T22:30:00Z"
+      },
+      {
+        "id": "46029e37-c3c4-407e-b75a-a0ee1c165edc",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T17:15:00Z"
+      },
+      {
+        "id": "6e6d6e91-7d16-483b-a7a3-bf08c03ed8b9",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T17:15:00Z"
+      },
+      {
+        "id": "7dd7bcaf-d4cc-472d-9a47-e6d38b273561",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T22:45:00Z"
+      },
+      {
+        "id": "76801a82-e20a-4db4-80ad-6e32a3566e31",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T20:45:00Z"
+      },
+      {
+        "id": "d74f11c0-df48-465a-b87c-ed2111f8b0d2",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T12:10:00Z"
+      },
+      {
+        "id": "19b8af2e-1fdd-4148-8992-b4bd2db60882",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T19:50:00Z",
+        "note": "Caught a duplicate charge"
+      },
+      {
+        "id": "5bb69968-e71d-44ee-951b-dd9c865cc04e",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T06:45:00Z"
+      },
+      {
+        "id": "9545dc3d-412e-4a66-bb0b-04a5f7578332",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-24",
+        "completedAt": "2025-08-24T06:40:00Z"
+      },
+      {
+        "id": "4f698635-8985-48bb-831b-b046d4e12853",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T06:15:00Z"
+      },
+      {
+        "id": "cb9aa0c9-c308-43f0-95be-abc3c02d9b9d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T18:40:00Z"
+      },
+      {
+        "id": "7ce02e54-3e67-4edd-af3c-49a4ea9d87e5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T20:45:00Z"
+      },
+      {
+        "id": "25376952-ef00-4634-98be-ec55867c8b16",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T12:10:00Z"
+      },
+      {
+        "id": "f5e7dfb5-ce7a-430b-8f44-538023fe7844",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T19:45:00Z"
+      },
+      {
+        "id": "f62c4dce-2d3c-487e-b331-75e01689662a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T20:40:00Z"
+      },
+      {
+        "id": "96c494d3-a2d0-4775-aa20-6c0d4c54601c",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T08:15:00Z"
+      },
+      {
+        "id": "197b45e8-a511-44b5-b88f-c163d7c7ef3c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T06:05:00Z"
+      },
+      {
+        "id": "373f36b6-1ed0-47dc-808d-4e668a897bea",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T22:45:00Z"
+      },
+      {
+        "id": "169d66e2-f4a5-49ab-b13c-bddb554963ed",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T07:10:00Z"
+      },
+      {
+        "id": "ebcbc729-353b-4e4c-ba95-28608b2e48ec",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T21:20:00Z"
+      },
+      {
+        "id": "1050f4c6-57cd-496c-92b6-f1768b79bc14",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T06:40:00Z"
+      },
+      {
+        "id": "d70c39a9-2c49-4509-b5e5-a931a08b51b9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T21:50:00Z"
+      },
+      {
+        "id": "28ede3f2-510f-4a6e-94a2-4a29312e187f",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T07:20:00Z"
+      },
+      {
+        "id": "393770af-57e7-4399-8e1d-4bbcf7b89927",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T12:45:00Z"
+      },
+      {
+        "id": "3c561186-37b1-4deb-870f-5027136e1be9",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-25",
+        "completedAt": "2025-08-25T18:50:00Z"
+      },
+      {
+        "id": "4860ed3a-5031-4164-802f-bfd290081279",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T08:05:00Z"
+      },
+      {
+        "id": "acb28fc5-2f2f-4f0c-b362-6a6b712aedbf",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T17:45:00Z"
+      },
+      {
+        "id": "264818ae-9794-4ed0-a34e-7c571d4c9ec9",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T18:00:00Z"
+      },
+      {
+        "id": "34055d41-fbff-4722-a9f1-7babf2c26900",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T21:30:00Z"
+      },
+      {
+        "id": "524919d7-cda3-44dd-810d-b764161dd0f7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T06:05:00Z"
+      },
+      {
+        "id": "5096e33e-a946-4a1b-a569-c2c977385fe3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T12:00:00Z"
+      },
+      {
+        "id": "09586c1b-44f7-45b6-96c3-6849ff08c62b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T07:00:00Z"
+      },
+      {
+        "id": "8f2eb2e8-c4f2-4cc5-88ec-c1d2b2609bf8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T19:45:00Z"
+      },
+      {
+        "id": "1895e1a4-fe98-4f03-9d87-9d7cf2487795",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T06:20:00Z"
+      },
+      {
+        "id": "27404d57-4dfc-479b-8fb4-7a8b7fbcf086",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-26",
+        "completedAt": "2025-08-26T22:10:00Z"
+      },
+      {
+        "id": "d95b9d1e-4964-468d-acf1-d6b0039c5dae",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T06:15:00Z"
+      },
+      {
+        "id": "a6d9cfbe-c0c4-4663-ace9-fefacbd74228",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T20:15:00Z"
+      },
+      {
+        "id": "60546e1f-411d-4b21-b10a-94a33bd0289e",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T21:00:00Z"
+      },
+      {
+        "id": "33124135-b7ca-439e-86e1-1a025804b21a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T08:50:00Z"
+      },
+      {
+        "id": "4333f760-518a-4780-a28a-2323ec3f46ef",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T20:20:00Z"
+      },
+      {
+        "id": "5bccf20b-41de-4aed-b463-b1db5703b313",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T20:15:00Z"
+      },
+      {
+        "id": "9f2baea9-7a90-4940-8dab-6379b14d7d40",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T19:40:00Z"
+      },
+      {
+        "id": "4ba27b2f-b1a0-4b31-9e9a-7850d3f8f004",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T17:40:00Z"
+      },
+      {
+        "id": "919a701d-c1a6-41b7-9fdd-e194f3de82a1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T07:30:00Z"
+      },
+      {
+        "id": "5882f49e-5a65-4d96-8c90-7c64ba95409b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-27",
+        "completedAt": "2025-08-27T06:45:00Z"
+      },
+      {
+        "id": "2f09f977-b35f-4757-bc55-9b3b8ccd94ce",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T19:05:00Z"
+      },
+      {
+        "id": "428824ae-71e9-491c-9040-dd648ca316cb",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T18:10:00Z"
+      },
+      {
+        "id": "113ad5b6-0032-40c5-ade3-33e52cef20e3",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T06:50:00Z"
+      },
+      {
+        "id": "4a2df1a5-a890-412e-bcea-26b4cf6a9615",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T21:30:00Z"
+      },
+      {
+        "id": "db48f9d5-b34d-467f-9587-c04058092a00",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T19:20:00Z"
+      },
+      {
+        "id": "1f6b4768-c1ac-4835-aeb3-5ae23111082e",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T17:15:00Z"
+      },
+      {
+        "id": "ccd12aec-7f6a-40e4-9ace-b3004734fd15",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T21:05:00Z"
+      },
+      {
+        "id": "344261cc-75e5-427b-9153-35c261b28f82",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T20:30:00Z"
+      },
+      {
+        "id": "d3f5954b-9448-449c-b600-5b2884c5bf03",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T22:45:00Z"
+      },
+      {
+        "id": "c60912f1-a3a4-48ee-a877-afab86e6e15f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T17:10:00Z"
+      },
+      {
+        "id": "2e989df8-ee9a-4ac5-8bec-a0f4dac970c3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T20:40:00Z"
+      },
+      {
+        "id": "5085f03b-2019-4a7b-8ff9-b7d5cef4ff0a",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T20:20:00Z"
+      },
+      {
+        "id": "b57273ee-1aeb-4bb7-b067-c2faaa6ebcfb",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-28",
+        "completedAt": "2025-08-28T22:20:00Z"
+      },
+      {
+        "id": "a2fba2fa-8174-4776-a98d-d54b2baaad04",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T18:45:00Z"
+      },
+      {
+        "id": "a1c0821c-935c-488b-ba5a-48cda0208b4f",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T06:10:00Z"
+      },
+      {
+        "id": "63b4b947-5313-4a8a-883f-e2ca091894de",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T20:50:00Z"
+      },
+      {
+        "id": "312d15f7-c831-42be-ae69-31f2e43146c8",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T17:15:00Z"
+      },
+      {
+        "id": "d94c0ad7-7ddc-4752-b8c5-130a635f43ec",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T21:20:00Z"
+      },
+      {
+        "id": "c2dd4c4b-9c1c-4b62-830c-78984b4d0c55",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T21:10:00Z"
+      },
+      {
+        "id": "8fca6355-b0cb-4e17-8aec-439dec642342",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T06:10:00Z"
+      },
+      {
+        "id": "caaa6176-1915-4fd5-88a5-5df50555c88b",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T20:20:00Z"
+      },
+      {
+        "id": "843ccda0-7164-42bc-a55f-57d0460c93f9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T07:10:00Z"
+      },
+      {
+        "id": "124bc6f7-9f1f-48e2-b926-afb8054276f3",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T19:15:00Z"
+      },
+      {
+        "id": "7e1636fb-924e-42c7-9a79-c2d0e6054073",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-08-29",
+        "completedAt": "2025-08-29T18:45:00Z"
+      },
+      {
+        "id": "8ddf350c-1845-44c3-b554-55fd94f0dceb",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T22:10:00Z"
+      },
+      {
+        "id": "b073b562-236d-4857-936a-789e955b422e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T18:05:00Z"
+      },
+      {
+        "id": "94cefd08-61ac-417f-b647-ab3cb0082545",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T21:50:00Z"
+      },
+      {
+        "id": "cdd027e5-4893-4311-a5e9-656f3b663962",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T07:30:00Z"
+      },
+      {
+        "id": "2723f473-5a42-4816-a38d-6e67f2f0ed68",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T19:05:00Z"
+      },
+      {
+        "id": "33c9c25f-773a-475f-8124-bf9fa2826549",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T18:05:00Z"
+      },
+      {
+        "id": "9aab00da-4c7f-4082-a698-572ecbd5d2c6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T17:05:00Z"
+      },
+      {
+        "id": "7cb2be53-403e-4965-9066-28e946db45cc",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T08:15:00Z"
+      },
+      {
+        "id": "83ac3c42-aa8a-4636-a91f-f80389be2389",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T17:40:00Z"
+      },
+      {
+        "id": "cce0be75-604d-4d1a-8b71-e9eb399cb47c",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T08:20:00Z"
+      },
+      {
+        "id": "96bcac83-c493-44f0-a246-bf5799436644",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-30",
+        "completedAt": "2025-08-30T08:50:00Z"
+      },
+      {
+        "id": "09a46fa2-6b33-4ff2-80f2-00881ccb6059",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T17:00:00Z"
+      },
+      {
+        "id": "8693fee6-3833-4294-8a5c-ce6dd2e75fe1",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T07:15:00Z"
+      },
+      {
+        "id": "1820cbdb-a4f8-419a-b370-433ff34c3f0f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T17:05:00Z"
+      },
+      {
+        "id": "7ce3a7f9-2d4a-4988-845b-6c6d64865ab6",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T17:20:00Z"
+      },
+      {
+        "id": "f2c6e2f5-d903-4fff-9493-dcbc1d334b70",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T08:30:00Z"
+      },
+      {
+        "id": "f2b49f13-e105-45f9-8277-38e369770c96",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T12:00:00Z"
+      },
+      {
+        "id": "4a5cc6fb-f700-491c-a158-69f6449b4a44",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T22:50:00Z"
+      },
+      {
+        "id": "1f79a130-d50b-4e56-8945-aefb166a90c5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T19:20:00Z"
+      },
+      {
+        "id": "e746fa2d-1f08-4068-a644-d709fea84b8a",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T08:10:00Z"
+      },
+      {
+        "id": "d7c1dd61-1d48-46ca-8fbc-75151811ceb6",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T12:40:00Z"
+      },
+      {
+        "id": "c6ba44e0-1cdb-4626-b41d-9839883ea042",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-08-31",
+        "completedAt": "2025-08-31T06:40:00Z"
+      },
+      {
+        "id": "09ef3833-c0a8-40b1-8c64-a59f4fb104a7",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T21:05:00Z"
+      },
+      {
+        "id": "2c8ecede-9717-43ac-86c5-d5a11c21b44d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T18:45:00Z"
+      },
+      {
+        "id": "299948c8-6a13-45ea-a32d-f5cefd2d126b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T07:40:00Z"
+      },
+      {
+        "id": "ae592b21-18ed-4ca0-a3c3-58fc5acabff4",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T12:30:00Z"
+      },
+      {
+        "id": "8c349293-7e9d-4d0c-b602-9f5cd69cae4f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T07:15:00Z"
+      },
+      {
+        "id": "04334a5f-9552-4dee-b210-ffa6d22a39d5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T06:15:00Z"
+      },
+      {
+        "id": "4f139bc2-64f6-4862-8685-a560449c9a42",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T20:05:00Z"
+      },
+      {
+        "id": "069e5833-ece8-4570-9c73-4d122aa5c165",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T17:05:00Z"
+      },
+      {
+        "id": "57d140a8-48e3-4d9b-86c0-aad5e60ad16c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T07:00:00Z"
+      },
+      {
+        "id": "ca27b13c-32c4-49bb-a99f-4a272c6b91f8",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T08:30:00Z"
+      },
+      {
+        "id": "4901b6c8-0445-4cc1-9311-4d8f186fec21",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T19:30:00Z"
+      },
+      {
+        "id": "54bd27c3-f062-4c2e-bbcd-4c4501c15d75",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T12:15:00Z"
+      },
+      {
+        "id": "ac7ee804-0371-4e3d-8b73-788169907506",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T17:05:00Z"
+      },
+      {
+        "id": "02174515-41bb-42d6-af2d-6045fcc4894e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T08:20:00Z"
+      },
+      {
+        "id": "e299dbb9-3346-4489-8674-8c83971b6ba4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T08:15:00Z"
+      },
+      {
+        "id": "a49aac36-d1ad-4694-97a9-c540cdc2bb78",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T21:00:00Z"
+      },
+      {
+        "id": "73f7914f-441e-44df-ba1a-81fbbfc9617a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T08:15:00Z"
+      },
+      {
+        "id": "623a5849-1bf4-4bae-b6ee-d7c86945d49c",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-01",
+        "completedAt": "2025-09-01T22:20:00Z"
+      },
+      {
+        "id": "c7dadd75-8dc6-43ed-8b82-f38a32ae0706",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T06:20:00Z"
+      },
+      {
+        "id": "781d6ad9-6672-4a08-959e-ebfeed49e808",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T08:20:00Z"
+      },
+      {
+        "id": "e020c76a-0b06-4cd3-9f01-b02bbdb050c2",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T21:30:00Z"
+      },
+      {
+        "id": "9d585a61-1eed-4ed4-81fd-5891ed3a7bd0",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T06:15:00Z"
+      },
+      {
+        "id": "059bb095-0454-4a8e-acff-7dbc3e15245f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T20:10:00Z"
+      },
+      {
+        "id": "29bb70c1-1e17-4663-a748-0d845d1c2843",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T20:05:00Z"
+      },
+      {
+        "id": "54fa2e3c-f107-4627-a5c7-335405258cbc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T12:15:00Z"
+      },
+      {
+        "id": "806b7d0e-c182-49d8-b477-e840b0df6840",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T19:40:00Z"
+      },
+      {
+        "id": "73569533-afba-4f2e-aad0-a6dfeea7af6f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T07:10:00Z"
+      },
+      {
+        "id": "1c541e45-09bd-4e18-a9f1-b5206640dce2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T20:00:00Z"
+      },
+      {
+        "id": "c4426a0a-d6da-488e-adfd-8348a1dba3ef",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T18:00:00Z"
+      },
+      {
+        "id": "dafb02f5-261a-4d8c-9b41-8298d4d354e6",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T18:20:00Z"
+      },
+      {
+        "id": "f1ac04c6-63cf-4ea4-8676-cb4987024044",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T20:10:00Z"
+      },
+      {
+        "id": "df2a2aa9-de36-48bd-a553-c44af2535c0d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T17:50:00Z"
+      },
+      {
+        "id": "99c5e72e-18d3-4ece-b057-c1cec67af1bf",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-02",
+        "completedAt": "2025-09-02T22:30:00Z"
+      },
+      {
+        "id": "00edf3db-521e-403c-9294-99d50f14108a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T17:30:00Z"
+      },
+      {
+        "id": "b3761ea2-e503-4e21-856f-00e0a2be79e9",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T07:15:00Z"
+      },
+      {
+        "id": "1f59a352-287f-41d6-8e98-88e5ea21c0d7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T06:05:00Z"
+      },
+      {
+        "id": "421886fe-1148-430a-8ea4-5fd02e774f4f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T21:45:00Z"
+      },
+      {
+        "id": "df957205-5769-492e-ace8-fefd81d78eac",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T07:00:00Z"
+      },
+      {
+        "id": "204ad20e-328a-4237-a589-11c94781d760",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T19:00:00Z"
+      },
+      {
+        "id": "d3c2f140-8fec-4d36-9f7a-0350dea135ba",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T20:50:00Z"
+      },
+      {
+        "id": "0eaa9e91-7f18-43e4-9204-ffd195042f7b",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T17:30:00Z"
+      },
+      {
+        "id": "732d08d1-d649-410b-90ab-f94e4455c1d7",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T06:15:00Z"
+      },
+      {
+        "id": "b139d9d0-4f7b-4cb6-9195-a66113400b0c",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T07:00:00Z"
+      },
+      {
+        "id": "a31e2dd3-998c-4685-9768-7c06c0a4eeb2",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T17:50:00Z"
+      },
+      {
+        "id": "dc193c1e-f5ea-41fc-98eb-7c6b343bde1c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T17:45:00Z"
+      },
+      {
+        "id": "68c44562-c22d-4934-a36e-1e7add1a23b1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T07:05:00Z"
+      },
+      {
+        "id": "186aea15-c8ba-4477-8990-d7ab35bc50f0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-03",
+        "completedAt": "2025-09-03T12:45:00Z"
+      },
+      {
+        "id": "75ba5709-a142-44f6-9eeb-89acc9d548dc",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T21:20:00Z"
+      },
+      {
+        "id": "5ba0b2d5-8d38-4298-961b-726d5afd043d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T12:45:00Z"
+      },
+      {
+        "id": "abc96d62-e4f9-480e-9eae-10aba14d0229",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T21:30:00Z"
+      },
+      {
+        "id": "26cd183f-f79d-4640-90cf-93b06abd0c37",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T08:20:00Z"
+      },
+      {
+        "id": "3d3c59ac-a755-4646-8b5b-b65f4555ac99",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T06:30:00Z"
+      },
+      {
+        "id": "f07bad0d-baa1-4d7c-9e2f-e5b4f1c48aa8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T21:45:00Z"
+      },
+      {
+        "id": "392ca202-645d-485b-91bb-256e07ec1cd4",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T20:30:00Z"
+      },
+      {
+        "id": "77b6af17-4624-458b-b9db-b16ff86e26c8",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T08:45:00Z"
+      },
+      {
+        "id": "ac102da8-350e-4e96-a5a8-7f970a47b66e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T06:40:00Z"
+      },
+      {
+        "id": "acbecfd0-4880-4fa3-96db-e174698874cb",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T12:20:00Z"
+      },
+      {
+        "id": "bdc5a060-d884-4a89-a1fa-7bd71e5cbafd",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T06:05:00Z"
+      },
+      {
+        "id": "d77f5073-7147-4ae0-918d-23c377234171",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T17:45:00Z"
+      },
+      {
+        "id": "0638388f-2147-405c-8912-54758278bd4f",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T12:40:00Z"
+      },
+      {
+        "id": "c7237baa-7633-46fa-9638-3d2b8709dc0d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T22:10:00Z"
+      },
+      {
+        "id": "c1e1b48e-c99d-40a6-a8dd-ae601cb688d9",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T21:10:00Z"
+      },
+      {
+        "id": "15f93807-ed30-4dfd-95f7-5387561a9ef1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-04",
+        "completedAt": "2025-09-04T22:45:00Z"
+      },
+      {
+        "id": "f815e5e8-71b7-4a2b-a525-144079d900d8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T19:50:00Z"
+      },
+      {
+        "id": "3db2961a-ef5b-4195-a043-24fb381ffc46",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T12:20:00Z"
+      },
+      {
+        "id": "a14a771d-dcb4-47d0-b796-4d545fbefde1",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T21:15:00Z"
+      },
+      {
+        "id": "d9be7de4-5582-4726-9dbb-0ecf63fe3ea8",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T08:05:00Z"
+      },
+      {
+        "id": "6c823007-da61-4293-aed4-5fb37386dc03",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T06:50:00Z"
+      },
+      {
+        "id": "16df9142-c1d0-43bc-8317-6afc1963db8d",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T12:30:00Z"
+      },
+      {
+        "id": "f4adb3dc-1d1b-4a62-bc9f-db018e776ee9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T07:45:00Z"
+      },
+      {
+        "id": "ab641a79-2215-4103-a7dc-f2bf1f6cf26c",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T18:45:00Z"
+      },
+      {
+        "id": "b6bb118d-c8c3-4d46-806b-4a693bd0d4e8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T21:10:00Z"
+      },
+      {
+        "id": "90c600fc-e0f5-4f06-87b5-dd2af04af2ad",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T08:30:00Z"
+      },
+      {
+        "id": "7f23d55c-c568-43df-9600-824fb3b63585",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T21:10:00Z"
+      },
+      {
+        "id": "03752b0b-ec7a-4dc9-9f0c-165328d0978c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T20:15:00Z"
+      },
+      {
+        "id": "5bae2d93-bdfc-4f45-817a-d7e37aedaca8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-05",
+        "completedAt": "2025-09-05T19:40:00Z"
+      },
+      {
+        "id": "27f3751f-19d2-4d8a-ac6d-dbbb182f2542",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T08:05:00Z"
+      },
+      {
+        "id": "92bac5de-38c9-484b-a26b-612dba815dbb",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T08:45:00Z"
+      },
+      {
+        "id": "cb1351ae-b554-4bc1-83fa-51e915c53ce9",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T21:50:00Z"
+      },
+      {
+        "id": "afe85729-e6e1-4e63-b1eb-519f6951da3b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T18:05:00Z"
+      },
+      {
+        "id": "7c4b51e0-5ab5-44d5-a284-8d3dacaa20aa",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T21:15:00Z"
+      },
+      {
+        "id": "8315503c-26e4-4c97-bd81-8170e858f5c3",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T08:45:00Z"
+      },
+      {
+        "id": "96a84699-1321-472e-b87e-6a9c5f57db50",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-06",
+        "completedAt": "2025-09-06T21:50:00Z"
+      },
+      {
+        "id": "dc82fdf1-baba-427e-9523-67f62c68f7ed",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T21:20:00Z"
+      },
+      {
+        "id": "7d383fff-40b7-45b1-ab4b-9ebfded723e9",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T22:30:00Z"
+      },
+      {
+        "id": "6a45ef82-1cb7-49c7-b9b7-701816eb858f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T20:45:00Z"
+      },
+      {
+        "id": "81f30eb9-4ae8-44b6-8238-10e8ffc818af",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T21:30:00Z"
+      },
+      {
+        "id": "925ef931-4812-4a76-a620-bade07551ef6",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T06:20:00Z"
+      },
+      {
+        "id": "d585ffae-5f28-485b-a187-8a132815de71",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T21:10:00Z"
+      },
+      {
+        "id": "f4cbdcb4-a82e-4b53-9595-e4da4fe39569",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T21:45:00Z"
+      },
+      {
+        "id": "40daddb0-d4de-48e2-9d8a-e96d31674951",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T07:15:00Z"
+      },
+      {
+        "id": "3469af8e-8090-4ee8-9a0f-7c5e57cfb7fc",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T18:20:00Z"
+      },
+      {
+        "id": "93b6e818-8d19-4759-a91e-113ec9bbe5b8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-07",
+        "completedAt": "2025-09-07T18:20:00Z"
+      },
+      {
+        "id": "f8e4754f-b17b-4e3f-bc06-5af636446092",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T19:05:00Z"
+      },
+      {
+        "id": "2a70a9c1-1c66-4027-9b40-e1c50a765981",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T21:40:00Z"
+      },
+      {
+        "id": "00be8896-72c3-4068-9e9e-455bcd28a05b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T20:40:00Z"
+      },
+      {
+        "id": "fa9e3dfd-570b-4ce6-a043-babb61125904",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T21:00:00Z"
+      },
+      {
+        "id": "8e157788-0bed-4bc9-8813-893817cde539",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T06:00:00Z"
+      },
+      {
+        "id": "ef4a7870-c448-41b3-80ff-f8127695fac8",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T18:50:00Z"
+      },
+      {
+        "id": "e8dc5c4d-893c-48d9-a1cf-12f738406be7",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T21:20:00Z"
+      },
+      {
+        "id": "559cb347-9baa-4711-958d-31baced2adf3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T07:50:00Z"
+      },
+      {
+        "id": "95bfb72b-e7c9-4cde-a251-df9877af2a34",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T21:45:00Z"
+      },
+      {
+        "id": "7cf8d581-f1c0-4d3b-bc18-f3a14e6c25c8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T22:50:00Z"
+      },
+      {
+        "id": "4644cd78-42e2-49b6-ac42-c768f1b6762e",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T08:00:00Z"
+      },
+      {
+        "id": "09b027c7-0798-436c-ad02-7747e23f5b66",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T18:05:00Z"
+      },
+      {
+        "id": "50bf982d-7628-41bb-a906-e3494f25aaf0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T08:30:00Z"
+      },
+      {
+        "id": "450a3465-d95d-4962-840b-800e7eff4758",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T07:45:00Z"
+      },
+      {
+        "id": "8e4ead4b-848b-462c-8889-94de34b9ae4e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T06:10:00Z"
+      },
+      {
+        "id": "5760ae60-8443-4666-aa4b-0e4bc0cfa324",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-08",
+        "completedAt": "2025-09-08T21:50:00Z"
+      },
+      {
+        "id": "979394bf-f9ae-4296-a33d-69b30da7af91",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T17:00:00Z"
+      },
+      {
+        "id": "2cab9fc9-b147-44aa-af53-c5a925419b9e",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T20:20:00Z"
+      },
+      {
+        "id": "00e0551e-ebe0-4fdb-aca2-5e4015a4b88d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T08:30:00Z"
+      },
+      {
+        "id": "9d1d686f-6459-4b6c-bb39-8b0f354905e6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T06:45:00Z"
+      },
+      {
+        "id": "50c330dc-dbfa-4ab6-83cd-a4705ace712d",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T20:05:00Z"
+      },
+      {
+        "id": "417d3d55-51ad-4f3a-8a85-06f7330cb1bf",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T18:20:00Z"
+      },
+      {
+        "id": "e4650c52-fbe5-4fc1-8808-d3a0e988f1a3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T17:15:00Z"
+      },
+      {
+        "id": "9bd1291c-b325-4cab-9ca0-fd4c6be5cc1d",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T20:50:00Z"
+      },
+      {
+        "id": "a0dc1da0-5602-4b19-83bf-58c9248734a3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T21:10:00Z"
+      },
+      {
+        "id": "2d339b9d-1cd2-4623-8f8d-3d14f4d116e0",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T22:15:00Z"
+      },
+      {
+        "id": "1ccbeb17-ba9b-4ed1-9875-b25a461aba36",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T17:00:00Z"
+      },
+      {
+        "id": "7b55e6de-69ab-45aa-9206-bf9cc279d9b6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T08:10:00Z"
+      },
+      {
+        "id": "df9fc93b-8bd7-4a4d-bdd4-c001a49cda1c",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-09",
+        "completedAt": "2025-09-09T20:15:00Z"
+      },
+      {
+        "id": "b6a8cab3-7d87-4070-b005-4d9e0ed9acc4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T08:45:00Z"
+      },
+      {
+        "id": "d65a45ae-507e-427d-b7f4-86dfca193da0",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T18:20:00Z"
+      },
+      {
+        "id": "ed686598-9c23-48ad-a8b0-157b8d1a69b5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T21:30:00Z"
+      },
+      {
+        "id": "47ad9837-8c3a-4933-af84-ef18f457e94f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T12:40:00Z"
+      },
+      {
+        "id": "d1626ad0-b096-4bca-929d-01e63a309369",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T18:30:00Z"
+      },
+      {
+        "id": "60f7d4a0-165a-49c3-953e-2395966a9cf1",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T08:10:00Z"
+      },
+      {
+        "id": "b2f33659-1259-44ac-9d2b-6726057e7deb",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T18:40:00Z"
+      },
+      {
+        "id": "51f99065-a5a5-45b0-82bb-0b1a2a5fb345",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T08:45:00Z"
+      },
+      {
+        "id": "5910d443-a8b0-42ef-a4aa-98177e0f7119",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T21:40:00Z"
+      },
+      {
+        "id": "eea3abcf-5c0d-4b42-a52a-021cdab2a01d",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T12:20:00Z"
+      },
+      {
+        "id": "4ce36113-a0e1-4b87-a89d-a82b6e8cc835",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T19:20:00Z"
+      },
+      {
+        "id": "ebaf5e04-2878-4a19-9e60-390fb876f9ff",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T22:20:00Z"
+      },
+      {
+        "id": "34ce6c70-7dfb-44c5-a27b-128e4e7c71cd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T08:30:00Z"
+      },
+      {
+        "id": "7e2227e4-762e-4ca5-9145-859b9adf91e4",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T17:40:00Z"
+      },
+      {
+        "id": "5ae20b7b-e2be-4124-aa58-d1b632911df6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-10",
+        "completedAt": "2025-09-10T08:10:00Z"
+      },
+      {
+        "id": "d21e186e-5a70-4bbb-aeef-4255a0d258aa",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T21:00:00Z"
+      },
+      {
+        "id": "389965f7-666e-40c6-9bd7-0a3dd4a9ca6d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T17:05:00Z"
+      },
+      {
+        "id": "01492c76-1ab3-4666-a214-e329cf6c8706",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T20:00:00Z"
+      },
+      {
+        "id": "f33c182f-8898-424e-a5ec-0c07e36ecac0",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T18:10:00Z"
+      },
+      {
+        "id": "8364c4d7-b1d0-463f-8bc4-dc5bd3876ed1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T22:30:00Z"
+      },
+      {
+        "id": "9a53c32d-bcaf-4a77-8392-09b9c04fb750",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T07:00:00Z"
+      },
+      {
+        "id": "abc1cd49-cef7-410f-8bd9-5d69aea8a149",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T06:20:00Z"
+      },
+      {
+        "id": "ee813b15-9fce-4a06-bee0-691b01cb0ab3",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T07:50:00Z"
+      },
+      {
+        "id": "417957af-0fac-4d1b-8927-96fa57d50b6f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T17:15:00Z"
+      },
+      {
+        "id": "d488648b-2c60-4c44-a3ff-473d6ce4a31f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T06:45:00Z"
+      },
+      {
+        "id": "8de12523-353f-4f4b-beaa-d36493ac8aa9",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T19:20:00Z"
+      },
+      {
+        "id": "65c22afc-e56d-49c5-99c7-9126fafb0b6a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T17:40:00Z"
+      },
+      {
+        "id": "f1d31d19-01b0-4ee9-a26a-e285d1d189b5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-11",
+        "completedAt": "2025-09-11T18:45:00Z"
+      },
+      {
+        "id": "25a95e5b-7ccb-4806-8aa9-26605b11878a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T20:45:00Z"
+      },
+      {
+        "id": "85ab4865-e999-4c4c-a0b8-266483befa2f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T21:30:00Z"
+      },
+      {
+        "id": "e2e6af52-f596-4252-90b7-862f627f3c43",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T19:10:00Z"
+      },
+      {
+        "id": "263a00ad-3a23-4b91-8c56-eb11d6649674",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T19:00:00Z"
+      },
+      {
+        "id": "ff6d38fa-ee90-4095-be09-7381d8ffa3c6",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T17:05:00Z"
+      },
+      {
+        "id": "d7f43b6e-2e45-457c-9e39-16dda6880077",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T21:45:00Z"
+      },
+      {
+        "id": "6d70c289-20eb-46b6-826d-e6af7566ef28",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T20:50:00Z"
+      },
+      {
+        "id": "8e1968e4-41fc-496e-8905-e72137eafff1",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T20:05:00Z"
+      },
+      {
+        "id": "279d4738-4b68-4845-b8ce-839bfb3f6a24",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T18:05:00Z"
+      },
+      {
+        "id": "9ca9faab-beb4-4384-8aa4-cb2b75c9485d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T07:20:00Z"
+      },
+      {
+        "id": "c827d333-f916-40e3-b962-bbfd56616b7e",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T22:45:00Z"
+      },
+      {
+        "id": "f782aeba-b645-4610-84e9-6ec596b3674a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T07:45:00Z"
+      },
+      {
+        "id": "717c7a77-7a69-48ac-9df2-52cb9b24c037",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T17:15:00Z"
+      },
+      {
+        "id": "86c2af7f-1cf6-4f46-89b4-8a5e50607f31",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T19:15:00Z"
+      },
+      {
+        "id": "f8be84fa-1492-461e-a659-d768c86d2f25",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T17:30:00Z"
+      },
+      {
+        "id": "4a54a223-3a6e-4d12-bdf0-7614ab5c450b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-12",
+        "completedAt": "2025-09-12T19:20:00Z"
+      },
+      {
+        "id": "1d975e62-7df3-4d35-97bf-c97e8be54adc",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T07:05:00Z"
+      },
+      {
+        "id": "613a7fbb-8943-4fe0-93d9-18f869a8252b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T21:50:00Z"
+      },
+      {
+        "id": "da5f677c-c164-4efb-9504-64d2ddcdea66",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T20:05:00Z"
+      },
+      {
+        "id": "74e248f0-8510-46ec-b578-65326b224219",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T22:00:00Z"
+      },
+      {
+        "id": "d7ed468b-c319-4176-abcd-cc59e707067a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T19:30:00Z"
+      },
+      {
+        "id": "7bb33abb-c3f7-4413-9a16-8fb745f3bd53",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T20:00:00Z"
+      },
+      {
+        "id": "7a8a2daf-874d-4605-9cc5-5519c64458eb",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T21:00:00Z"
+      },
+      {
+        "id": "c9187c52-520b-44b6-ac09-16bb0e4ab794",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T08:00:00Z"
+      },
+      {
+        "id": "fdaafca6-40a4-4f49-bd2a-e8d9ba967bdd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T21:45:00Z"
+      },
+      {
+        "id": "64e302f1-00bd-4927-88a6-6e369476e0e7",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T17:10:00Z"
+      },
+      {
+        "id": "3c09a67c-6bad-4e78-9696-67c241cf606a",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T18:50:00Z"
+      },
+      {
+        "id": "048ae216-7737-45e0-a69d-3a6b5bf512aa",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-13",
+        "completedAt": "2025-09-13T08:45:00Z"
+      },
+      {
+        "id": "921a6e68-3b4d-4b92-9ec5-f01c2169618a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T21:00:00Z"
+      },
+      {
+        "id": "b6a6fada-14d9-45ef-a88f-0990170d940b",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T19:00:00Z"
+      },
+      {
+        "id": "3b091891-c291-4127-9189-15efb9166772",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T20:05:00Z"
+      },
+      {
+        "id": "9b83f970-6361-4304-b30d-8b615ca591bf",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T07:50:00Z"
+      },
+      {
+        "id": "d419f699-ad0a-4806-a1da-59bbc080b896",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T12:30:00Z"
+      },
+      {
+        "id": "b06ccfb2-a6e0-4fbd-9718-a483099ff51e",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T20:00:00Z"
+      },
+      {
+        "id": "e24e7356-2228-4ccd-89a3-61ec23179dd5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T18:05:00Z"
+      },
+      {
+        "id": "10accd63-f958-461a-a960-9aa1754653f4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T19:05:00Z"
+      },
+      {
+        "id": "ebf4d8d4-dd53-4d57-9b18-5c9eefd59c5a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T19:50:00Z"
+      },
+      {
+        "id": "6334f92a-4759-492b-9042-0adf6c8cbd5a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T08:30:00Z"
+      },
+      {
+        "id": "bfe13e77-95fc-40fa-a3bf-14d5a96f7cef",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T12:50:00Z"
+      },
+      {
+        "id": "1ed0adb8-dc35-41b6-aaea-1d61e08b1b9e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T18:30:00Z"
+      },
+      {
+        "id": "277ec46e-c899-4186-a219-9f897145f1c7",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T07:50:00Z"
+      },
+      {
+        "id": "712b9d92-ef9e-40ae-beac-e10fb96b9746",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-14",
+        "completedAt": "2025-09-14T18:20:00Z"
+      },
+      {
+        "id": "66472fb7-d425-4400-a233-321b7dd76279",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T19:30:00Z"
+      },
+      {
+        "id": "fb473086-149f-42cb-b2c5-440ecbd9721b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T06:50:00Z"
+      },
+      {
+        "id": "685b8b85-3267-40a7-9e51-ce10e1acff1d",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T07:15:00Z"
+      },
+      {
+        "id": "bcbd85b0-33ac-436f-a215-64e0d8f49a59",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T06:10:00Z"
+      },
+      {
+        "id": "da2176ad-2195-4e92-afa6-99843dc17de9",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T20:20:00Z"
+      },
+      {
+        "id": "84f9e6d4-16f5-4e98-8bd6-78897552d2b2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T20:45:00Z"
+      },
+      {
+        "id": "c7d322ec-669b-4a60-ab31-c262292fe40b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T06:20:00Z"
+      },
+      {
+        "id": "353376b5-be2b-4c12-ac83-4b8ef8bc023f",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T12:40:00Z"
+      },
+      {
+        "id": "74c9f854-bacb-4f08-bf51-3be2e49fba18",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T21:30:00Z"
+      },
+      {
+        "id": "0e7d3b28-d8d5-4e85-8e35-7f1c112e8a81",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T18:20:00Z"
+      },
+      {
+        "id": "3f67155b-508e-43f1-97c5-1ea53bfa5889",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T17:20:00Z"
+      },
+      {
+        "id": "7f87f8c8-bdbd-499b-81eb-688ababc2680",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T08:45:00Z"
+      },
+      {
+        "id": "9eff118b-e70e-40eb-81c2-5d282f3b7285",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T12:50:00Z"
+      },
+      {
+        "id": "702adfd9-75ff-440e-96ca-183a8e9b50c2",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T21:30:00Z",
+        "note": "Short entry, still counts"
+      },
+      {
+        "id": "24c1b889-b7ec-4c80-876a-d209d7c95942",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T22:15:00Z"
+      },
+      {
+        "id": "8e0c39c1-42b8-4be2-beeb-2589608e6e09",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T20:40:00Z"
+      },
+      {
+        "id": "863a5f2b-37f5-4856-98c7-1b20962a4603",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T18:30:00Z"
+      },
+      {
+        "id": "86fabdd2-5b71-47f6-a4a0-bc9373a20594",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-15",
+        "completedAt": "2025-09-15T21:45:00Z"
+      },
+      {
+        "id": "a9bca733-caa0-4144-b910-8c628375cc3f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T21:50:00Z"
+      },
+      {
+        "id": "28251f31-1199-473f-87e1-6cddbf9a6c69",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T12:05:00Z"
+      },
+      {
+        "id": "acc56f81-d98c-4f04-9617-1deb09123e47",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T06:30:00Z"
+      },
+      {
+        "id": "5892095c-3382-4d43-85dc-f84000b8eaba",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T12:00:00Z"
+      },
+      {
+        "id": "af713f22-9ac5-4f06-b23f-53593bbf14e5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T12:40:00Z"
+      },
+      {
+        "id": "791b4f40-09c5-44fa-be2f-b0faf0eef59f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T08:05:00Z"
+      },
+      {
+        "id": "a13c0831-3580-4f9e-af45-71e1a5a07cf1",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T18:50:00Z"
+      },
+      {
+        "id": "fc42e054-3f7f-4d12-aeed-4d78465d7689",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T06:20:00Z"
+      },
+      {
+        "id": "cef4db23-2be1-4843-ab7a-2116ec6a32fb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T21:15:00Z"
+      },
+      {
+        "id": "f27bb04b-8f01-439d-8322-6fdb62433ffb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T17:15:00Z"
+      },
+      {
+        "id": "4dda5906-5417-4e9b-8382-ba5a483a1c04",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T18:45:00Z"
+      },
+      {
+        "id": "001ceee1-a786-4878-92bf-7a1efb3f6458",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T21:10:00Z"
+      },
+      {
+        "id": "3b9d5b5b-7e1d-437b-9d64-b4de1a7ac42a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T18:20:00Z"
+      },
+      {
+        "id": "292d21d8-b8ca-4281-817d-4ae7fa5f14d3",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-16",
+        "completedAt": "2025-09-16T17:30:00Z"
+      },
+      {
+        "id": "89bb3ace-fd74-4f70-93d3-9d226928879a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T17:40:00Z"
+      },
+      {
+        "id": "76224e14-ef9d-4fb1-aae6-d336d4cd2c2d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T18:10:00Z"
+      },
+      {
+        "id": "3c193b8b-0a6c-4350-9753-65508073df77",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T21:45:00Z"
+      },
+      {
+        "id": "851b68e9-e9c8-477a-ad93-5d4b368206b7",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T12:40:00Z"
+      },
+      {
+        "id": "bc86fe36-e20d-4c60-929e-b813edf6fd15",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T18:50:00Z"
+      },
+      {
+        "id": "d165fcc1-9e09-434e-865f-701fb873015b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T12:10:00Z"
+      },
+      {
+        "id": "e91f38cb-ab1b-4dd3-b807-c51bea1499cb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T22:20:00Z"
+      },
+      {
+        "id": "23891bb7-1c13-44e8-9d94-10000fb64111",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T20:30:00Z"
+      },
+      {
+        "id": "316bc373-f36e-47f8-9293-43a26fda4f11",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T21:40:00Z"
+      },
+      {
+        "id": "2a90be3e-fe5c-4b84-a7b8-80aff5446c78",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T20:20:00Z"
+      },
+      {
+        "id": "0ab8ea5d-d80f-454e-b891-3721770d5965",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T07:50:00Z"
+      },
+      {
+        "id": "f3c5dc9d-218e-4a04-9847-60aab5f45282",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-17",
+        "completedAt": "2025-09-17T18:20:00Z"
+      },
+      {
+        "id": "0008cbc1-d11e-47cd-bec8-e9f15681ab2b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T08:40:00Z"
+      },
+      {
+        "id": "f4d38e4d-b537-46b9-a61f-b29135a9f559",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T12:20:00Z"
+      },
+      {
+        "id": "7696ee72-972e-425f-b0d3-de5d8628a373",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T17:40:00Z"
+      },
+      {
+        "id": "4035ec6d-fb73-4bd0-9fc2-0fd51616aae0",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T21:40:00Z"
+      },
+      {
+        "id": "63199380-c44a-420e-99a2-d55469f61989",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T08:20:00Z"
+      },
+      {
+        "id": "48e32b04-0394-46de-b592-05ee65478e0f",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T08:30:00Z"
+      },
+      {
+        "id": "b2f37236-6a93-486b-b54c-45fc5b7cd27f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T22:10:00Z"
+      },
+      {
+        "id": "c160f0fa-776e-46c9-bf38-f14d754898e4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T20:05:00Z"
+      },
+      {
+        "id": "9827f3cb-f95a-4af4-96e7-59e032d0e48b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T18:00:00Z"
+      },
+      {
+        "id": "75fdb79c-8637-4d9d-a9fd-6a811e031fb2",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T07:30:00Z"
+      },
+      {
+        "id": "ebfc1f22-e555-4e4f-9709-b867764fa5c7",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T20:00:00Z"
+      },
+      {
+        "id": "1c702b6b-6256-4e57-95b6-7fe1a76b3abb",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T18:30:00Z"
+      },
+      {
+        "id": "473590ce-032b-4a0c-bc09-7b4e02798f02",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T08:05:00Z"
+      },
+      {
+        "id": "046e9529-cf13-4f99-8956-1871ae608e3b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T17:40:00Z"
+      },
+      {
+        "id": "616b3c16-1b78-4d86-b8c3-6035ee398c02",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-18",
+        "completedAt": "2025-09-18T08:00:00Z"
+      },
+      {
+        "id": "b91c5fa6-86a9-43eb-8012-882aa332abe2",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T17:10:00Z"
+      },
+      {
+        "id": "1e1b0186-1d56-4899-8bd8-9a202b473f2d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T07:50:00Z"
+      },
+      {
+        "id": "b6335ce8-ad54-464b-88a7-b9cba9cec6b4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T18:45:00Z"
+      },
+      {
+        "id": "5d951bbd-349c-4c7a-bcb7-1ba656046019",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T20:45:00Z"
+      },
+      {
+        "id": "53571a8e-b36e-4a2a-a5bd-a8f65d6a5aca",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T18:45:00Z"
+      },
+      {
+        "id": "69c723e7-b379-4e96-be7f-1e3c88647254",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T12:30:00Z"
+      },
+      {
+        "id": "fe9c91b6-38d8-49ee-86d7-4d507a951d6d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T22:40:00Z"
+      },
+      {
+        "id": "26334759-7dbb-4f08-88a1-252c5743b4b4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T06:15:00Z"
+      },
+      {
+        "id": "d2b92184-28eb-4cf7-8d5f-51fbcf80457f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T17:15:00Z"
+      },
+      {
+        "id": "fdabd4ad-b005-419e-8898-8c9993077e75",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T22:30:00Z"
+      },
+      {
+        "id": "60c46452-41c6-4da7-be0e-ddf2e02b2387",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T22:15:00Z"
+      },
+      {
+        "id": "a5ae33e0-77f7-46ee-b3bf-23944d0126f2",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T19:05:00Z"
+      },
+      {
+        "id": "76e0c979-6916-4af3-ba42-d5434963b91f",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T06:40:00Z"
+      },
+      {
+        "id": "0a1e1d71-4a07-41ee-8f9e-4fe71c5d57f3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T22:45:00Z"
+      },
+      {
+        "id": "8e6582a4-49d7-4f56-8798-36e8b11997fc",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T21:20:00Z"
+      },
+      {
+        "id": "c26841f9-9e81-4d99-a72d-a25bae22fc94",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-19",
+        "completedAt": "2025-09-19T12:00:00Z"
+      },
+      {
+        "id": "a85b07b2-14e5-466e-ba53-5704fb3f8055",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T07:50:00Z"
+      },
+      {
+        "id": "df425f88-4e97-4898-a9dc-49732298ce0a",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T21:50:00Z"
+      },
+      {
+        "id": "b33d3d85-bbcb-4238-abec-0458696dfdb9",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T20:05:00Z"
+      },
+      {
+        "id": "99004d82-4d09-411c-acc4-88d688b5ac27",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T19:30:00Z"
+      },
+      {
+        "id": "5189fa5c-7f18-4784-a30d-d6e90f8b62d1",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T06:00:00Z"
+      },
+      {
+        "id": "6a3c3a6f-8057-400e-b389-022d42b66b91",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T12:05:00Z"
+      },
+      {
+        "id": "e85c4f2e-f45e-4aa4-88d0-64a4eaa9d745",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T12:40:00Z"
+      },
+      {
+        "id": "7ecaabcf-a8fa-4a41-9765-9d92b80955df",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T12:15:00Z"
+      },
+      {
+        "id": "21e33e28-577c-4382-a62d-76298976dcbd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T12:45:00Z"
+      },
+      {
+        "id": "8b76de39-b570-4f72-9a48-2764d432a62c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T18:45:00Z"
+      },
+      {
+        "id": "23aa365e-bf28-4276-9a37-e6ed43eb2306",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-20",
+        "completedAt": "2025-09-20T06:45:00Z"
+      },
+      {
+        "id": "e80bd3ff-4086-4cff-93be-0297d5b6fc58",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T17:30:00Z"
+      },
+      {
+        "id": "bb09d63f-d071-4802-a7f4-d60eabc44018",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T07:10:00Z"
+      },
+      {
+        "id": "436ea117-6596-443d-92bd-cb5fa475df3c",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T08:40:00Z"
+      },
+      {
+        "id": "f7135e50-b5ec-4e12-84f5-225f27bd470e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T21:05:00Z"
+      },
+      {
+        "id": "aff723a5-7bf9-4bec-ab56-4a8064c44591",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T18:05:00Z"
+      },
+      {
+        "id": "72a14f85-84f3-47f0-a3b1-0517a53afceb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T19:15:00Z"
+      },
+      {
+        "id": "9c0ee57f-931f-4b46-9ae5-2ed61d95892b",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T17:40:00Z"
+      },
+      {
+        "id": "ca69a590-9981-4fe2-a666-fa1460e02bca",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-21",
+        "completedAt": "2025-09-21T19:05:00Z"
+      },
+      {
+        "id": "c5ae5839-cbd1-4278-a1ee-12ee58653ada",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T06:40:00Z"
+      },
+      {
+        "id": "ca8a2094-b131-47f2-89aa-849c38e4e708",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T17:05:00Z"
+      },
+      {
+        "id": "e9ca932f-fb12-48f1-9f90-473ec9981f4b",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T12:30:00Z"
+      },
+      {
+        "id": "5a9e6004-6332-4384-b46c-abfbf07e9416",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T19:30:00Z"
+      },
+      {
+        "id": "66f07af6-564a-42dc-87aa-fb8fc789b5be",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T06:30:00Z"
+      },
+      {
+        "id": "3dca42bb-f514-49ed-b8ec-dc9ba15b21ba",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T21:40:00Z"
+      },
+      {
+        "id": "a233818d-a9e3-4ea3-bb1f-66ca9e370bd8",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T18:00:00Z"
+      },
+      {
+        "id": "3b09a1e4-55ee-4ff7-bb68-4a4bb7091b37",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T07:10:00Z"
+      },
+      {
+        "id": "0b6aa9d2-7e0f-4931-95ee-d1f603cadcd8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T22:05:00Z"
+      },
+      {
+        "id": "22e75d9c-fb2d-4aed-8706-f2c36739bdaa",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T18:30:00Z"
+      },
+      {
+        "id": "437cf50b-4350-4e02-be73-1a080f6d7ef1",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T21:40:00Z"
+      },
+      {
+        "id": "4b037fbd-de3d-4ccf-b98e-abb7c262536e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T17:30:00Z"
+      },
+      {
+        "id": "ec6b7b80-23e8-4a57-b9dd-2ff88b5b551d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T19:45:00Z"
+      },
+      {
+        "id": "5aaf4562-fd42-499a-acb5-d934de8d1279",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T18:50:00Z"
+      },
+      {
+        "id": "ab435403-b882-4555-9c54-90d5f9851c30",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T20:40:00Z"
+      },
+      {
+        "id": "27a7f516-a432-47c8-b799-bd0346ffd712",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T06:00:00Z"
+      },
+      {
+        "id": "b2f56c1a-dd0d-4707-af5d-3518a495933e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-22",
+        "completedAt": "2025-09-22T06:05:00Z"
+      },
+      {
+        "id": "569d21b8-7ca3-48e9-9b04-e4d5f03e132a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T17:00:00Z"
+      },
+      {
+        "id": "bc1c27dc-16c8-4be6-9b79-e30e7e7e6ef3",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T18:40:00Z"
+      },
+      {
+        "id": "557ee27f-7ac1-44ed-8766-ae20abd2897d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T19:50:00Z"
+      },
+      {
+        "id": "67752ba0-5458-4c7b-b5fc-022f96b9578c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T06:00:00Z"
+      },
+      {
+        "id": "ce88c66f-7c83-4e1b-9910-f98519f2773b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T18:30:00Z"
+      },
+      {
+        "id": "55db76a3-cbff-40d5-99a0-21f729156c2c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T20:15:00Z"
+      },
+      {
+        "id": "c8b95962-e0dc-4ff5-a94b-4679bbce81bb",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T20:05:00Z"
+      },
+      {
+        "id": "13f1f956-9d54-4475-b008-7756acf94607",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T22:50:00Z"
+      },
+      {
+        "id": "e42ef79f-d843-448a-8aa7-2697a2c96888",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T17:50:00Z"
+      },
+      {
+        "id": "4263d5fb-4919-4132-9952-948f5356cbda",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T08:45:00Z"
+      },
+      {
+        "id": "c6271f2e-40da-4dbd-b499-fd09619a1648",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T18:50:00Z"
+      },
+      {
+        "id": "affcac7a-48e7-439b-9718-de17db3bcca7",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T18:05:00Z"
+      },
+      {
+        "id": "da2763ec-3051-4804-8590-f9009dfcbdce",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T07:15:00Z"
+      },
+      {
+        "id": "3e603e7d-3e40-4185-93f5-d6edd8eade60",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T20:45:00Z"
+      },
+      {
+        "id": "590aac67-6208-4732-b589-546ca7a0f7ef",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-23",
+        "completedAt": "2025-09-23T21:20:00Z"
+      },
+      {
+        "id": "3b0dec24-91d8-4082-8938-e7ba61e1d509",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T17:30:00Z"
+      },
+      {
+        "id": "b46eefda-0199-417d-a125-ff19978d6706",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T07:15:00Z"
+      },
+      {
+        "id": "5556a5cb-b05d-4233-a7cf-954421a4b391",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T19:30:00Z"
+      },
+      {
+        "id": "58df8d9d-bb5c-4186-b67c-addda39c02ce",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T07:20:00Z"
+      },
+      {
+        "id": "f2920736-5c57-4c4a-be73-e977b2d224ad",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T06:00:00Z"
+      },
+      {
+        "id": "51ab608e-7b56-4625-97c4-f6139bbeff4f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T07:30:00Z"
+      },
+      {
+        "id": "d1e93729-8804-455e-89dc-fa9b2fdfd9d9",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T18:30:00Z"
+      },
+      {
+        "id": "7b49f3df-ccaa-46c1-8d68-ac8b1a1cd274",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T22:15:00Z"
+      },
+      {
+        "id": "3ae63d67-1ea9-4bc6-b099-bea5fb0da508",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T20:45:00Z"
+      },
+      {
+        "id": "4ed91cc8-90ee-44da-8258-ba2112ac9d92",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T18:00:00Z"
+      },
+      {
+        "id": "89d7fb31-e336-4e66-a178-3e37e6a73eb6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T21:40:00Z"
+      },
+      {
+        "id": "e895ea6a-8cb8-4ff5-a3e2-95f036892225",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T17:40:00Z"
+      },
+      {
+        "id": "99e7b498-2c55-422f-979c-2efdfdf21105",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T21:45:00Z"
+      },
+      {
+        "id": "c07000bb-6308-4632-95c1-ac04e52dbe9c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T07:50:00Z"
+      },
+      {
+        "id": "32647545-e2f2-4328-937b-fde36a9a3db6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-24",
+        "completedAt": "2025-09-24T07:40:00Z"
+      },
+      {
+        "id": "fdcf7597-31a0-49d6-9c78-1f1db9dfecc5",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T18:20:00Z"
+      },
+      {
+        "id": "88369a66-6d70-4c47-b248-3bf0c54458d7",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T21:05:00Z"
+      },
+      {
+        "id": "6dde7657-628b-491a-88c8-eec6c8d524a7",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T22:20:00Z"
+      },
+      {
+        "id": "7403bb77-0b9a-4067-a2be-354c69a11310",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T18:40:00Z"
+      },
+      {
+        "id": "b4957472-a7f2-4201-897e-53dcdda17f4b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T08:00:00Z"
+      },
+      {
+        "id": "46fb8786-fe56-43e9-b4ce-d9e25b5593cb",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T18:40:00Z"
+      },
+      {
+        "id": "e72f7ad4-7e69-456b-bfc3-a84807992d17",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T08:00:00Z"
+      },
+      {
+        "id": "2009f2d0-736d-49f2-8555-1f82fd9c99b2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T12:20:00Z"
+      },
+      {
+        "id": "a7f50719-e3cf-4cd5-9ade-506a56cbcef4",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T12:00:00Z"
+      },
+      {
+        "id": "c11643f7-a5fc-49a8-b8da-59a9a9e3450c",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T12:05:00Z"
+      },
+      {
+        "id": "76cb4e04-f49b-43dd-9898-a39dfe8a80e9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T07:30:00Z"
+      },
+      {
+        "id": "463422a9-1d9f-4ce6-9d0d-462b8a493c09",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T18:10:00Z"
+      },
+      {
+        "id": "87d71491-7431-4277-a4db-b0a4c44bfb25",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-25",
+        "completedAt": "2025-09-25T21:10:00Z"
+      },
+      {
+        "id": "0397e5bc-9e00-46a1-91d7-87c0f113de69",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T22:00:00Z"
+      },
+      {
+        "id": "373444fc-b0d6-4511-b258-e0a08a58995e",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T19:05:00Z"
+      },
+      {
+        "id": "75e0459d-c350-4048-825a-258bbaeb01c0",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T19:20:00Z"
+      },
+      {
+        "id": "f994f2b2-5a84-4de8-871b-1a27bded7462",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T21:20:00Z"
+      },
+      {
+        "id": "15b28249-8a13-4f09-a586-8a2891be66e0",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T07:00:00Z"
+      },
+      {
+        "id": "62eecfe6-9722-4d2a-ad94-cfcfa2ccb9d4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T17:45:00Z"
+      },
+      {
+        "id": "07fd8e56-117a-4b1e-b925-9f814710c192",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T22:30:00Z"
+      },
+      {
+        "id": "e6799c8f-5dd8-461c-a531-268d8b68c030",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T12:05:00Z"
+      },
+      {
+        "id": "7ddac277-a154-4cc1-ae30-1c65bd9ca542",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T21:45:00Z"
+      },
+      {
+        "id": "21875f03-c074-4877-ba43-289c7cf35689",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T22:50:00Z"
+      },
+      {
+        "id": "4581a638-f0a8-4634-a31a-6c4f45614791",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T07:15:00Z"
+      },
+      {
+        "id": "d34b4bf6-2706-46cb-950f-824c33ce07ba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T18:40:00Z"
+      },
+      {
+        "id": "d84cf760-b462-4883-a7cb-5aa1e20f0df5",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-26",
+        "completedAt": "2025-09-26T12:45:00Z"
+      },
+      {
+        "id": "ff19fc74-2fe1-4c61-908d-559d69d0f435",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T12:00:00Z"
+      },
+      {
+        "id": "bf6ee061-99ab-4e33-9562-b947584996ed",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T18:40:00Z"
+      },
+      {
+        "id": "4c4ad708-93fb-477b-b34a-5718c3cef814",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T07:45:00Z"
+      },
+      {
+        "id": "42e5a17b-f0dd-4011-9925-fddb3e29e289",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T07:00:00Z"
+      },
+      {
+        "id": "3c00d316-ff25-4bce-b85a-0d733e036f8c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T22:00:00Z"
+      },
+      {
+        "id": "ee599662-1412-416c-9e82-8c501a037694",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T20:10:00Z"
+      },
+      {
+        "id": "abed1dfe-fc00-4ced-8cda-e4e5826ef284",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T22:30:00Z"
+      },
+      {
+        "id": "93f72acc-aebe-4005-804b-30ce10a1f9ba",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T17:05:00Z"
+      },
+      {
+        "id": "ebe62a79-d26c-451d-9ea2-79cd15631562",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T20:30:00Z"
+      },
+      {
+        "id": "0d481696-8185-409e-b7ca-74ff7f526b9b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T06:00:00Z"
+      },
+      {
+        "id": "f1ba511b-7a54-4beb-8d0a-00eb6d1dea52",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T22:00:00Z"
+      },
+      {
+        "id": "9fb44152-1c19-4bec-b87a-2842dbbd6e6d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-27",
+        "completedAt": "2025-09-27T08:20:00Z"
+      },
+      {
+        "id": "ec988a46-a45b-4056-8739-d285ac72cbe2",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T21:10:00Z"
+      },
+      {
+        "id": "58fe974f-f849-4d67-ada4-00009f5e0054",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T20:15:00Z"
+      },
+      {
+        "id": "2a3361ca-2627-4592-958c-c36f5dec5570",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T07:40:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "979b55ab-526a-4613-8d1e-e20e8d9f35e5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T17:40:00Z"
+      },
+      {
+        "id": "cb59053c-7884-4df1-aa63-862afe453e01",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T12:10:00Z"
+      },
+      {
+        "id": "c0bc21a3-20ba-4876-a3ed-34155705122e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T18:50:00Z"
+      },
+      {
+        "id": "5efb1cd2-777b-4788-9f3c-db223c88a7cd",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T19:20:00Z"
+      },
+      {
+        "id": "5fb01dcc-9626-48ca-932d-1efcb048cc07",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T22:20:00Z"
+      },
+      {
+        "id": "674f51e6-eec8-45fb-9400-3a3828ae5090",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T22:45:00Z"
+      },
+      {
+        "id": "11f77eea-0046-4c04-9b49-28081cb07e12",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T22:10:00Z"
+      },
+      {
+        "id": "a9905952-56e3-41fc-8674-b47d232c6a71",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T12:15:00Z"
+      },
+      {
+        "id": "f3c9f0d0-13fe-4056-982c-7c823469686a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T19:05:00Z"
+      },
+      {
+        "id": "32318f9c-37b1-426b-b5ae-f3459a1dc851",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T12:45:00Z"
+      },
+      {
+        "id": "2d19efdd-d9b2-4119-a77c-7dcaccd33590",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:15:00Z"
+      },
+      {
+        "id": "545a7afd-1bca-491c-9cc0-4e9e9bf1eee1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:00:00Z"
+      },
+      {
+        "id": "9b6ed2d6-4472-4d0a-a61f-d0eacb572527",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T20:15:00Z"
+      },
+      {
+        "id": "058ac15b-4101-4a61-b311-e759eeb63ea6",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T20:10:00Z"
+      },
+      {
+        "id": "d630d5d9-53f1-4bf2-b0bc-f55e5431d0c5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:50:00Z"
+      },
+      {
+        "id": "5394d704-4583-4b85-a318-c8b717f7b454",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:05:00Z"
+      },
+      {
+        "id": "246cde15-03a3-43fb-8001-97f4413bf70f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T06:10:00Z"
+      },
+      {
+        "id": "6684478f-5ec3-41a9-9033-d0af91775bbb",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T08:05:00Z"
+      },
+      {
+        "id": "db1a9fb6-d342-45d4-8087-4dca5adf49b5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T18:15:00Z"
+      },
+      {
+        "id": "1224adb0-b3a1-4f81-9ab2-fab146254607",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T20:20:00Z",
+        "note": "Reviewed groceries"
+      },
+      {
+        "id": "a35477f5-c868-4082-9ba8-fc6440e431b6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T07:15:00Z"
+      },
+      {
+        "id": "ade0d742-0885-4136-84d2-31584586b942",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T19:45:00Z"
+      },
+      {
+        "id": "a63dc2f5-6c64-422c-b1fd-7f709206efca",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T20:30:00Z"
+      },
+      {
+        "id": "ae1cda60-6b45-496f-a4bb-00b026b4a05e",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T08:50:00Z"
+      },
+      {
+        "id": "e62c9383-b5c0-4ad0-a3b9-5a727f625cf1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T06:45:00Z"
+      },
+      {
+        "id": "5d3319ce-0742-4e24-a456-eb46cf5c2ddc",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T21:00:00Z"
+      },
+      {
+        "id": "697fb74d-c94e-43d8-8acd-52e2d7279367",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T19:45:00Z"
+      },
+      {
+        "id": "fb112e9a-ee2a-4e75-9e44-36487480cfbc",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T06:15:00Z"
+      },
+      {
+        "id": "c48c0d85-0e9f-4031-a321-c1698933fd37",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T22:20:00Z"
+      },
+      {
+        "id": "2cb24581-976c-463a-a055-8adf8c0be3e8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T18:40:00Z"
+      },
+      {
+        "id": "4178e7ce-e06d-4eab-8918-854a93a33a53",
+        "habitId": "b5363a4c-2d87-493c-a4ca-1d93523a3b85",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T22:05:00Z"
+      },
+      {
+        "id": "1f3dd50e-f85e-49db-9e4d-ab79018dd897",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T19:30:00Z"
+      },
+      {
+        "id": "a0302ee0-b5ab-45bf-9881-6c49ce9cce8d",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T08:30:00Z"
+      },
+      {
+        "id": "3a67d3d4-e5ed-4c8c-9652-47b3c7c1d7b6",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T07:30:00Z"
+      },
+      {
+        "id": "e654c0e1-7668-4e49-8af3-961b8dafc3ac",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T19:40:00Z"
+      },
+      {
+        "id": "1237d46f-4fe2-47b4-bcd8-32b500e61308",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T20:15:00Z"
+      },
+      {
+        "id": "90e23473-662f-4234-86f7-502a6ccaca07",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T08:45:00Z"
+      },
+      {
+        "id": "85ffb4a7-0277-4ccb-800d-4efd1daaef3d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T17:15:00Z"
+      },
+      {
+        "id": "1a5fe561-546f-4e90-b7b9-14cc2614ae12",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T22:10:00Z"
+      },
+      {
+        "id": "b27b55d4-998b-472c-831a-40c2ba9a8822",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T08:15:00Z"
+      },
+      {
+        "id": "8a63b252-2cc1-488f-87a2-dd2c4ffb3314",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T17:30:00Z"
+      },
+      {
+        "id": "833df211-2bae-47dc-a6ee-3f0d10c437f0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T20:50:00Z"
+      },
+      {
+        "id": "6cb2a835-dd74-4c9a-bba9-e67449ddafc1",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T12:50:00Z"
+      },
+      {
+        "id": "d82e0f67-96c5-4ff7-84e0-3551c7ff9822",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T21:40:00Z"
+      },
+      {
+        "id": "c44b293c-607e-4251-93e4-05fd0d7680bc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T21:40:00Z"
+      },
+      {
+        "id": "7d008426-2690-4d61-8030-66379a8b7bde",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T21:50:00Z"
+      },
+      {
+        "id": "dcb9452d-df0c-4f6b-b754-553fff630606",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T12:45:00Z"
+      },
+      {
+        "id": "26d749cd-7a25-4d9f-8360-ad2673aff93c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T08:10:00Z"
+      },
+      {
+        "id": "ce89dca9-e05d-46f7-86b1-89c0fc2da46e",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T07:30:00Z"
+      },
+      {
+        "id": "f2863b4c-11a6-4acc-bafb-9bc3a65f3345",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T19:10:00Z"
+      },
+      {
+        "id": "19b9f96e-c3cb-4181-a72b-c73aedc806e5",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T22:20:00Z"
+      },
+      {
+        "id": "31445eeb-cc0f-4acd-8a8b-5c59b7f3dd21",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T21:30:00Z"
+      },
+      {
+        "id": "f9264a5b-285c-4480-8779-ad1ac87d9bf1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T22:45:00Z"
+      },
+      {
+        "id": "0ddab51c-2952-479b-8ed1-28fd9c3810c6",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T06:30:00Z"
+      },
+      {
+        "id": "1f498c41-fbb9-4c73-b794-7d6e7aaf4cdc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T08:30:00Z"
+      },
+      {
+        "id": "d123f97b-8c66-4e55-82fb-0f6de90fb4d5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T20:05:00Z"
+      },
+      {
+        "id": "6e235e6c-53a5-4327-868d-7b045d50b3b9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T12:10:00Z"
+      },
+      {
+        "id": "75b0b325-42e2-4392-9c6b-e148a1f1a77e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T21:15:00Z"
+      },
+      {
+        "id": "b1bd7570-579e-4f8e-a137-5d403cd7c202",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T20:40:00Z"
+      },
+      {
+        "id": "0bddde26-bf97-46c5-a1c3-60f6a580a72f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T12:50:00Z"
+      },
+      {
+        "id": "4e44dc39-9490-492d-a932-7986af203b5f",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T17:20:00Z"
+      },
+      {
+        "id": "893ae92a-1428-4e7e-8ef8-b4cef11cf543",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T06:05:00Z"
+      },
+      {
+        "id": "5da92c6f-01fa-4959-9d55-1bebf1a8d88f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T06:00:00Z"
+      },
+      {
+        "id": "55e48df9-8da5-44f3-b5f4-2183dde4f73c",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T18:30:00Z"
+      },
+      {
+        "id": "c793ad72-6a92-472d-a40e-7fd9e62298e2",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T12:10:00Z"
+      },
+      {
+        "id": "471bec16-12be-41ac-92a9-4b164a46766d",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T06:40:00Z"
+      },
+      {
+        "id": "b7058d17-cc11-46ce-a41b-49b26d1cbc03",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T07:00:00Z"
+      },
+      {
+        "id": "a297ec4f-2a82-47ad-aa60-b78f1db867b0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T21:15:00Z"
+      },
+      {
+        "id": "8aac5733-bfbe-4248-87a8-a3fae64cd16a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T12:20:00Z"
+      },
+      {
+        "id": "04a1d8cd-634b-4bbf-8c41-35872fb7ef19",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T12:50:00Z"
+      },
+      {
+        "id": "faca5b0d-ad2a-4bdd-85c0-067252dada32",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T12:20:00Z"
+      },
+      {
+        "id": "7ebbb22d-92e3-4e8b-b0ca-9acfa867f59c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T20:15:00Z"
+      },
+      {
+        "id": "a0c1e4ec-7fe8-4895-98aa-831448e875b2",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T17:20:00Z"
+      },
+      {
+        "id": "4d81ccbe-2898-413f-ae3b-0bf2edc16044",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T08:20:00Z"
+      },
+      {
+        "id": "420501e9-3783-46d7-a96c-59a7fe483c35",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T17:05:00Z"
+      },
+      {
+        "id": "b9a48ee7-e73a-4e1f-8172-e80965994326",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T22:40:00Z"
+      },
+      {
+        "id": "4e3e66fd-88b2-4042-9678-b09493902d65",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T22:10:00Z"
+      },
+      {
+        "id": "ca2e130f-ec92-4eab-a393-57b5162cf741",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T22:20:00Z"
+      },
+      {
+        "id": "bd9f1254-db44-4249-a52b-33335757965d",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T18:10:00Z"
+      },
+      {
+        "id": "ddbeae9e-b1a5-4b95-b4e5-48f426bf5981",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T22:00:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "a65b02ba-555d-4759-8d44-866d75e5b33d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T08:45:00Z"
+      },
+      {
+        "id": "105ca435-2fa6-4808-baa3-00013d53e34b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T21:45:00Z"
+      },
+      {
+        "id": "1bdcc630-768d-4043-96ab-3cd4f95292d9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T22:30:00Z"
+      },
+      {
+        "id": "5eedba65-1f8e-47df-8066-61fe92f8f923",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T20:20:00Z"
+      },
+      {
+        "id": "5c08a5b9-d9f3-4971-b0a8-2a897d6920a2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T06:40:00Z"
+      },
+      {
+        "id": "b7ac2a9c-fb21-41b0-959b-e0987c59a97a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T18:20:00Z"
+      },
+      {
+        "id": "a22ca5cf-a0d4-49c4-8937-82a802cbc5c7",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T18:15:00Z"
+      },
+      {
+        "id": "1283f1a2-cd1d-4042-9695-c640128b3be9",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T06:50:00Z"
+      },
+      {
+        "id": "faaab4b0-a1d6-4a09-af05-735790e479c0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T18:50:00Z"
+      },
+      {
+        "id": "be7cdb6a-d2b2-472a-9d20-b8fcbe77ab71",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T20:15:00Z"
+      },
+      {
+        "id": "0af99711-a93c-4716-83cb-103e66d09e55",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T08:40:00Z"
+      },
+      {
+        "id": "d7f40764-6fcb-44a6-8aa4-7ad1bb5937c8",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T21:45:00Z"
+      },
+      {
+        "id": "78797242-e3e6-4897-ad73-0cabe6c5adec",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T07:45:00Z"
+      },
+      {
+        "id": "a1e6864d-efd5-4cd5-9954-32aee4da122e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T21:40:00Z"
+      },
+      {
+        "id": "2314576b-1c04-436e-9a65-0baf22a41a26",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T08:20:00Z"
+      },
+      {
+        "id": "f9907b14-9d6b-40ff-994e-23e5ad137a48",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T20:10:00Z"
+      },
+      {
+        "id": "b5bd8496-1b4f-4c93-9b25-7cab94734c92",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T20:05:00Z"
+      },
+      {
+        "id": "0672d166-4f25-4edb-9c39-da3f02176e1f",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T22:45:00Z"
+      },
+      {
+        "id": "72ae3a3a-8a32-4f05-ad4c-9166d974bcb0",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T19:30:00Z"
+      },
+      {
+        "id": "4faa70e0-c154-45fb-8e6d-e7dbe7858773",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T12:50:00Z"
+      },
+      {
+        "id": "ddd7142d-57e6-4709-b54a-f367ec72418c",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T18:10:00Z"
+      },
+      {
+        "id": "8ab3cd0a-6772-4d12-9c76-dc9e1c7fd7d5",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T19:40:00Z"
+      },
+      {
+        "id": "4224e8e0-793c-474f-8d50-32bf348353c7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T17:05:00Z"
+      },
+      {
+        "id": "9d5fda83-5f78-4e7d-9713-a4b56c01bcfa",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T17:50:00Z"
+      },
+      {
+        "id": "f2517e49-b41b-4809-9359-15bb08afb0d9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T18:05:00Z"
+      },
+      {
+        "id": "3cedab0a-dc07-47f3-adba-33814c41513b",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T17:30:00Z"
+      },
+      {
+        "id": "5be41ab7-77bd-46c0-ae12-a3be2dba9e55",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T20:00:00Z"
+      },
+      {
+        "id": "fe71da3e-30ca-45fc-af1b-ab5f0b7e90a2",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T07:00:00Z"
+      },
+      {
+        "id": "9fe6eb5e-7565-419f-99e0-300cd0b83474",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T20:00:00Z"
+      },
+      {
+        "id": "9b6bb7c3-9995-4f87-b0c8-8615149ea663",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T06:45:00Z"
+      },
+      {
+        "id": "7c458342-4818-4412-b095-d23fede4c350",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T20:40:00Z"
+      },
+      {
+        "id": "f72439e2-2e3d-4243-ac93-6f574f43273a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T08:00:00Z"
+      },
+      {
+        "id": "c792a66a-5677-4ebf-b1e1-ebac721b9fef",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T19:40:00Z"
+      },
+      {
+        "id": "ab558af8-7532-489b-907f-406ffdf80f12",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T21:30:00Z"
+      },
+      {
+        "id": "69368947-de1b-4a15-a7de-f179223f2157",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T08:05:00Z"
+      },
+      {
+        "id": "0b4030f7-7c99-4db1-aebf-e55c4ca4e7ed",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T19:20:00Z"
+      },
+      {
+        "id": "a3fddf0b-a378-42bd-848d-39427e48e810",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T22:15:00Z"
+      },
+      {
+        "id": "f0a5c23e-9a7a-47ab-8302-aa854c4b1486",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T08:45:00Z"
+      },
+      {
+        "id": "ae680d51-f044-4e45-839f-72d1f8c582d8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T06:00:00Z"
+      },
+      {
+        "id": "ac5baedc-3436-477b-948e-38920aeea36b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T19:30:00Z"
+      },
+      {
+        "id": "aad380c0-8853-47ea-96f5-560b755a0699",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T18:10:00Z"
+      },
+      {
+        "id": "0e908978-201f-4ea8-9954-77763ce5b426",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T12:30:00Z"
+      },
+      {
+        "id": "eabac8c8-ca83-49cb-9aa2-f481d463a113",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T08:20:00Z"
+      },
+      {
+        "id": "51500de8-8667-4616-ac95-01a787ffd27d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T22:45:00Z"
+      },
+      {
+        "id": "04f6feee-fcdc-4c01-9fe9-18305ffc2814",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T12:45:00Z"
+      },
+      {
+        "id": "748764dd-6193-4a5b-ae3f-b83ebdf5337f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T20:50:00Z"
+      },
+      {
+        "id": "96bf5beb-d88f-4d8d-9b87-42814bc6882c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T21:10:00Z"
+      },
+      {
+        "id": "773451ec-8be8-4a37-977b-4972112dfcee",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T07:40:00Z"
+      },
+      {
+        "id": "81ea783f-b8d8-4685-be8e-d87d4d87b676",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T08:05:00Z"
+      },
+      {
+        "id": "f1d11e82-f96f-4d52-aae6-136d8301a4f8",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T18:15:00Z"
+      },
+      {
+        "id": "849a1d14-6b7a-4f18-b66b-7eeb1b211463",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T07:15:00Z"
+      },
+      {
+        "id": "ab85eb23-0722-4ae5-b5d1-1d22e9ef18c2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T22:30:00Z"
+      },
+      {
+        "id": "f2fcfae5-e9f2-47fa-8b77-49fafe28a21b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T22:20:00Z"
+      },
+      {
+        "id": "d9470c9d-d362-4013-b182-6103c30da4d5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T08:45:00Z"
+      },
+      {
+        "id": "bca96730-1afc-43da-a4e8-bfde56f7b4e4",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T12:50:00Z"
+      },
+      {
+        "id": "569e1f08-2880-4819-9edf-fceba259d798",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T06:15:00Z"
+      },
+      {
+        "id": "c27e399c-3eaf-424e-939e-63ae5225ddb7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T12:45:00Z"
+      },
+      {
+        "id": "4a7103c1-7e95-4ec6-9798-7ff80185dcee",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T12:30:00Z"
+      },
+      {
+        "id": "8f5daf5f-af70-4cc4-bdb0-b06406c5976e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T12:00:00Z"
+      },
+      {
+        "id": "ec3e4aed-e275-45a7-8693-645dd8deb0ac",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T08:20:00Z"
+      },
+      {
+        "id": "69c66e3f-588d-4541-a7e3-0c8f595eb166",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T17:10:00Z"
+      },
+      {
+        "id": "baccea6c-5dd6-458f-a4a6-d47ece054aea",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T19:45:00Z"
+      },
+      {
+        "id": "6bf452ce-6abf-4270-859d-df23730ae9ae",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T17:30:00Z"
+      },
+      {
+        "id": "115a3f54-16dc-4f68-b60a-08f1aa25b82b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T06:05:00Z"
+      },
+      {
+        "id": "48ee1031-9663-4106-bee8-441040861ca5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:15:00Z"
+      },
+      {
+        "id": "00829c78-84f1-415e-bc80-dce6ac6b0f53",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T17:10:00Z"
+      },
+      {
+        "id": "7a3866d2-2da0-4c1c-887e-7ecb472864a4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:50:00Z"
+      },
+      {
+        "id": "9e78e5db-e303-4b14-96ed-a91fb945bade",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T19:00:00Z"
+      },
+      {
+        "id": "7080a547-ac99-48d3-964e-b39921725600",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T06:10:00Z"
+      },
+      {
+        "id": "148c75e4-5020-47cc-b6d3-b2e45e66b453",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T21:00:00Z"
+      },
+      {
+        "id": "554daeca-c12c-4ad1-a0fa-00abde2bc04a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T17:40:00Z"
+      },
+      {
+        "id": "8e9d2bd6-b04b-4d4f-bb9e-41f3d7194aff",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:15:00Z"
+      },
+      {
+        "id": "c7fca7c6-330a-4328-8e59-529b8ea047f1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:00:00Z"
+      },
+      {
+        "id": "ddf69417-173d-4fba-aa87-456203167b74",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T22:45:00Z"
+      },
+      {
+        "id": "985f1bd9-8361-446d-85f5-4f2a550e547e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T19:40:00Z"
+      },
+      {
+        "id": "77bbd5c3-c9e4-4a16-93e9-5232c97ec395",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T07:00:00Z"
+      },
+      {
+        "id": "81c45f5a-4cae-4135-a12b-735d3e81ba9a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T18:00:00Z"
+      },
+      {
+        "id": "f75f9263-97ce-4bc5-809c-f087b9d8b4ec",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T18:20:00Z"
+      },
+      {
+        "id": "2553ec45-6939-4a74-87e1-b59a7b375522",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T07:00:00Z"
+      },
+      {
+        "id": "7778cdbd-2ca4-4280-8eb7-89ec6b4171c3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T17:05:00Z"
+      },
+      {
+        "id": "fc968011-b5bc-4ba5-a45d-f02015398171",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T19:45:00Z"
+      },
+      {
+        "id": "46656442-7721-4d67-a8c6-79f05899e27d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T19:40:00Z"
+      },
+      {
+        "id": "1b351b08-9840-4ad6-aa5a-956ea1ffacb2",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T22:15:00Z"
+      },
+      {
+        "id": "bf09a501-3852-4e2d-8c53-56d0df2c5df5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T22:00:00Z"
+      },
+      {
+        "id": "5f256b09-0787-47c4-8a14-3bcdd52d2990",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T06:20:00Z"
+      },
+      {
+        "id": "9709812d-0ec0-4623-af61-6cdc153d5da7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T06:20:00Z"
+      },
+      {
+        "id": "37fcbbbd-fdde-4994-97b6-d5634b9ca59d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T20:05:00Z"
+      },
+      {
+        "id": "b791e98e-75af-4f93-b45c-8f19e17f29e9",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T08:20:00Z"
+      },
+      {
+        "id": "6a02156d-b70b-46e3-af23-578ecfdb9deb",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T08:50:00Z"
+      },
+      {
+        "id": "0d98f09b-1394-4c7f-a883-27e196ebf757",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T21:00:00Z"
+      },
+      {
+        "id": "32865c2b-ff15-4e07-acef-7052230b720e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T19:30:00Z"
+      },
+      {
+        "id": "1e607c65-25bf-493e-931d-a4276827e8b9",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T17:30:00Z"
+      },
+      {
+        "id": "ffdda0b8-4944-4543-ab35-e6a6beac35b9",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T08:00:00Z"
+      },
+      {
+        "id": "24b380ee-cc51-4eb5-b459-39461a692e13",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T19:30:00Z"
+      },
+      {
+        "id": "e9734a64-065b-4764-ae08-daa406bd5981",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T18:15:00Z"
+      },
+      {
+        "id": "baffec4f-be55-4daa-8cea-2a903229b16f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T08:05:00Z"
+      },
+      {
+        "id": "cdb572b7-eff1-4ac3-af50-6fbc20d79661",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T08:05:00Z"
+      },
+      {
+        "id": "75ce212c-3b49-4103-a604-b120926c5224",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T22:20:00Z"
+      },
+      {
+        "id": "92bcc50a-3fcf-4226-b711-c53f23849ced",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T20:05:00Z"
+      },
+      {
+        "id": "935f2ab4-c023-4bd2-b4b7-5c2e7954d0a2",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T17:45:00Z"
+      },
+      {
+        "id": "691bc1a2-3127-43c5-98e6-e0d03143bd49",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T20:20:00Z"
+      },
+      {
+        "id": "b0f345a9-5bb6-4d4f-807d-b6fcbcbfbc59",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T21:45:00Z"
+      },
+      {
+        "id": "77429753-c3e5-4a19-be38-e7382f86e73f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T17:00:00Z"
+      },
+      {
+        "id": "b3fdff0a-6f73-4345-a439-0c7a8dd5e2a2",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T21:45:00Z"
+      },
+      {
+        "id": "176a8f3b-0424-473a-b60a-3dcfebc0dcb2",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T08:05:00Z"
+      },
+      {
+        "id": "ced7fadc-5188-48a9-8115-a8a0612d7d11",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T20:40:00Z"
+      },
+      {
+        "id": "49e50be6-c6fd-4c45-b250-dd5b5a9646f4",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T08:45:00Z"
+      },
+      {
+        "id": "3f4b1f70-0a72-4a92-ab18-6abb009b08da",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T22:40:00Z"
+      },
+      {
+        "id": "6a81a16a-23ba-4cf8-8362-77d205db9f84",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T17:45:00Z"
+      },
+      {
+        "id": "e644407f-cc47-48f4-b99e-79fe69692ee4",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T17:45:00Z"
+      },
+      {
+        "id": "90f3297e-f272-4ad2-99a1-215223da298c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T18:30:00Z"
+      },
+      {
+        "id": "c8caeed0-d4e3-4e33-a0a8-6638163a796d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T17:30:00Z"
+      },
+      {
+        "id": "0e4efbc0-9eec-40a7-a042-69ce635bc779",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T20:20:00Z"
+      },
+      {
+        "id": "33cf45b4-a4c6-4cb4-9f57-bd6670eae48c",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T18:50:00Z"
+      },
+      {
+        "id": "52d2339b-123e-41cc-8004-7e23444d0f88",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T17:20:00Z",
+        "note": "Nonfiction notes"
+      },
+      {
+        "id": "507628f2-551c-47fe-88eb-eaeb7c92fd4d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T20:10:00Z"
+      },
+      {
+        "id": "f182e517-e7d5-4448-8a20-e9715d9736a7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T18:40:00Z"
+      },
+      {
+        "id": "67672d33-cbdc-4822-987d-b23b0e0bc916",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T22:00:00Z"
+      },
+      {
+        "id": "78ca3107-a02d-4c37-aa1a-5a186fa6ba1c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T17:45:00Z"
+      },
+      {
+        "id": "99d34bf4-ca4f-467f-aa5b-02c86d2461be",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T08:15:00Z"
+      },
+      {
+        "id": "eca85f8f-8711-45ef-b127-49efa0c085e9",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T07:15:00Z"
+      },
+      {
+        "id": "29808563-078d-4620-bc5e-69e8c8981ec1",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T20:50:00Z"
+      },
+      {
+        "id": "05489f35-f73a-4cb6-bef7-9fe4d0ae6ac7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T12:05:00Z"
+      },
+      {
+        "id": "dfbdf7f3-65ff-4a7a-829d-3f35c10f5e76",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T19:10:00Z"
+      },
+      {
+        "id": "aa4a558e-7515-4773-a6e8-0014a17e26c7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T12:15:00Z"
+      },
+      {
+        "id": "c8bc4a6d-826d-4c35-afab-fefc8b2eee02",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T08:40:00Z"
+      },
+      {
+        "id": "fd411cdf-8bf5-4dad-9832-74400a9241c5",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T06:30:00Z"
+      },
+      {
+        "id": "cf1de26a-dfb4-41be-9696-b0155b16ae76",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T22:50:00Z"
+      },
+      {
+        "id": "255e232e-9d8d-4489-a50b-645cc2215099",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T18:05:00Z"
+      },
+      {
+        "id": "f18efc58-f29b-4003-a95e-b523f1fbf7c4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T21:30:00Z"
+      },
+      {
+        "id": "47b9f493-1b36-4a65-a23b-d7e6d60e5d75",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T12:05:00Z"
+      },
+      {
+        "id": "2554872e-fc84-4253-bcb6-b8f0081254a7",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T22:15:00Z"
+      },
+      {
+        "id": "f3707b2f-5b98-4b23-8999-6f9514534a4b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T07:00:00Z"
+      },
+      {
+        "id": "5c23ddb4-6397-4adf-a96d-08c7e09a5c83",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T12:10:00Z"
+      },
+      {
+        "id": "4e9a5310-bfa2-42c1-b428-9bfbe6e12bba",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T18:45:00Z"
+      },
+      {
+        "id": "bad06ad3-bd11-423d-b2b2-44f03f0f8738",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T19:15:00Z"
+      },
+      {
+        "id": "135c481e-b612-429e-9021-cdb232b1521e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T18:40:00Z"
+      },
+      {
+        "id": "71d424e9-e36f-43a9-9c19-cc15f5d8ab04",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T22:05:00Z"
+      },
+      {
+        "id": "777f7ec4-022c-4aff-9379-fb02b0f08f59",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T07:20:00Z"
+      },
+      {
+        "id": "74524ace-ebc7-4eed-8221-165446fdc447",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T22:20:00Z"
+      },
+      {
+        "id": "11bbb598-b81b-465a-9ce3-ae146e35579a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T17:45:00Z"
+      },
+      {
+        "id": "97ecfe4b-7884-44d4-b292-cd32f5cf4450",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T19:10:00Z"
+      },
+      {
+        "id": "84becbb1-d622-4de7-9d24-e4afd1d43ca9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T07:30:00Z"
+      },
+      {
+        "id": "1c57e431-2af7-4237-9ce7-0e61f6da16cd",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T07:40:00Z"
+      },
+      {
+        "id": "6fe1115c-fc31-4e25-986f-37b55d7e203f",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T17:40:00Z"
+      },
+      {
+        "id": "b112550d-e17a-4799-b381-01082283695d",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T20:05:00Z"
+      },
+      {
+        "id": "18a17cf9-4f27-44d9-bac8-44ce95ae873b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T21:50:00Z"
+      },
+      {
+        "id": "8fabe615-5ea0-4a55-a733-24a63b21fcaf",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T20:05:00Z"
+      },
+      {
+        "id": "299ee4a2-fc31-4a7c-8b3a-74c09de4f2d3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T06:10:00Z"
+      },
+      {
+        "id": "cfe3c437-d1b7-4fdf-915d-690bc02600ec",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T22:15:00Z"
+      },
+      {
+        "id": "021f3bfa-778f-468b-b25e-e49d795e9cf8",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T20:50:00Z"
+      },
+      {
+        "id": "05a8a9de-1313-4db2-9db7-29ed7ae9f8c4",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T20:10:00Z"
+      },
+      {
+        "id": "b6d2ec90-2960-4930-b695-608a85eae734",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T21:00:00Z"
+      },
+      {
+        "id": "094686fe-01ff-4e32-a997-a257e4a0a9cf",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T17:45:00Z"
+      },
+      {
+        "id": "0cce9817-839d-49b0-93f4-6721a11c246d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T08:10:00Z"
+      },
+      {
+        "id": "f89bdcf0-05d1-471e-b4a4-9f08e23d8455",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T18:10:00Z"
+      },
+      {
+        "id": "808ec69e-6ba0-4c29-8d5f-ff3cd858ac12",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T12:40:00Z"
+      },
+      {
+        "id": "01dc7e1b-b36a-41f3-bcf3-afa2d28e9b1e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T07:45:00Z"
+      },
+      {
+        "id": "29c970b2-ffd9-47db-ba9c-0d02797d7935",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T22:50:00Z"
+      },
+      {
+        "id": "ce72a14f-dca3-4aa7-91b9-57f232c22ef4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T08:10:00Z"
+      },
+      {
+        "id": "00de95a5-f10a-4303-a56f-c9bdde1d6c38",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T18:50:00Z"
+      },
+      {
+        "id": "600c8df6-a4b3-4deb-bc38-3e1617825ca9",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T20:30:00Z"
+      },
+      {
+        "id": "b97318be-4f25-4cf9-8504-a44b6bc57054",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T17:00:00Z"
+      },
+      {
+        "id": "9ede68ca-4220-4b8e-adad-e1caa4aa572c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T07:30:00Z"
+      },
+      {
+        "id": "b11b713e-6042-49de-a766-2fe0e04c757d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T21:05:00Z"
+      },
+      {
+        "id": "8c58f2d3-6386-4c08-ba5d-13a9085eec9d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T20:10:00Z"
+      },
+      {
+        "id": "e0ae56a4-5776-4f20-8bfb-e28507d59a94",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T06:50:00Z"
+      },
+      {
+        "id": "02469d2c-d603-4f38-a16a-f0d0249c6c98",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T18:05:00Z"
+      },
+      {
+        "id": "e260a75d-3977-40e0-b249-259bb772a200",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T12:30:00Z"
+      },
+      {
+        "id": "3280c434-027c-4d3e-b0b0-773fc6d63f43",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T12:30:00Z"
+      },
+      {
+        "id": "bb90bae6-352c-45b1-a35e-4295c2ebb5c4",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T19:00:00Z"
+      },
+      {
+        "id": "3306bfd2-0443-40a8-a2b9-d5fa4af9da85",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T19:50:00Z"
+      },
+      {
+        "id": "2311eece-3dd2-4a0a-9d4b-d700babaeaea",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T22:45:00Z"
+      },
+      {
+        "id": "a724130f-3c1b-4375-bcb0-20319181cfe4",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T19:50:00Z"
+      },
+      {
+        "id": "705b9f4f-b1f1-4ff3-9659-3cf01d053edf",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T17:45:00Z"
+      },
+      {
+        "id": "eb025da8-382e-46b4-981c-0f49c36d741c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T20:05:00Z"
+      },
+      {
+        "id": "9e2cf22d-7b8d-461c-8185-72de713582fd",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T07:20:00Z"
+      },
+      {
+        "id": "56eabc48-8daa-451f-afb9-0258b47c1248",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T06:05:00Z"
+      },
+      {
+        "id": "01b6a7c1-66bc-41fe-97f1-e9f3cb588e70",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T19:00:00Z"
+      },
+      {
+        "id": "62fd5e9b-5275-4ea8-8415-8c388c9d2b3a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T06:10:00Z"
+      },
+      {
+        "id": "d14f1d56-2eda-44a0-b977-16dad1eef2cc",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T08:45:00Z"
+      },
+      {
+        "id": "ddffc0fa-ea48-4f02-9ea3-2523db2132c5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T21:40:00Z"
+      },
+      {
+        "id": "20e06887-6b6e-47d9-9385-8d523119e0f9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T07:50:00Z"
+      },
+      {
+        "id": "9524b055-2ae1-4585-8edf-d933bf2ed71a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T17:00:00Z"
+      },
+      {
+        "id": "ca70d5f0-fca1-4fbd-a3b7-d42dfb7575ab",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T22:00:00Z"
+      },
+      {
+        "id": "727dcbe0-c682-4796-b6ed-2f4bf0e9d90f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T20:30:00Z"
+      },
+      {
+        "id": "abbb27e8-2d11-48f9-817a-c097b6237552",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T19:15:00Z"
+      },
+      {
+        "id": "fa986932-02a0-4aa7-ab15-da71b84827f3",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T22:00:00Z"
+      },
+      {
+        "id": "54f0217f-7744-4328-b351-e8934ba9b624",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T07:00:00Z"
+      },
+      {
+        "id": "47cc8c4d-d79b-4f67-9ee7-afd75a83978c",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T20:00:00Z"
+      },
+      {
+        "id": "54a30828-375a-4ff0-8bcc-fc9b4614f41c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T18:15:00Z"
+      },
+      {
+        "id": "b16c0a84-e27d-4658-baae-66daa42ed138",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T19:45:00Z"
+      },
+      {
+        "id": "5d62a390-809e-4bd8-b07f-da6e5a98af3a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T17:00:00Z"
+      },
+      {
+        "id": "fe9b1452-ab1e-4bfa-bbba-653bd8455209",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T07:45:00Z"
+      },
+      {
+        "id": "58c7a98c-5655-4c4d-846b-10f673059e10",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T06:05:00Z"
+      },
+      {
+        "id": "310aa211-9c09-4052-8a6a-7d4754b37a82",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T20:30:00Z"
+      },
+      {
+        "id": "f250698b-11d1-468a-a8f6-413897454c69",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T21:10:00Z"
+      },
+      {
+        "id": "a9022d55-b015-4c73-b5e3-5bf9a0f817ce",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T19:05:00Z"
+      },
+      {
+        "id": "41bc8124-da7e-4e64-af9f-6929dc1f95f7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T06:00:00Z"
+      },
+      {
+        "id": "1b2dd5d6-2308-40ef-af06-0bde8d221540",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T20:50:00Z"
+      },
+      {
+        "id": "7719252e-06cc-4622-8a5e-a128c0fc876d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T08:10:00Z"
+      },
+      {
+        "id": "a5c8362b-2b0a-4523-aa0f-c43a37a58379",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T22:00:00Z"
+      },
+      {
+        "id": "5f3e5c65-33c6-42f0-a6d0-a76cfe4e64c8",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T08:30:00Z"
+      },
+      {
+        "id": "6a796cc6-cfd5-411c-85c3-41e0b332733d",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T22:30:00Z"
+      },
+      {
+        "id": "de4836e9-dfb0-4633-b0d3-7b6523b3329b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T06:45:00Z"
+      },
+      {
+        "id": "debf4518-6e93-4dce-81c7-5492fbb2d771",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T08:50:00Z"
+      },
+      {
+        "id": "7eb73562-0a1a-4b93-bc68-1ee2f70ea963",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T06:30:00Z"
+      },
+      {
+        "id": "96f152ce-1646-4dac-9eb8-12e77858e4da",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T22:10:00Z"
+      },
+      {
+        "id": "01d64cc7-ea00-4b6f-a512-4e397b771047",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T21:30:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "42c2eb39-92b3-452d-a5d0-720007aeeb70",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T07:10:00Z"
+      },
+      {
+        "id": "7b9b8cf3-b982-42db-b1f0-1218d35442d4",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T08:05:00Z"
+      },
+      {
+        "id": "cefe3367-1597-411e-b2f4-e9047ef28014",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T20:15:00Z"
+      },
+      {
+        "id": "cc60412e-5a9f-45b4-b250-68a2b571474f",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T08:50:00Z"
+      },
+      {
+        "id": "7e7dac66-4e3b-4a94-82b9-a0911aed4e99",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T21:50:00Z"
+      },
+      {
+        "id": "d9f24be7-0361-4f75-8689-b42056955028",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T17:10:00Z"
+      },
+      {
+        "id": "87605f19-f405-4d0f-8a49-eb8a40642776",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T17:20:00Z"
+      },
+      {
+        "id": "a525e8a4-f47c-4bc4-91fd-d73007bba28a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T21:10:00Z"
+      },
+      {
+        "id": "815823f1-5461-45a2-b377-826667a21002",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T19:10:00Z"
+      },
+      {
+        "id": "2e3b7b66-e842-42d4-a335-1a617b7cc864",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T07:45:00Z"
+      },
+      {
+        "id": "077abbbf-e59b-4947-b989-396c34dd9ee3",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T19:45:00Z"
+      },
+      {
+        "id": "1adb8b03-7562-4783-901e-da20d70d61f1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T22:30:00Z"
+      },
+      {
+        "id": "53de16cf-3e3a-4766-9d70-689edb6c9799",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T07:45:00Z"
+      },
+      {
+        "id": "7e618372-200b-4e07-a6ad-035d76c1d444",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T12:15:00Z"
+      },
+      {
+        "id": "c45dd8d2-5a9d-4016-8c67-82ee0413d477",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T12:40:00Z"
+      },
+      {
+        "id": "657c335e-a767-48b3-b099-f0ab4ee8f381",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T12:00:00Z"
+      },
+      {
+        "id": "5ad1fa76-5556-4272-bd4f-9a4fe075a053",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T12:40:00Z"
+      },
+      {
+        "id": "a2cea77b-1ee4-427e-9c05-f5cd7b00fb23",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T20:50:00Z"
+      },
+      {
+        "id": "04de13c8-a3f9-4fa8-bc49-23ea79a5ae1b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T08:50:00Z"
+      },
+      {
+        "id": "5d68849a-94cf-48ab-8bd8-bda275fc15af",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T22:00:00Z"
+      },
+      {
+        "id": "0e41eda9-f237-4008-a874-72dfd40d5e59",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T22:50:00Z"
+      },
+      {
+        "id": "c6f9b001-1aea-40f8-baed-557ced1ac95c",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T12:40:00Z"
+      },
+      {
+        "id": "736b7031-bea9-45a6-9c32-c4d2642dc2e6",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T20:40:00Z"
+      },
+      {
+        "id": "53ceeb40-4b2e-4b5e-94cd-182bb5de2157",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T07:30:00Z"
+      },
+      {
+        "id": "97fc0997-3401-4b57-9ada-62b4212fd83f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T06:50:00Z"
+      },
+      {
+        "id": "d9f0ba66-1fd9-4fa5-8054-91b885e1e10d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T17:30:00Z"
+      },
+      {
+        "id": "208c3c4d-157b-4617-b986-c9f8c6f1e0eb",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T06:20:00Z"
+      },
+      {
+        "id": "ddd5375e-ab2c-4d11-97d0-ff3c80c654a2",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T06:15:00Z"
+      },
+      {
+        "id": "de7b8a45-a866-4a34-aad3-96b66ca8490d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T06:20:00Z"
+      },
+      {
+        "id": "f3571f93-1371-4ff3-83d2-cbb405c986bb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T20:20:00Z"
+      },
+      {
+        "id": "7f0ec1b1-599f-4a49-9b81-fb8d0def41d4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T12:00:00Z"
+      },
+      {
+        "id": "46c0937f-0980-4dad-957f-38f619c451c8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T18:45:00Z"
+      },
+      {
+        "id": "9e46d0cd-3194-49e0-984a-9d4a25144ba3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T18:00:00Z"
+      },
+      {
+        "id": "dda6d95f-1877-4874-b407-02ea32e13511",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T19:40:00Z"
+      },
+      {
+        "id": "2eaaa2d4-6f22-41b3-b9ac-092b850d0bde",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T06:10:00Z"
+      },
+      {
+        "id": "17112a86-c3ea-4709-b826-3447ff699632",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T06:05:00Z"
+      },
+      {
+        "id": "e57d9cba-2dbf-49c2-bf66-40ab07440734",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T20:10:00Z"
+      },
+      {
+        "id": "15c7cb93-8b87-4f29-af5b-6130a5ed95c3",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T12:00:00Z"
+      },
+      {
+        "id": "acc29c97-b1ba-4545-b5ae-324b6fd48773",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T08:20:00Z"
+      },
+      {
+        "id": "4a5c8691-f823-4219-80ad-043f51e5e631",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T06:15:00Z"
+      },
+      {
+        "id": "c4c0b4d8-0225-4c92-8641-1bf821576e6e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T08:20:00Z"
+      },
+      {
+        "id": "8a8ec5bb-9a67-4bd3-90a3-09431aa0f731",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T21:45:00Z"
+      },
+      {
+        "id": "b0a0a874-b664-46c8-a543-e2b03e93e383",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T08:20:00Z"
+      },
+      {
+        "id": "1fdb8642-8da9-49bc-a839-c8359c005220",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T06:15:00Z"
+      },
+      {
+        "id": "4c6e4066-2a7f-46e0-94b6-e0ce5072840e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T19:05:00Z"
+      },
+      {
+        "id": "f55fa1ca-cd4b-49e0-9ec8-be7e3b356125",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T18:20:00Z"
+      },
+      {
+        "id": "28bf78a3-2d28-425c-bf70-79854339994d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T21:30:00Z"
+      },
+      {
+        "id": "beada4e6-ee86-4bc4-af5a-666af2c49977",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T18:30:00Z"
+      },
+      {
+        "id": "3955ad96-9b9d-47e5-87d7-42aab6ecff22",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T20:00:00Z"
+      },
+      {
+        "id": "45a287b6-c5c7-4a11-b74e-99f0db4ab7a2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T12:15:00Z"
+      },
+      {
+        "id": "ddbf8c3b-cfa9-4a34-8465-0b8d47579eb1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T06:20:00Z"
+      },
+      {
+        "id": "9c836660-dda6-459f-9add-3cb1b2695049",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T18:05:00Z"
+      },
+      {
+        "id": "0e913dfc-f3b1-4e42-8eeb-bfe736b7e9ea",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T08:15:00Z"
+      },
+      {
+        "id": "32a6310b-cff3-4e15-b0ad-1c552eea6c91",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T07:15:00Z"
+      },
+      {
+        "id": "0df03a6a-cb68-4c0b-b405-172591cc26ec",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T06:40:00Z"
+      },
+      {
+        "id": "5bb83a3f-61e5-4981-a715-3c0d1df7d388",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T19:50:00Z"
+      },
+      {
+        "id": "a6ce599a-bb59-4166-9b1e-a6f453e53857",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T12:20:00Z"
+      },
+      {
+        "id": "97d96985-87c7-4511-be3e-36b35d3be0c7",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T17:15:00Z"
+      },
+      {
+        "id": "e20e31b6-0aff-4b4c-af85-8ad6d8c8ec04",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T21:00:00Z"
+      },
+      {
+        "id": "189ada7b-b20f-418c-954e-8a9a85a8e3b8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T12:50:00Z"
+      },
+      {
+        "id": "7fcf228b-74dd-4f51-9ad8-c1763a4c2b69",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T22:00:00Z"
+      },
+      {
+        "id": "9cf91dec-5008-4aad-b3d2-0b4a41b637a7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T06:45:00Z"
+      },
+      {
+        "id": "c5195ec1-50ca-49ba-b3e4-6eb03b8e569f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T19:20:00Z"
+      },
+      {
+        "id": "ddf7db31-f01d-4e08-9149-dba32778bc33",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T17:20:00Z"
+      },
+      {
+        "id": "241a7b08-9a91-48e9-8f3a-85c206457ac8",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T22:30:00Z"
+      },
+      {
+        "id": "8755ff67-e81e-40dd-8295-100df72bf124",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T18:45:00Z"
+      },
+      {
+        "id": "268c8c22-5762-468b-b3ca-30843c5dcaf8",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T22:10:00Z"
+      },
+      {
+        "id": "5ae7f619-cbf0-4020-a355-d062af1fe0dd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T06:45:00Z"
+      },
+      {
+        "id": "1c3ef1e9-9775-4233-82f7-afb7dfd65979",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T20:20:00Z"
+      },
+      {
+        "id": "a64f487c-df1c-4155-8161-6e2bef6b38f2",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T17:45:00Z"
+      },
+      {
+        "id": "c5ad3b70-3d39-4f6c-a71a-77402e7f15bc",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T22:45:00Z"
+      },
+      {
+        "id": "271489ef-033f-422b-80c9-8aa3e205926f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T06:15:00Z"
+      },
+      {
+        "id": "b948d6a3-d84b-4281-8c5b-26af4614193f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T22:50:00Z"
+      },
+      {
+        "id": "19d084b0-9962-4bdd-ab4d-9e6d94b18681",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T20:40:00Z"
+      },
+      {
+        "id": "0a1f13e3-9d3f-4d5a-9fb0-5f299283eece",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T07:20:00Z"
+      },
+      {
+        "id": "fb8bf56d-2968-4ee0-a41b-70df564c70ba",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T07:05:00Z"
+      },
+      {
+        "id": "bf7783d0-4bb0-4913-8223-5e5b0aadfe65",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T22:40:00Z"
+      },
+      {
+        "id": "f96e56e5-96cd-45e9-9498-b5d0f6100fa3",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T21:30:00Z"
+      },
+      {
+        "id": "21766f24-2f9b-4790-931e-d94ba155b4e1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T17:50:00Z"
+      },
+      {
+        "id": "c9f79eb2-89c2-4b2e-a0d0-c9b532ecda64",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T12:45:00Z"
+      },
+      {
+        "id": "a19bb664-5f1d-4c20-8a5f-d6c5b1f4d925",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T12:30:00Z"
+      },
+      {
+        "id": "04443830-8cca-442f-b2ea-ea40593a68e5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T07:00:00Z"
+      },
+      {
+        "id": "f7e39166-60f0-4bc7-abaa-ab17b2cb0154",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T21:40:00Z"
+      },
+      {
+        "id": "06004f67-19fc-4a8d-8641-4b265168669b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T18:15:00Z"
+      },
+      {
+        "id": "27fdcf62-a4b9-4bc9-9978-69aa14ed2469",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T12:00:00Z"
+      },
+      {
+        "id": "2f5a6329-fcec-463d-8f3a-e11b0030d66e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T12:00:00Z"
+      },
+      {
+        "id": "e559a65e-eec5-463a-9727-f37fd794196d",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T06:00:00Z"
+      },
+      {
+        "id": "86bc5864-c087-447a-9036-8b1a649cedfd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T12:45:00Z"
+      },
+      {
+        "id": "97309ab4-73da-4345-a2c5-8d0b12967da9",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T21:40:00Z"
+      },
+      {
+        "id": "debed5c5-5b0b-4bc9-87e6-21d42bb25331",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T19:05:00Z"
+      },
+      {
+        "id": "bf4740f4-3af5-4f8e-a489-a4ebf21820ed",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T07:10:00Z"
+      },
+      {
+        "id": "40f3701c-3fa4-4c7c-b41c-e76d2c677b1e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T19:30:00Z"
+      },
+      {
+        "id": "2640652a-dfd2-4da2-918d-ba70ebdfc7d0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T06:40:00Z"
+      },
+      {
+        "id": "2d409388-065c-4efa-b969-260ef1aea991",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T20:00:00Z"
+      },
+      {
+        "id": "b4051298-7ebd-41cf-a7e7-c2a8518956a6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T07:10:00Z"
+      },
+      {
+        "id": "17e7f339-7807-41cb-bd03-fff205a85aed",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T20:15:00Z"
+      },
+      {
+        "id": "8c28787c-7b4e-4d55-b75c-a81c1404df24",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T17:45:00Z"
+      },
+      {
+        "id": "283b2b16-e866-42ab-8f68-7af8d71fe0ef",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:15:00Z"
+      },
+      {
+        "id": "f8d56e1c-2be9-4468-8914-80cad02d408a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T12:40:00Z"
+      },
+      {
+        "id": "1104181d-bd1a-4765-b698-6d9996a3bcfb",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T12:20:00Z"
+      },
+      {
+        "id": "97d5125d-1c3e-420d-82b9-5045e4231dba",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T20:45:00Z"
+      },
+      {
+        "id": "2ebe3566-8463-4135-a65a-7fd63dec44e6",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T21:10:00Z"
+      },
+      {
+        "id": "1ec8c44b-7ead-4975-9390-aa285a22ad8c",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T19:05:00Z"
+      },
+      {
+        "id": "7d7d80f2-0ab4-40d7-9cb4-93c07eb4a157",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T19:50:00Z"
+      },
+      {
+        "id": "57b979b5-f5e4-4ab2-bf88-a0f113c3614a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T20:50:00Z"
+      },
+      {
+        "id": "f2aefb91-d1ed-429e-9f72-3b355868c01c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T08:30:00Z"
+      },
+      {
+        "id": "58b0c7c0-fcf3-4285-97af-71b3b790bd79",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:00:00Z"
+      },
+      {
+        "id": "ff3ee8ec-b96b-400e-9971-250499a33548",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T19:10:00Z"
+      },
+      {
+        "id": "6b2201cb-f803-42ac-a39d-5acbac84737a",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:45:00Z"
+      },
+      {
+        "id": "1eec63a7-a582-46c6-828c-0b842c24ce9d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:20:00Z"
+      },
+      {
+        "id": "db427e80-eed8-46d4-813e-6e0a8adce80f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T21:50:00Z"
+      },
+      {
+        "id": "0c55fcfe-597f-4b00-83cb-94fdeb535176",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T21:10:00Z"
+      },
+      {
+        "id": "aae7ba11-b0b0-40da-be76-44de7f2a7cfe",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T20:10:00Z"
+      },
+      {
+        "id": "dc93c2b8-42b3-4856-a0b4-dc00c69e7b7b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T07:30:00Z"
+      },
+      {
+        "id": "32c68ad7-e83a-44eb-97cb-838d4ef7df21",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T22:10:00Z"
+      },
+      {
+        "id": "db05df64-fc0d-4ab0-bd64-310d1aaee6f1",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T06:15:00Z"
+      },
+      {
+        "id": "3592f20b-87e4-402e-83f1-936d0e41ccbf",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T20:10:00Z"
+      },
+      {
+        "id": "21b53ec5-2a2b-4ebe-be12-cb25d74148b1",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T22:15:00Z"
+      },
+      {
+        "id": "e5d95038-91e2-4333-941d-0442150313c4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T21:20:00Z"
+      },
+      {
+        "id": "36e583c4-42f4-465c-b125-a9c2b2001f32",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T06:10:00Z"
+      },
+      {
+        "id": "c17d81cc-d264-41cb-9ed6-196299344754",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T17:40:00Z"
+      },
+      {
+        "id": "f384d1a0-cf9c-4587-a59c-f3681998c208",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T21:30:00Z"
+      },
+      {
+        "id": "c5fc6418-dcaf-4c6a-aa5f-084b6da1f46b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T21:20:00Z"
+      },
+      {
+        "id": "e333f184-03d1-49a4-adb2-5aef32283b0d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T22:10:00Z"
+      },
+      {
+        "id": "4d81b026-8e09-4030-8920-af50565c40e3",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T18:30:00Z"
+      },
+      {
+        "id": "1872a909-e727-4f15-aba7-917dd979667a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T19:10:00Z"
+      },
+      {
+        "id": "6c7f7728-53be-42d4-8915-9a885283774e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:00:00Z"
+      },
+      {
+        "id": "4a9895c9-17d9-4a1c-bbdf-536df7f5fcc6",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:30:00Z"
+      },
+      {
+        "id": "57453f36-7c8c-4d3f-86f7-7fc36ba02116",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T19:45:00Z"
+      },
+      {
+        "id": "479970f8-2789-4046-beca-1c0fd5473128",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T19:15:00Z"
+      },
+      {
+        "id": "6220da37-b43c-44c1-98b2-3c0341ffeb7a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T21:10:00Z"
+      },
+      {
+        "id": "2ed13d7f-f319-4d88-8819-f675301271bf",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:50:00Z"
+      },
+      {
+        "id": "d5f352af-db19-45c0-bbd9-0bc9f76a43b0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T17:30:00Z"
+      },
+      {
+        "id": "bd59cc50-e353-4820-b965-cc4498b2a425",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T18:05:00Z"
+      },
+      {
+        "id": "191574c6-0daf-484e-afdf-11c2292b0fd8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T08:10:00Z"
+      },
+      {
+        "id": "a6fc9a20-f603-4099-8bcf-84bab0522c00",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T17:45:00Z"
+      },
+      {
+        "id": "e4c694a9-bd52-41ec-873c-4927bc57cf4d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T12:50:00Z"
+      },
+      {
+        "id": "d00f9c7c-93d7-478f-96f5-99834293edec",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T06:05:00Z"
+      },
+      {
+        "id": "d1c048bb-19bb-4253-83e6-22dfcde84e4b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T20:10:00Z"
+      },
+      {
+        "id": "3fa5ca06-cad4-4f24-9308-7867612f04b5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T21:20:00Z"
+      },
+      {
+        "id": "7f7a3bdf-92ef-4245-9055-7ebc2150c00a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T22:50:00Z"
+      },
+      {
+        "id": "fd977273-d9af-4fac-b1a2-8fd7878583be",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T19:30:00Z"
+      },
+      {
+        "id": "7141efd6-938a-48f2-b049-a44d7c8b7d53",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T21:15:00Z"
+      },
+      {
+        "id": "96baa1ce-9c21-47c7-9037-d34a81c3c77f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T12:15:00Z"
+      },
+      {
+        "id": "fb1f2768-b543-44e6-a545-2fd0832de244",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T08:15:00Z"
+      },
+      {
+        "id": "ab4b3274-42a2-402b-8ed8-a80d6c990ffd",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T18:30:00Z"
+      },
+      {
+        "id": "9eaa6675-a696-4160-a1c9-c1e3e3791460",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T06:10:00Z"
+      },
+      {
+        "id": "373b1b44-59d8-4f3b-ba80-b6a36f434e34",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T07:20:00Z"
+      },
+      {
+        "id": "859f4392-e636-44af-b98e-373fbd288154",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T20:15:00Z"
+      },
+      {
+        "id": "fb987ce9-8a2f-484a-a31d-5a63ee55b3ac",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T19:30:00Z"
+      },
+      {
+        "id": "2a7d2b01-7f3a-434f-bb3b-5c8dd2bdafd4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T19:50:00Z"
+      },
+      {
+        "id": "e4fa0244-99ed-43d8-b20f-42995e057093",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T18:05:00Z"
+      },
+      {
+        "id": "7162615e-e3f1-4365-a4e6-cf4c32072371",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T07:10:00Z"
+      },
+      {
+        "id": "90223dc7-3d21-43a2-8b68-271e3836f27e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T20:40:00Z"
+      },
+      {
+        "id": "cc40afae-9c52-40b4-b98b-ceae380c7f58",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T22:45:00Z"
+      },
+      {
+        "id": "4de11bf8-a69e-4823-a52d-dfa02fabd638",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T21:40:00Z"
+      },
+      {
+        "id": "71f6051c-f568-4f15-9a4d-1a626eabcb17",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T22:10:00Z"
+      },
+      {
+        "id": "f25f1939-22f9-44a5-9d37-6496aa99a155",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T07:30:00Z"
+      },
+      {
+        "id": "a0513463-df88-4040-ade4-234eb95b51e2",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T07:05:00Z"
+      },
+      {
+        "id": "d1296deb-7bdb-4e3e-9823-5e92f9446b77",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:05:00Z"
+      },
+      {
+        "id": "b20d6d80-6454-4523-a9b8-2b4a1e92af64",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:15:00Z"
+      },
+      {
+        "id": "08284661-942a-4ae9-8110-ac23c34cd28a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T06:10:00Z"
+      },
+      {
+        "id": "f2697443-ea3d-4c77-91c2-0422a27b0ff5",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T08:00:00Z"
+      },
+      {
+        "id": "2bdc4903-01fd-414d-a8c8-7fc70959630c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T06:05:00Z"
+      },
+      {
+        "id": "199d1ad1-e040-4515-8d59-b7eb946b4ad4",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T06:05:00Z"
+      },
+      {
+        "id": "462618e4-1e6a-4e7f-8147-855068eec14d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T17:20:00Z"
+      },
+      {
+        "id": "ca4a0b99-7711-4fea-88b0-67fa09b2dd19",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T07:15:00Z"
+      },
+      {
+        "id": "06a0b1bd-3de1-43f8-9666-4f6162f537a4",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T06:20:00Z"
+      },
+      {
+        "id": "36ba93ca-31dc-468b-8f92-c1ae63423102",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T18:10:00Z"
+      },
+      {
+        "id": "5d8495b3-6d4e-4535-a38d-dad0fddd1640",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T07:40:00Z"
+      },
+      {
+        "id": "3d77a0a4-5df3-44a4-8fbe-729c3a4fd002",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T08:00:00Z"
+      },
+      {
+        "id": "7564dd88-7696-4a77-937b-d5626d2d4496",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T17:15:00Z"
+      },
+      {
+        "id": "e375ced3-79f1-42f0-8c0f-fb484274f38f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T17:50:00Z"
+      },
+      {
+        "id": "a7f956ba-e7e5-4ce2-a966-9614751dab3e",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T06:05:00Z"
+      },
+      {
+        "id": "8de193f3-442c-40ac-94da-d4c370cb1fe7",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T21:45:00Z"
+      },
+      {
+        "id": "6fab8863-4d3f-490a-86e9-2846710a61d0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T08:30:00Z"
+      },
+      {
+        "id": "92174027-03f6-40f9-a238-7a74e2f54954",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T07:45:00Z"
+      },
+      {
+        "id": "2b73015e-fa29-4d93-8c15-dfe51b3835e2",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T22:50:00Z"
+      },
+      {
+        "id": "3ed9177e-5e80-483d-bfd6-f326b18dbf5c",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T07:40:00Z"
+      },
+      {
+        "id": "59f5e5e6-636f-48f2-88c2-2bca6ab38a60",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T21:45:00Z"
+      },
+      {
+        "id": "02c58d3f-1188-47c6-b746-5c0ce1970d6b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T21:50:00Z"
+      },
+      {
+        "id": "89abb916-8d90-4abc-b539-c834f02f6791",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T19:40:00Z"
+      },
+      {
+        "id": "ff49bb04-0240-4a37-bf92-648a56782e4a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T06:00:00Z"
+      },
+      {
+        "id": "f69d2a7f-0a20-47ef-9fe0-d97f197de646",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T22:40:00Z"
+      },
+      {
+        "id": "42d6ce05-5851-466d-9763-1a8e9b008853",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T12:15:00Z"
+      },
+      {
+        "id": "8ec4ffca-45c8-4364-89b2-95fd34f5ffd5",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T22:45:00Z"
+      },
+      {
+        "id": "ae086ce1-5d62-4509-ab1e-213ec13dc196",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T12:45:00Z"
+      },
+      {
+        "id": "e2b07a60-7d28-492a-a516-ae0b78b75d49",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T12:40:00Z"
+      },
+      {
+        "id": "9e4a5e83-5990-48d5-8c15-6ed9713cd52f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T20:40:00Z"
+      },
+      {
+        "id": "f3499b27-4fc3-4ea3-b9df-75f33639884c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:20:00Z"
+      },
+      {
+        "id": "3389445e-a233-4b64-8186-a584efd48f1a",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T08:00:00Z"
+      },
+      {
+        "id": "f71b66e9-144c-4cf4-9a54-814bd6bc7bd6",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T20:15:00Z"
+      },
+      {
+        "id": "80d46f94-400f-4775-b05e-35ee1fa191ea",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T08:40:00Z"
+      },
+      {
+        "id": "585b3c30-3051-44e9-bdfa-c803e7d16b3a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T19:20:00Z"
+      },
+      {
+        "id": "5258bb7e-6c53-4254-a304-2225687eca07",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T06:40:00Z"
+      },
+      {
+        "id": "fb33859a-9c1e-4119-9dcf-9b95c2cd0302",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:00:00Z"
+      },
+      {
+        "id": "644890e4-b1f9-4919-a6bb-8368f069d79a",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T17:15:00Z"
+      },
+      {
+        "id": "9281ff79-75c6-4bd2-8319-65fceeec4d96",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T21:00:00Z"
+      },
+      {
+        "id": "49bcd477-1677-4d4b-8e76-22c0783f134d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T07:05:00Z"
+      },
+      {
+        "id": "4cb835c5-a560-4f3c-b164-5d87b0039061",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:30:00Z"
+      },
+      {
+        "id": "f361ee75-1e39-42c5-93fa-633da11d8987",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T07:20:00Z"
+      },
+      {
+        "id": "93ac50f9-b64f-4de7-876f-2b14a4abec31",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T12:20:00Z"
+      },
+      {
+        "id": "83a9776e-003a-4e58-81c4-356a2c6b46ba",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T12:40:00Z"
+      },
+      {
+        "id": "9c0651fa-479e-4a45-93bf-dda6dfd0087c",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T17:15:00Z"
+      },
+      {
+        "id": "800000f8-9a96-4890-aea7-6fc3d925ebcd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T19:20:00Z"
+      },
+      {
+        "id": "3783b618-fd90-4688-991e-77bf54c2ea23",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T22:00:00Z"
+      },
+      {
+        "id": "73942b4a-d160-49f8-9a71-8ab70024d916",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T07:00:00Z"
+      },
+      {
+        "id": "33456aea-41c3-4569-88c2-fd9fade6c09e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T07:05:00Z"
+      },
+      {
+        "id": "f655ca72-230e-487d-9f9d-2ab73d318e79",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T07:15:00Z"
+      },
+      {
+        "id": "a9b9ec0c-0c1d-4ff0-97aa-1703db1f7a81",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T21:30:00Z"
+      },
+      {
+        "id": "147fea92-556b-42ed-b30f-8dca9b173998",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T08:10:00Z"
+      },
+      {
+        "id": "8e7f63c8-af13-4e86-b7a2-ddeb28289f70",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T20:45:00Z"
+      },
+      {
+        "id": "c1bc0b69-6a39-42ed-951d-e9e364ead438",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T08:20:00Z"
+      },
+      {
+        "id": "ab78aa95-0b38-435a-bf3b-b4fdfa276c68",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T17:15:00Z"
+      },
+      {
+        "id": "b26a8dfc-07ea-49e6-9a62-046fb03c6849",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T06:30:00Z"
+      },
+      {
+        "id": "385f05e2-4ad5-4431-8d6e-b9edad6385d6",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T22:15:00Z"
+      },
+      {
+        "id": "2b6f26e9-a08d-4bdc-af4b-a4d133ff3aa5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T12:40:00Z"
+      },
+      {
+        "id": "e065de4a-4ac1-4362-a6d4-d9bc3bd6f4dc",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T18:30:00Z"
+      },
+      {
+        "id": "407331f2-dd68-4e04-9007-2b92d6449323",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T07:45:00Z"
+      },
+      {
+        "id": "f5bad2a9-b4ae-459c-be3a-d6cd908c4fc4",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T18:30:00Z"
+      },
+      {
+        "id": "2e2f6372-55f9-4278-b9c5-5825774391a2",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T08:15:00Z"
+      },
+      {
+        "id": "d671dbcd-1fc9-4dd2-802e-7e2df545d323",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T07:20:00Z"
+      },
+      {
+        "id": "5f82f787-e610-491b-b4ce-8724724f963a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T06:10:00Z"
+      },
+      {
+        "id": "f9b379b0-402c-43b3-8d34-39cbfebd28d0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T18:20:00Z"
+      },
+      {
+        "id": "8475d614-40cf-4c88-bb8f-8b637a4e1cdc",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T08:20:00Z"
+      },
+      {
+        "id": "4406ea21-36a7-4a84-a0d4-64e403c0c001",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T08:00:00Z"
+      },
+      {
+        "id": "935c18ab-31d0-4098-b27a-eba7ec918311",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T18:50:00Z"
+      },
+      {
+        "id": "3e3c8857-bb3d-46f9-9add-99682e6d0d61",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T12:50:00Z"
+      },
+      {
+        "id": "06718048-d20b-44d6-bf65-63883d68e035",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T21:00:00Z"
+      },
+      {
+        "id": "a6fc8694-b01f-4b7c-aa3c-f99b57abea9e",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T18:00:00Z"
+      },
+      {
+        "id": "ce19d3c3-7b8e-4cb6-a855-d034128f2a75",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T20:30:00Z"
+      },
+      {
+        "id": "92be6e95-9deb-4277-927b-3f783deacb2f",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T21:30:00Z"
+      },
+      {
+        "id": "d98b0b20-0c19-4042-9d32-21e59390a4ef",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T08:50:00Z"
+      },
+      {
+        "id": "d2fe0e3e-aa73-40aa-a335-b2b02563ea50",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T07:05:00Z"
+      },
+      {
+        "id": "5e65bdfa-70d2-4319-a7d4-9cd7294cbf60",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T19:05:00Z"
+      },
+      {
+        "id": "64ecb36d-0c01-42b1-b7a6-85008f6eedbc",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T19:40:00Z"
+      },
+      {
+        "id": "54e8e4a8-1c6d-4a2f-9302-715786a87b74",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T22:50:00Z"
+      },
+      {
+        "id": "6dfd64aa-d7df-4dbf-9296-b27f56098be8",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T17:00:00Z"
+      },
+      {
+        "id": "26b81777-7f25-4dab-8d1b-da204ad9a4f7",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T07:05:00Z"
+      },
+      {
+        "id": "f773429b-1c18-4bee-9c16-152e3289ba45",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T22:05:00Z"
+      },
+      {
+        "id": "166cbf9f-c2af-4101-b27a-8475a42ccb8a",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T21:00:00Z"
+      },
+      {
+        "id": "77ec3864-3742-42a3-8eeb-2b73ec274f9e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T17:15:00Z"
+      },
+      {
+        "id": "0ad2f9e0-46ef-4dc1-83a6-01c7a1bcdedb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T06:10:00Z"
+      },
+      {
+        "id": "dcae5cbf-4485-48bb-926d-5cc747d9434c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T18:20:00Z"
+      },
+      {
+        "id": "9c66c8f5-94fb-4d8f-b8d9-567bbc50dedc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T07:10:00Z"
+      },
+      {
+        "id": "21232190-620f-4f3e-95c3-d2158718f4fd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T17:30:00Z"
+      },
+      {
+        "id": "4ab7bd6c-79e6-4587-a349-c6dd00f70e55",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T19:40:00Z"
+      },
+      {
+        "id": "c9b267c8-1566-4023-8268-58abda2c0501",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T19:10:00Z"
+      },
+      {
+        "id": "24cead74-85f7-40b9-9a8a-70f136c9b9c5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T17:30:00Z"
+      },
+      {
+        "id": "ed451f61-54c2-4fe3-944f-77a16da62461",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T19:50:00Z"
+      },
+      {
+        "id": "68953c20-51ab-4096-9960-c76787ae12a8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T06:05:00Z"
+      },
+      {
+        "id": "1f8e674c-23cc-4a8e-9335-3c31ab148a30",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T18:50:00Z"
+      },
+      {
+        "id": "efb8c08a-200b-4344-bbc2-f2c539e96b49",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T20:00:00Z"
+      },
+      {
+        "id": "39cd0d37-20c4-4a64-9df4-dce1adb8a37f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T07:45:00Z"
+      },
+      {
+        "id": "83ebf779-1a9d-4827-8d87-cc9a5fac65d9",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T12:05:00Z"
+      },
+      {
+        "id": "a0831bcd-92a2-48f5-8d84-86debc402a16",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T12:45:00Z"
+      },
+      {
+        "id": "b44881b3-858e-4568-9897-81d2a8a37683",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T20:50:00Z"
+      },
+      {
+        "id": "8b90fb0f-e0a7-41ce-86fd-0afe995cb3ce",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T22:45:00Z"
+      },
+      {
+        "id": "e8aae6ec-67d6-403d-a967-5058438c2533",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T08:05:00Z"
+      },
+      {
+        "id": "eb16a7a8-3621-47b5-b9c9-3f614bcdf465",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T06:45:00Z"
+      },
+      {
+        "id": "fa9538d8-f02c-4cf8-9378-4fa4c282c755",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T12:20:00Z"
+      },
+      {
+        "id": "76f5ca49-7916-4d84-978f-3f7953df6dca",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T06:20:00Z"
+      },
+      {
+        "id": "fa3b6f55-43e3-4ea1-971b-4990c18e00ca",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T06:00:00Z"
+      },
+      {
+        "id": "bf3ebe5c-21c0-4449-b903-c5b095121757",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T12:45:00Z"
+      },
+      {
+        "id": "898b7660-68f2-4b3b-bac7-444a13caa21c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T07:00:00Z"
+      },
+      {
+        "id": "e8777474-67f8-4b15-9e69-85a94dcf9bc0",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T18:15:00Z"
+      },
+      {
+        "id": "a7b1c907-b4b8-46c2-a091-cdc4676e5c56",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T12:05:00Z"
+      },
+      {
+        "id": "9817abd3-4aef-4cf0-9e9a-f92c3b56f03e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T18:40:00Z"
+      },
+      {
+        "id": "759d30fe-2c3a-4af5-aac3-0ecdea3376aa",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T22:50:00Z"
+      },
+      {
+        "id": "72057b9c-d96f-4c91-a803-f47e55dab5bb",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T06:00:00Z"
+      },
+      {
+        "id": "5b144172-84b9-48e2-8de8-d8f212a2f8be",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T22:45:00Z"
+      },
+      {
+        "id": "d8957381-d49a-4fd2-b9a1-93ab9fe905d2",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T08:50:00Z"
+      },
+      {
+        "id": "081effaf-9a8a-4cb8-89e0-5a34b2e17fe7",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T06:20:00Z"
+      },
+      {
+        "id": "8d349dc4-fc87-46ee-a3d6-6a616879c935",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T19:10:00Z"
+      },
+      {
+        "id": "3ddde17f-6fb8-4146-9f58-f184fd5174f9",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T19:20:00Z"
+      },
+      {
+        "id": "7105e0b2-ccba-435d-ba31-a6c599c2d3e3",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T06:45:00Z"
+      },
+      {
+        "id": "518f6c85-ff8e-41f9-aa4e-2303a800c6ff",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T19:45:00Z"
+      },
+      {
+        "id": "3ad165c4-3c75-4d30-a258-d25c119363e4",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T18:50:00Z"
+      },
+      {
+        "id": "657c80eb-4402-43f6-885b-620c6680beac",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T07:20:00Z"
+      },
+      {
+        "id": "a1e6e3b6-538e-445c-a6e6-c5b057f30533",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T06:50:00Z"
+      },
+      {
+        "id": "bdf7eb71-0f28-4682-8a28-f13de450175f",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T19:45:00Z"
+      },
+      {
+        "id": "ae1c5cda-40cb-4b21-96fd-aa8f11267da1",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T17:15:00Z"
+      },
+      {
+        "id": "25be82e4-14d3-4038-9391-10ca235734a0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T17:30:00Z"
+      },
+      {
+        "id": "8c8cc6bb-ce0c-45a2-a073-bfca96db8b1e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T20:40:00Z"
+      },
+      {
+        "id": "6ad542ed-592f-47ef-82ee-3cf0e23fbec5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T19:40:00Z"
+      },
+      {
+        "id": "2159464c-8709-4e4f-894a-a0320da4ab75",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T18:40:00Z"
+      },
+      {
+        "id": "6513df9b-1a17-4395-b63c-5c831725c6ed",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T06:05:00Z"
+      },
+      {
+        "id": "b0abf742-bd24-44eb-8163-a53f6401c755",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T19:05:00Z"
+      },
+      {
+        "id": "1f371c03-e9eb-4463-909d-e845e3322b71",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T17:40:00Z"
+      },
+      {
+        "id": "a19d1805-79d9-4eed-b595-4bc12f047c49",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T07:50:00Z"
+      },
+      {
+        "id": "e8411684-e131-49bb-8dc7-25c116ddc559",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T18:05:00Z"
+      },
+      {
+        "id": "1ff04d43-c357-4b80-a0ee-0022aaa6f4a1",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T12:10:00Z"
+      },
+      {
+        "id": "8ae61546-1ddb-435f-8ec4-cae2320e082f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T21:30:00Z"
+      },
+      {
+        "id": "c9c23f05-2321-4247-bca5-8466d01b1b37",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T19:50:00Z"
+      },
+      {
+        "id": "bc53860e-ff5f-4d48-ad9c-01a8c55e97e4",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T22:20:00Z"
+      },
+      {
+        "id": "c8b4bdca-8ab9-46d7-b84c-d0cb153d53b8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T19:10:00Z"
+      },
+      {
+        "id": "6a96db36-95ce-4740-83e0-adff25ecdd9a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T18:20:00Z"
+      },
+      {
+        "id": "994fae68-9e9c-431a-9c6d-1cd694740300",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T17:50:00Z"
+      },
+      {
+        "id": "bb1c2ab6-a4f8-4304-bff5-aa04d1aca665",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T18:50:00Z"
+      },
+      {
+        "id": "eb08b8d6-d127-49b9-a368-a415fb490cfe",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T17:15:00Z"
+      },
+      {
+        "id": "6d79285d-d17b-4d53-aee9-835479873e6e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T18:50:00Z"
+      },
+      {
+        "id": "ddcfc4a7-58fe-4f15-b681-2ca009319223",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T22:05:00Z"
+      },
+      {
+        "id": "edad31a7-da80-4c47-abd9-fdfea39de9d8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T19:00:00Z"
+      },
+      {
+        "id": "9ac85a0a-97d0-4788-9255-34615631e14c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T17:30:00Z"
+      },
+      {
+        "id": "833e6d04-b941-4b8e-a098-ea34c7419d00",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T19:10:00Z"
+      },
+      {
+        "id": "4d4d8148-8848-42a5-b961-311779241afd",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T19:15:00Z"
+      },
+      {
+        "id": "d5b99411-c5fa-430f-b858-7eba776fd559",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T20:50:00Z"
+      },
+      {
+        "id": "d6cede4f-93d3-4b44-ab95-0c8223be936b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T12:50:00Z"
+      },
+      {
+        "id": "1662a076-d642-4ba1-81b8-8b9908fd13ec",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T08:05:00Z"
+      },
+      {
+        "id": "87a94420-6414-4270-9f21-618cbdb30904",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T18:05:00Z"
+      },
+      {
+        "id": "97cd940a-d674-49f9-9aec-1da67e32e749",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T21:15:00Z"
+      },
+      {
+        "id": "22acf519-d4fa-478b-8393-1e3ef8d47e4a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T21:15:00Z"
+      },
+      {
+        "id": "18e78c26-7b39-4fde-834e-55f10d42ef64",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T07:15:00Z"
+      },
+      {
+        "id": "e24ad07e-51d7-4696-976e-ac7833f9b917",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T07:10:00Z"
+      },
+      {
+        "id": "0387ebfd-421d-4d92-9f84-01cb192cc274",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T20:10:00Z"
+      },
+      {
+        "id": "5a805005-f30b-41ff-97c4-a1c13e8aade5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T17:40:00Z"
+      },
+      {
+        "id": "a8ded7e3-ae0b-4a5d-8613-8959b1f33ff8",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T19:30:00Z"
+      },
+      {
+        "id": "016b0c49-57b1-4dcf-875c-38b95e45908b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T06:00:00Z"
+      },
+      {
+        "id": "2158d145-2979-409b-9b77-66a91d68c0e0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T17:30:00Z"
+      },
+      {
+        "id": "8e78bb3b-ae46-45f6-8426-3da59e1d0bed",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T22:15:00Z"
+      },
+      {
+        "id": "0d165438-91e3-4a45-8438-8c18ee6fbd3d",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T17:20:00Z"
+      },
+      {
+        "id": "e02859f9-3208-48c9-ac24-975a7a682800",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T21:20:00Z"
+      },
+      {
+        "id": "1c225e70-11da-4004-966d-149a663b6122",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T18:30:00Z"
+      },
+      {
+        "id": "0023d22c-2c25-4c5b-91e0-fc9800c4d52f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T20:05:00Z"
+      },
+      {
+        "id": "949f89e6-6136-4886-b58c-f00efe37d7b5",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T18:15:00Z"
+      },
+      {
+        "id": "e1928346-8e6c-4fb8-976f-0d0e78184823",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T07:50:00Z"
+      },
+      {
+        "id": "ce839a12-7ff6-46c8-ab36-84751f92790d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T21:40:00Z"
+      },
+      {
+        "id": "5032adce-1760-4e58-9bdd-029830c1ee6e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T19:05:00Z"
+      },
+      {
+        "id": "476828fa-5d7b-47ca-ab05-265521e4c16d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T12:10:00Z"
+      },
+      {
+        "id": "417ad5b5-bdf0-48fc-bba9-058104ccf414",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T18:50:00Z"
+      },
+      {
+        "id": "154a16ee-17cd-45c5-9933-0562a95a8b96",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T12:05:00Z"
+      },
+      {
+        "id": "e258e1cd-9723-41e4-9866-5f895d10b9fa",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T12:00:00Z"
+      },
+      {
+        "id": "a8cac8e2-2706-4f08-ad4f-84989374f32d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T07:40:00Z"
+      },
+      {
+        "id": "54a61a5b-3045-441e-b8ec-b4ed6300f86f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T07:45:00Z"
+      },
+      {
+        "id": "d501275e-20b5-4dbd-bd07-c0f994fe786c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T19:05:00Z"
+      },
+      {
+        "id": "04785b9e-db80-4d33-9fd8-abe203716d48",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T08:45:00Z"
+      },
+      {
+        "id": "adacffd9-9bb3-4d6b-87b5-e14f2c6b47a1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T17:10:00Z"
+      },
+      {
+        "id": "929e4558-d8e9-474f-85de-6450e3ba26c3",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T06:10:00Z"
+      },
+      {
+        "id": "60481e94-35f8-4ff3-a393-545fcf35cd3d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T18:10:00Z",
+        "note": "Short entry, still counts"
+      },
+      {
+        "id": "69548c80-a1bd-4ed2-987a-75a0a157db6b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T08:15:00Z"
+      },
+      {
+        "id": "fd60fff8-7735-4ae5-8a12-75d27dc8c60e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T07:20:00Z"
+      },
+      {
+        "id": "5a753909-bad0-4eea-be5c-0dc20169a565",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T19:10:00Z"
+      },
+      {
+        "id": "f26bdfe7-cc49-40b7-adbe-9e88bf0a57b3",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T12:05:00Z"
+      },
+      {
+        "id": "6c6848eb-be20-4efd-bda5-1f6609590994",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T19:10:00Z"
+      },
+      {
+        "id": "da1496d2-f750-4699-bf22-9ffd4e631d58",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T06:20:00Z"
+      },
+      {
+        "id": "92f70184-1544-43a2-b619-cabc1673353a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T20:05:00Z"
+      },
+      {
+        "id": "c41f8fbd-b0b7-43c7-9024-10325c5c82d3",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T06:00:00Z"
+      },
+      {
+        "id": "60c92c38-f530-4552-9e71-832ed3ad7e58",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T12:10:00Z"
+      },
+      {
+        "id": "f7b05b88-f85a-40dd-bb96-5767427bd7b3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T19:40:00Z"
+      },
+      {
+        "id": "8d29429e-6dd4-40c5-85cc-49c29fb05cde",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T18:45:00Z"
+      },
+      {
+        "id": "f8f5f035-24e2-4f2a-b525-be83da3d17e9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T21:05:00Z"
+      },
+      {
+        "id": "452450b4-d14f-4855-b303-727985db87fa",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T20:30:00Z"
+      },
+      {
+        "id": "06608f61-1f16-46b9-8b25-e493432e4748",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T21:50:00Z"
+      },
+      {
+        "id": "3218c628-addb-40a2-ad28-433b2c2f74dd",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T22:30:00Z"
+      },
+      {
+        "id": "cc4e104d-1854-43fc-81c4-cb2585a5bb3b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T21:10:00Z"
+      },
+      {
+        "id": "87e9bf54-b72c-4702-8169-dcdce742ed64",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T12:45:00Z"
+      },
+      {
+        "id": "5f7d9d02-d6e0-4463-9123-edbfdc54597a",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T17:10:00Z"
+      },
+      {
+        "id": "b3975102-dc27-40ce-af94-0273a21752c8",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T21:45:00Z"
+      },
+      {
+        "id": "04fdcc98-95c7-4a98-94d4-7e44a8e07033",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T12:15:00Z"
+      },
+      {
+        "id": "53233a33-0827-491b-8759-fdef6740d7dc",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T12:00:00Z"
+      },
+      {
+        "id": "ea26ac63-d7ad-42da-ad51-8c95fc13f990",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T07:15:00Z"
+      },
+      {
+        "id": "66bfb5ea-df90-4622-b2cf-e365761451af",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T20:50:00Z"
+      },
+      {
+        "id": "39ea3e2a-c4bc-439a-a583-ce8fc5bb63a1",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T17:50:00Z"
+      },
+      {
+        "id": "ba6e861b-45e5-42cf-8bea-df9f4795eec4",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T17:30:00Z"
+      },
+      {
+        "id": "7bc18f7a-d391-4841-a3d7-1f24dc794834",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T12:20:00Z"
+      },
+      {
+        "id": "b87f4dbb-a065-497d-a9e1-b69bdf9012e4",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T17:10:00Z"
+      },
+      {
+        "id": "014ee5b9-3712-4452-a754-9ebf0c441168",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T20:30:00Z"
+      },
+      {
+        "id": "5266c8ef-1356-4b44-b714-31adceac8b53",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T06:05:00Z"
+      },
+      {
+        "id": "b41b1bc2-260b-45e8-b2c9-9af4173fce49",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T19:40:00Z"
+      },
+      {
+        "id": "9f5ce9c1-568d-47d8-b0f6-163eb28f6997",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T20:05:00Z"
+      },
+      {
+        "id": "629459fd-08e3-451d-aab5-5791c30d2d26",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T21:15:00Z"
+      },
+      {
+        "id": "d98c85ef-852b-445c-a962-7d7b1d0f91d7",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T17:20:00Z"
+      },
+      {
+        "id": "f1056fd4-73d0-400e-bf3b-82e155071041",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T20:30:00Z"
+      },
+      {
+        "id": "2df1661d-d3df-43e6-9f06-200cb64f88e1",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T17:15:00Z"
+      },
+      {
+        "id": "30ff1deb-d8f7-4369-9914-bae8c9623143",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T06:45:00Z"
+      },
+      {
+        "id": "59b63913-9a84-4853-83c0-b5a2344f10c5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T18:00:00Z"
+      },
+      {
+        "id": "f52d3baf-56e5-4118-b81b-e3bd55a1babc",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T22:45:00Z"
+      },
+      {
+        "id": "7629d9ea-98b0-497e-81cb-83fd2c323ff7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T12:10:00Z"
+      },
+      {
+        "id": "feb7ff3b-241b-47c6-b063-ceb6b77e1b93",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T08:10:00Z"
+      },
+      {
+        "id": "68b92395-b91c-4917-8f6e-bc06ee54bbad",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T22:50:00Z"
+      },
+      {
+        "id": "7949ea30-1d84-4e93-bbab-c290a5b801a9",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T06:15:00Z"
+      },
+      {
+        "id": "682143e4-6459-4d03-80ff-44b0e551c848",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T08:15:00Z"
+      },
+      {
+        "id": "1dee22a2-30d1-47f3-8ac9-830dcdfa0c15",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T06:30:00Z"
+      },
+      {
+        "id": "1aee0152-7467-4adb-89b0-fa826821b920",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T20:10:00Z"
+      },
+      {
+        "id": "cb2fe284-0c38-4fb2-8443-f29cb1ed43ef",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T18:05:00Z"
+      },
+      {
+        "id": "c1b5d4c9-10c4-4e31-867d-fef3cba807b2",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T21:40:00Z"
+      },
+      {
+        "id": "a62c22f9-b0b3-4aef-be1d-90af93913429",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T08:30:00Z"
+      },
+      {
+        "id": "7b425e0b-a345-4cc2-bc21-e1f58081c710",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T21:00:00Z"
+      },
+      {
+        "id": "961524c4-8e67-41c3-9c67-9ecebab5fdd6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T22:40:00Z"
+      },
+      {
+        "id": "132fba31-0934-466f-bdf4-5a1703dd6ea8",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T18:45:00Z"
+      },
+      {
+        "id": "46a8da68-70f9-40ba-8a7b-f6770cd31b8a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T19:10:00Z"
+      },
+      {
+        "id": "741a0c6e-ee40-4fa0-b912-267f2c8ef43a",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T12:15:00Z"
+      },
+      {
+        "id": "162e4e05-e8bd-4d70-9c02-6a3a23edcba6",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T08:30:00Z"
+      },
+      {
+        "id": "cd19ea87-3730-4089-8e32-c5f01b838d83",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T19:00:00Z"
+      },
+      {
+        "id": "ccaba349-5050-4290-a41b-6095d9ba3249",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T07:15:00Z"
+      },
+      {
+        "id": "0463d475-f113-4120-af30-9451b6fbcc20",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T08:40:00Z"
+      },
+      {
+        "id": "42820ded-757a-4a8b-94e9-0098f3725eb7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T21:20:00Z"
+      },
+      {
+        "id": "e42cbe6b-4809-4acf-94c6-27f53f1107b3",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T21:20:00Z"
+      },
+      {
+        "id": "3cdf6e28-2ee5-4bce-8079-30d4fc955976",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T12:05:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "a40174b4-a198-48bc-848b-cb9aa025010c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T17:40:00Z"
+      },
+      {
+        "id": "e02ded72-262d-467d-8ddf-4acd88d2860d",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T19:30:00Z"
+      },
+      {
+        "id": "ce1504b9-932d-4403-883d-57ce4718b0ba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T12:15:00Z"
+      },
+      {
+        "id": "46624ff4-2fa3-4587-a876-a47097dc3f9f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T08:20:00Z"
+      },
+      {
+        "id": "05750ab9-231a-43dc-89a8-40257bd08e51",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T20:45:00Z"
+      },
+      {
+        "id": "a3593073-0e04-423c-bb0d-063b3a53f91e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T18:00:00Z"
+      },
+      {
+        "id": "1e61f2f0-76cf-462e-8535-93170d754110",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T17:20:00Z"
+      },
+      {
+        "id": "d5dc7865-9583-4004-9784-7d6ac2bab4d5",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T19:50:00Z"
+      },
+      {
+        "id": "60256bd0-c4e7-40be-8941-232b5f7b003e",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T21:00:00Z"
+      },
+      {
+        "id": "17bb8208-e4b2-4676-9af6-2875e12037b8",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T07:15:00Z"
+      },
+      {
+        "id": "0e316bcf-7efa-442d-9243-d66d3c0302eb",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T19:40:00Z"
+      },
+      {
+        "id": "e5d2add3-cb05-4fd9-aede-96cab3de69d6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T12:50:00Z"
+      },
+      {
+        "id": "5a937db1-d3a1-431c-aae8-a8e48eebaaeb",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T19:15:00Z"
+      },
+      {
+        "id": "4b98669a-001e-457d-a742-db14f446402d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T18:00:00Z"
+      },
+      {
+        "id": "1f3cb3e9-87b8-4e7b-a2a7-4bd2dd00c69f",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T20:50:00Z"
+      },
+      {
+        "id": "214f5f2a-ef9f-4b98-8e06-126060dce3f6",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T22:15:00Z"
+      },
+      {
+        "id": "84d9b575-299b-4f91-9564-9f75411212a7",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T07:10:00Z"
+      },
+      {
+        "id": "bd2e23bd-2c26-40ea-baed-8ccef17be58d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T21:10:00Z"
+      },
+      {
+        "id": "c3a7de6c-774e-464a-a9f2-b069ab634b8a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T18:00:00Z"
+      },
+      {
+        "id": "dd7dba06-05b6-45eb-bd28-7f5f46117727",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T12:10:00Z"
+      },
+      {
+        "id": "9a4aa0b5-63fe-4f53-902a-a2fb7a7d6770",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T20:10:00Z"
+      },
+      {
+        "id": "916bcb98-bdd7-4541-af23-a08315aab708",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T06:45:00Z"
+      },
+      {
+        "id": "b86dd1ee-8060-49a4-909f-9180c98fb4c6",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T12:30:00Z"
+      },
+      {
+        "id": "2aa21d9d-b71b-43e2-b0f6-29b5551889a7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T18:05:00Z"
+      },
+      {
+        "id": "3f636618-200e-43fc-a66f-dd83862f7d22",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T22:00:00Z"
+      },
+      {
+        "id": "640925c0-6fcb-490e-ad3c-478bd6c02916",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T17:40:00Z"
+      },
+      {
+        "id": "87dc9754-e3e6-45d3-88f2-6401ea1f8e76",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T12:45:00Z"
+      },
+      {
+        "id": "0fe3506c-d3d4-4209-a9a6-3e936bb514af",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T20:05:00Z"
+      },
+      {
+        "id": "7a6dbcbb-a36d-4805-bc30-f942a84e3511",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T08:40:00Z"
+      },
+      {
+        "id": "53afe94e-68d1-4eeb-b2a5-0317cff47935",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T18:30:00Z"
+      },
+      {
+        "id": "3ddcce7b-8074-434f-a5ce-c82e18a34452",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T08:20:00Z"
+      },
+      {
+        "id": "851a793e-3176-4c84-93d6-fe445fa320ec",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T07:15:00Z"
+      },
+      {
+        "id": "2402fc78-39b0-4b18-a524-a55f00fb84a5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T07:05:00Z"
+      },
+      {
+        "id": "b0eebafc-c683-4caf-ac9a-3880fde7aa9d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T06:45:00Z"
+      },
+      {
+        "id": "8a487b2b-643b-4bcc-a801-89a11937ca06",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T22:50:00Z"
+      },
+      {
+        "id": "eb790cc6-08da-4968-af9a-8a6636711920",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T19:00:00Z"
+      },
+      {
+        "id": "e7e6d147-80e7-43b1-a41b-46ff6a65412f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T06:00:00Z"
+      },
+      {
+        "id": "0eef33e5-2b4a-4cdf-9e14-f15c919d56fe",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T19:45:00Z"
+      },
+      {
+        "id": "f306cb42-a119-4946-8d27-6d71471a3101",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T20:05:00Z"
+      },
+      {
+        "id": "b98a26b4-8849-413d-8a3b-f02856ea5bfd",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T06:30:00Z"
+      },
+      {
+        "id": "b29222bb-7116-41ed-9abb-e2d14fd1c546",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T06:05:00Z"
+      },
+      {
+        "id": "6090b5ae-da70-410d-9c39-ae2d3a3b73c7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T08:45:00Z"
+      },
+      {
+        "id": "c237a135-8219-4643-9517-6d0c1acf4538",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T19:10:00Z"
+      },
+      {
+        "id": "8e5d86cd-2af9-47cb-897c-3f1202cf6856",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T07:10:00Z"
+      },
+      {
+        "id": "b6a71722-2536-4d47-88e7-687ef6124c99",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T21:45:00Z"
+      },
+      {
+        "id": "4e236335-e5da-40d5-bfe7-a56affacde73",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T19:45:00Z"
+      },
+      {
+        "id": "a6ce3626-ae1f-46ca-a6d3-cec8882ca1d6",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T22:50:00Z"
+      },
+      {
+        "id": "409c6163-bbf6-453e-8117-d8f0701b01f0",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T18:30:00Z"
+      },
+      {
+        "id": "b0a1822d-10cf-4cc1-8673-61c9415e900f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T08:10:00Z"
+      },
+      {
+        "id": "d792a749-ba89-4642-8994-fa17bf01df92",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T17:20:00Z"
+      },
+      {
+        "id": "acbab166-2b21-4f32-a9c7-565dc3f4f79f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T08:15:00Z"
+      },
+      {
+        "id": "2816f127-3aa8-47ec-b582-a26bc08a1621",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T21:50:00Z"
+      },
+      {
+        "id": "079700ab-4364-4eed-8df2-61135aaaae7d",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T18:50:00Z"
+      },
+      {
+        "id": "b3c7adbf-c266-4d0b-87a3-139c1067d69a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T19:40:00Z"
+      },
+      {
+        "id": "0539398b-4ea7-43a8-8967-a2ebf7042aba",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T21:05:00Z"
+      },
+      {
+        "id": "061d4289-3da8-4654-a68b-774ccc42ab4d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T22:40:00Z"
+      },
+      {
+        "id": "4ecf26e3-d17a-4802-bcfe-b7f122453ee7",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T20:15:00Z"
+      },
+      {
+        "id": "1ad25bb1-dbeb-4224-a909-1c2559ee58c7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T21:45:00Z"
+      },
+      {
+        "id": "1105ae35-9f72-47de-8a84-0b636974349a",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T19:05:00Z"
+      },
+      {
+        "id": "1ff9ae8e-9680-4d92-8978-fc44593cccf0",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T22:30:00Z"
+      },
+      {
+        "id": "1429368d-4d49-4b57-801c-9a4fc8b6b252",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T20:30:00Z"
+      },
+      {
+        "id": "5e5e2a9e-516d-45eb-9042-f05fc1663c26",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T08:00:00Z"
+      },
+      {
+        "id": "e48f3b83-3715-4154-bcd1-445821eb667c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T12:40:00Z"
+      },
+      {
+        "id": "a113860a-68de-488f-86df-35090f246b87",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T22:05:00Z"
+      },
+      {
+        "id": "066b74b3-5313-4331-83af-1064848c7787",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T07:20:00Z"
+      },
+      {
+        "id": "10626249-368c-402d-b554-3a53fdf54a62",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T22:15:00Z"
+      },
+      {
+        "id": "24da8e17-3725-4222-8b6d-c93adfa884bc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T20:30:00Z"
+      },
+      {
+        "id": "77f20053-8a62-46a4-8d04-2fd18a7f142d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T17:40:00Z"
+      },
+      {
+        "id": "0fa3c351-4358-48fe-8ec4-bc36179baf26",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T22:10:00Z"
+      },
+      {
+        "id": "5a8199fd-6187-4471-9699-c71df3ccca86",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T08:15:00Z"
+      },
+      {
+        "id": "7ae092f6-bdfc-4253-98c9-e414d472a139",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T17:40:00Z"
+      },
+      {
+        "id": "302a4c45-a053-4d33-a35e-7463dfd54589",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T07:30:00Z"
+      },
+      {
+        "id": "9282cd59-503f-44fc-ad29-4ad40e01b553",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T19:10:00Z"
+      },
+      {
+        "id": "8bbd29e3-e29a-4ff7-ad94-db0628d5762f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T19:50:00Z"
+      },
+      {
+        "id": "02acfae8-9733-4dd1-bcfe-49e9c3356ef0",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T17:20:00Z"
+      },
+      {
+        "id": "79e51a44-f912-45dd-84ab-84fbd2360eaf",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T22:40:00Z"
+      },
+      {
+        "id": "79b0ae02-c5fd-4cae-bff8-0aa3e68b7729",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T12:50:00Z"
+      },
+      {
+        "id": "4d271960-4970-4954-b443-dea8025a0fe3",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T20:15:00Z"
+      },
+      {
+        "id": "e104ee37-0a79-4dbd-95bd-48ce68c0b3c9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T20:40:00Z"
+      },
+      {
+        "id": "d51ace25-7bc9-496c-a7ac-bb222826bc3f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T12:40:00Z"
+      },
+      {
+        "id": "ec3f735e-81ea-4a4f-8064-b6ce79e939b5",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T20:15:00Z"
+      },
+      {
+        "id": "cac722b0-d7e3-4158-962d-c78288b5faeb",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T07:20:00Z"
+      },
+      {
+        "id": "36b77d8b-4573-415e-8680-ca977445ca0f",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T17:10:00Z"
+      },
+      {
+        "id": "f4de656d-78e5-42b7-b326-6ed85f95d6ee",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T20:05:00Z"
+      },
+      {
+        "id": "be1ef6d0-51d6-4dc5-be08-8dd30d66888d",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T19:05:00Z"
+      },
+      {
+        "id": "219a4b2b-2b6a-4a2d-a83e-68538ac19e16",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T07:15:00Z"
+      },
+      {
+        "id": "08f212f0-b779-46a8-b2bc-7858ecd75682",
+        "habitId": "2713d127-fc67-423a-adc2-52f9684026db",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T19:05:00Z"
+      },
+      {
+        "id": "ce72c20c-65eb-4bf2-bd82-074b7614abca",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T20:00:00Z"
+      },
+      {
+        "id": "7cc6ca15-21b7-46e9-85d0-3faca9b2f091",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T08:05:00Z"
+      },
+      {
+        "id": "b8af4004-fd73-44ee-9f40-f40635fa4648",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T22:15:00Z"
+      },
+      {
+        "id": "6d6b8da2-f03f-4a06-aaf1-dfc6e75f00fb",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T21:15:00Z"
+      },
+      {
+        "id": "208ea36b-29eb-44ff-af3d-55f0a9dee532",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T19:00:00Z"
+      },
+      {
+        "id": "c65b4695-c3cb-4f88-bad3-e8a36be4c27b",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T20:20:00Z"
+      },
+      {
+        "id": "e3cda571-6642-49fe-8983-ac982e3ae31c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T07:20:00Z"
+      },
+      {
+        "id": "11ec43c8-3527-4172-a01d-7c1a93679f4a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T20:20:00Z"
+      },
+      {
+        "id": "350916b8-ff9b-4387-ba0f-e970e1cff078",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T21:00:00Z"
+      },
+      {
+        "id": "a11be7fc-0607-4a72-bf03-737a8ef9ec72",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T07:45:00Z"
+      },
+      {
+        "id": "29a7ff82-4b8b-49c1-a717-9f5cb27e8dcf",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T21:45:00Z"
+      },
+      {
+        "id": "d0c387eb-9e5b-48df-ba75-472500763a71",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T21:30:00Z"
+      },
+      {
+        "id": "1014cc2b-e6fb-42de-a226-e3c609bce62f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T17:20:00Z"
+      },
+      {
+        "id": "f6f46ce3-5516-44a3-9b66-6636c0aaf9db",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T12:50:00Z"
+      },
+      {
+        "id": "0a586d62-1c43-4eba-ac3d-cdfd5964940d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T07:20:00Z"
+      },
+      {
+        "id": "8b80ce83-8dca-4167-9b43-0c0fa98fe0fc",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T12:40:00Z"
+      },
+      {
+        "id": "cbcc65e1-74bc-4245-9c9c-5a988d9d1f4a",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T21:50:00Z"
+      },
+      {
+        "id": "45d118b3-8a23-4650-82a3-78c64fb58891",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T17:45:00Z"
+      },
+      {
+        "id": "bdc034ae-9812-4051-97c2-1e13abcbc361",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T20:45:00Z"
+      },
+      {
+        "id": "d2ac230b-fb94-40f7-8f35-ba34dc15d259",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T08:50:00Z"
+      },
+      {
+        "id": "61620108-462c-4b7f-9ef0-796ace7680a0",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T12:20:00Z"
+      },
+      {
+        "id": "00239f87-0ad4-4663-914d-d600dcaf2999",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T08:45:00Z"
+      },
+      {
+        "id": "3ec0a8fa-38b8-4e8e-9ecd-6d9dc30cb1c9",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T20:10:00Z"
+      },
+      {
+        "id": "ba685fcb-4afd-4d43-afac-9bdb6bd49c62",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T20:10:00Z"
+      },
+      {
+        "id": "203e5004-0cd8-4794-9a4a-395f943701bb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T17:10:00Z"
+      },
+      {
+        "id": "fa2f6fbc-a9d9-4dd7-bf39-e4e780dba353",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T12:50:00Z"
+      },
+      {
+        "id": "42ddc89f-338c-42b9-9924-055f50236daa",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T07:30:00Z"
+      },
+      {
+        "id": "ee8a14ee-43ee-415a-9d0d-a545aa26a60c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T21:10:00Z"
+      },
+      {
+        "id": "dc5b4c5d-28fc-4e96-9edb-bad4b711ab0f",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T12:00:00Z"
+      },
+      {
+        "id": "f3a486b6-5f1a-4618-8e58-5388feb83271",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T06:50:00Z"
+      },
+      {
+        "id": "75520dc6-ea01-4734-b889-e1d0d7e14a91",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T18:45:00Z"
+      },
+      {
+        "id": "6cbd2626-e667-4916-9db3-c0e749ed45b1",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T17:05:00Z"
+      },
+      {
+        "id": "db90cce9-e4e8-4b2b-9f57-8a9a82965c43",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T12:40:00Z"
+      },
+      {
+        "id": "e2c29368-3d16-4dea-b590-bcbfd420779f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:15:00Z"
+      },
+      {
+        "id": "c41980c9-e049-411d-be38-e267a9dd6462",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T19:40:00Z"
+      },
+      {
+        "id": "8cb0b24f-a597-4c15-afa8-647bacbae9e1",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:20:00Z"
+      },
+      {
+        "id": "d0f9a153-c19a-4b13-a977-3472e5ad6959",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T20:20:00Z"
+      },
+      {
+        "id": "1bb68894-874c-4cc5-95db-c71e99b08f27",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T12:05:00Z"
+      },
+      {
+        "id": "033430b4-4790-4635-bce3-08b1ecfed86e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T20:10:00Z"
+      },
+      {
+        "id": "6ce66fdd-46b3-4763-a2d2-39519ed402a0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T21:05:00Z"
+      },
+      {
+        "id": "c5a58e8b-8024-4325-a6af-ec45584b8f5c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:50:00Z"
+      },
+      {
+        "id": "0bdbc2fa-6db6-44b0-a76b-2fe3f43526f5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:30:00Z"
+      },
+      {
+        "id": "7c736963-45a1-4816-94e0-514d5497000b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T17:10:00Z"
+      },
+      {
+        "id": "1b98b99d-828f-4a38-abfc-7a4377d8f1b7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T19:50:00Z"
+      },
+      {
+        "id": "928da601-5b22-412f-a6d7-27d95e1aa00f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T22:40:00Z"
+      },
+      {
+        "id": "a75e48c9-25c1-44af-8fe2-8b7e10f01b47",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T17:45:00Z"
+      },
+      {
+        "id": "f54108de-07cb-4ea3-a930-43d79339e11b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T07:30:00Z"
+      },
+      {
+        "id": "955a2cf0-d774-43d6-afa3-4fd20e73c05f",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T20:20:00Z"
+      },
+      {
+        "id": "6d1b3b7d-7c3d-4051-9fa8-678068c4087b",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T07:50:00Z"
+      },
+      {
+        "id": "d30230a7-42e8-4701-9d3f-d20b441864e0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T12:50:00Z"
+      },
+      {
+        "id": "6c68eecf-0021-4d3d-98c4-4ec00a83fc6f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T21:45:00Z"
+      },
+      {
+        "id": "61e0ad0a-c9a2-41b8-a59c-cbe78ad50f0a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T07:20:00Z"
+      },
+      {
+        "id": "6f534102-02ed-432a-ac84-b8293c2cd6b8",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T19:40:00Z",
+        "note": "Reviewed groceries"
+      },
+      {
+        "id": "7e1c3e73-fdb1-40e0-865e-a933d3a921d8",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T08:15:00Z"
+      },
+      {
+        "id": "9c081895-7912-4d81-9c65-e04434e4dc46",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T07:30:00Z"
+      },
+      {
+        "id": "a57039cc-2f69-4fbe-b7c3-e95d97613686",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T22:30:00Z"
+      },
+      {
+        "id": "d582dde0-d72f-4bff-ae45-f469c2cb26e8",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T21:45:00Z"
+      },
+      {
+        "id": "4e715014-57b5-46ef-8574-fbbd4dd8be62",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T12:45:00Z"
+      },
+      {
+        "id": "74dac28b-8fa9-4e94-aab9-82338af19127",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T19:40:00Z"
+      },
+      {
+        "id": "f74d7365-dced-4a44-a6f6-92041e9dfb12",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T06:50:00Z"
+      },
+      {
+        "id": "2d4878d7-858e-43d6-a994-1089c15ac8e6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T18:10:00Z"
+      },
+      {
+        "id": "4c0f79de-3b13-499d-854a-d6e239b256e2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T22:15:00Z"
+      },
+      {
+        "id": "09bce33b-f0a9-4f4d-96cd-5a65dcc32699",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T08:00:00Z"
+      },
+      {
+        "id": "373e20d1-c44a-4587-941e-b46ef113eca9",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T18:45:00Z"
+      },
+      {
+        "id": "83e7bf7e-581e-4985-aa64-9070ad20cfcd",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T08:45:00Z"
+      },
+      {
+        "id": "301dd789-696f-439a-922f-d805bd16eb64",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T19:10:00Z"
+      },
+      {
+        "id": "35b7dcc7-5c5a-4c7e-8075-0651b533b23f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T17:20:00Z"
+      },
+      {
+        "id": "7bf26c21-6211-4920-93d9-2b98cce68afe",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T06:10:00Z"
+      },
+      {
+        "id": "8e652b76-cd31-4e6d-9108-d3ac8a9fa056",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T17:15:00Z"
+      },
+      {
+        "id": "294c9617-b373-4a0a-8aa9-95cc38f66a50",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T22:00:00Z"
+      },
+      {
+        "id": "59d933bb-c343-4efd-a8e0-1ca8c3f5a11f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T12:50:00Z"
+      },
+      {
+        "id": "9e6ae671-a7c1-47b6-8fbd-2a599d2bc4f3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T17:00:00Z"
+      },
+      {
+        "id": "b5cd7fcf-ed02-452a-857c-cd68a0464373",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T18:20:00Z"
+      },
+      {
+        "id": "1e939b7d-62bc-47bc-9d3a-d1701641baf8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T17:15:00Z"
+      },
+      {
+        "id": "d37d3f1b-c291-444d-8cf6-1d810da83384",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T17:10:00Z"
+      },
+      {
+        "id": "73964f43-6809-4570-961e-6b60b8f54e2b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T12:15:00Z"
+      },
+      {
+        "id": "364943fb-4419-49df-854d-002e5f4057e0",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T21:15:00Z"
+      },
+      {
+        "id": "86f6cc36-54a5-4cb7-bb46-80fc411bc98b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T06:10:00Z"
+      },
+      {
+        "id": "0217cc05-3f85-4002-81e6-99cbb6fc531e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T18:45:00Z"
+      },
+      {
+        "id": "f8a28e69-9db6-4d21-aa52-ed150f55aad5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T07:20:00Z"
+      },
+      {
+        "id": "c99296cf-b7de-4631-a22b-574c72a6e818",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T22:05:00Z"
+      },
+      {
+        "id": "645e91ce-e6a9-4083-894c-1ed7600e1ac1",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T12:10:00Z"
+      },
+      {
+        "id": "49d1dbf0-7374-4c98-9912-438a331df8b7",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T17:05:00Z"
+      },
+      {
+        "id": "051e798e-ba7f-4355-94aa-b0ef5af48d04",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T20:40:00Z"
+      },
+      {
+        "id": "e8196111-3b89-4a7a-86a4-62080a30940c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T20:30:00Z"
+      },
+      {
+        "id": "d8aedd3b-0ac1-4218-8bbb-a14dde2b8f2d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T07:00:00Z"
+      },
+      {
+        "id": "144a27e2-9635-4ccb-a441-54e9f14ec078",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T07:05:00Z"
+      },
+      {
+        "id": "33b681a7-104e-4a66-83c9-465d52e2c05f",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T08:10:00Z"
+      },
+      {
+        "id": "e4e1510f-9506-410c-890d-5f1746a5f74f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T17:10:00Z"
+      },
+      {
+        "id": "9305b15a-826b-4924-ae54-79287228cc5b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T12:45:00Z"
+      },
+      {
+        "id": "a80aa9c8-3db8-4ab8-9ba7-5e6d90378987",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T18:30:00Z"
+      },
+      {
+        "id": "e225c8cd-c4da-4037-8836-d9eb96b5d6d9",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T22:00:00Z"
+      },
+      {
+        "id": "6082060f-f8c7-41da-bdd0-4dc0abeacdd0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T18:50:00Z"
+      },
+      {
+        "id": "8d229623-5868-4a8f-812e-1923f686bdc5",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T20:15:00Z"
+      },
+      {
+        "id": "8bcaf650-bc5e-4fa2-87d6-bcfe4bd6bb69",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T20:40:00Z"
+      },
+      {
+        "id": "cceb6548-82f8-446f-af70-191658550039",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T20:10:00Z"
+      },
+      {
+        "id": "e8a71b0e-504b-40bf-9274-1956305fa2c0",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T06:20:00Z"
+      },
+      {
+        "id": "be25298b-26c4-43a7-a190-e8699bb975fb",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T20:50:00Z"
+      },
+      {
+        "id": "5ab6ad86-ff10-474f-a3d6-60131ee4695f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T20:00:00Z"
+      },
+      {
+        "id": "eb3c6e2f-9664-47a7-9f53-8686ecad88c1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T08:05:00Z"
+      },
+      {
+        "id": "89798584-b941-4a28-bedd-1cd48291b4a5",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T18:45:00Z"
+      },
+      {
+        "id": "b6215258-5161-4cf1-865b-d7b5d17906d4",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T12:05:00Z"
+      },
+      {
+        "id": "d0459ac3-749c-425a-b684-e0716606d509",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T07:45:00Z"
+      },
+      {
+        "id": "081bab5b-cbea-4be4-a3a0-95e5fc4ab2ae",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T19:15:00Z"
+      },
+      {
+        "id": "c48df0d3-0ac7-425b-b16e-8ee12c095c02",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T18:00:00Z"
+      },
+      {
+        "id": "bc724b4d-7281-4e65-8f59-e881b6b5065d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T08:15:00Z"
+      },
+      {
+        "id": "a7444319-0d8f-4cd9-8078-2cc2c4a501fd",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T22:05:00Z"
+      },
+      {
+        "id": "b27dba78-8803-47ef-8ae9-6575a8619a03",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T19:10:00Z"
+      },
+      {
+        "id": "5f25d9c3-eb6d-44de-8660-09d2adb2e4fc",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T07:15:00Z"
+      },
+      {
+        "id": "891deae9-6622-4e66-b90d-35f6ed435f25",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T21:10:00Z"
+      },
+      {
+        "id": "658b9d08-43a6-406a-b28e-951a640547fa",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T22:40:00Z"
+      },
+      {
+        "id": "b1767130-2ef3-4c7c-8d4b-6b7d1ecbc7ba",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T17:05:00Z"
+      },
+      {
+        "id": "25243f08-c453-4f59-869d-af0496d0a363",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T22:50:00Z"
+      },
+      {
+        "id": "686f1356-87e8-43c7-856e-b05df8dc54ec",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T19:15:00Z"
+      },
+      {
+        "id": "dc508790-153d-4d29-a620-b4bd8f94c696",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T07:10:00Z"
+      },
+      {
+        "id": "ffa9ba9c-fd0b-4f8f-a8ce-9fdd9246e350",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T21:10:00Z"
+      },
+      {
+        "id": "5a1e17d2-a440-4992-aa6a-be354bbb9ba7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T21:50:00Z"
+      },
+      {
+        "id": "a4fe2927-ba1b-444e-82d3-38a1a894d860",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T17:20:00Z"
+      },
+      {
+        "id": "e464cabb-6701-4f67-92bc-59f435a174fe",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T21:50:00Z"
+      },
+      {
+        "id": "7282cf3f-473d-457d-8d4a-8b9458d91191",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T21:50:00Z"
+      },
+      {
+        "id": "3e177749-7aec-4af7-bcde-8d89b3ffee0b",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T06:00:00Z"
+      },
+      {
+        "id": "fdd30210-0a0c-4749-920e-33c850e019fc",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T19:40:00Z"
+      },
+      {
+        "id": "6176f7f4-9f92-4198-adeb-309b02b22443",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T08:15:00Z"
+      },
+      {
+        "id": "3c8384d3-0719-4138-af3f-e0b05e20f89b",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T17:40:00Z"
+      },
+      {
+        "id": "383d015d-ae95-4f6c-a98f-7f622735aa1f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T20:45:00Z"
+      },
+      {
+        "id": "98959421-5466-4a67-9d21-33aebeffacbe",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T19:20:00Z"
+      },
+      {
+        "id": "58e759b5-3254-4608-81b4-a51bfe8059c7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T12:15:00Z"
+      },
+      {
+        "id": "17b347d2-3256-4a0c-932f-a522ec61ad32",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T19:30:00Z"
+      },
+      {
+        "id": "cc3bae75-fb47-43ae-aaa7-12b9a4c36565",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T22:00:00Z"
+      },
+      {
+        "id": "8a39efc9-9723-4591-a5cd-0fb6eadd937a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T18:15:00Z"
+      },
+      {
+        "id": "e650855e-85c0-468d-9dd6-1f01e401a4ef",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T08:30:00Z"
+      },
+      {
+        "id": "9d0bc590-4e14-41fb-b85e-48e44039369a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T17:10:00Z"
+      },
+      {
+        "id": "1299e6e7-e856-4a44-9598-a040ea020888",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T22:00:00Z"
+      },
+      {
+        "id": "4afb8f31-429c-4be3-a644-e3d675f57518",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T12:15:00Z"
+      },
+      {
+        "id": "fd94cf91-3acf-41c7-9881-a9c9861b310b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T21:45:00Z"
+      },
+      {
+        "id": "ce437105-af1e-4d14-8929-1c616e90acf0",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T08:15:00Z"
+      },
+      {
+        "id": "2038602d-a61a-4856-bc69-6629f35dec21",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T20:00:00Z"
+      },
+      {
+        "id": "339f68ec-d0ab-444d-a971-9c00318d8b9b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T12:00:00Z"
+      },
+      {
+        "id": "57b84573-2906-40a9-8a64-0c8fc6da0e40",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T12:00:00Z"
+      },
+      {
+        "id": "bca73541-48d6-4bbe-ac35-248fd35cef29",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T06:20:00Z"
+      },
+      {
+        "id": "024b1387-6b3d-45ee-901f-63d5171953d2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T18:00:00Z"
+      },
+      {
+        "id": "e08cc39b-3df1-410f-af4d-ab84028b114f",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T06:30:00Z"
+      },
+      {
+        "id": "e76b5474-38a6-4c60-826f-24befe51514b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T06:00:00Z"
+      },
+      {
+        "id": "94c37976-e975-48f5-b3c6-d7e895aeee19",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T08:40:00Z"
+      },
+      {
+        "id": "76d350b6-ec83-496b-838f-5410faadb33f",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T06:45:00Z"
+      },
+      {
+        "id": "c3a570fe-fc8e-4947-b5d3-60eabfc44996",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T06:50:00Z"
+      },
+      {
+        "id": "f8927925-2014-4cdf-8d72-ef842dc469fd",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T21:15:00Z"
+      },
+      {
+        "id": "7170e594-284c-4e91-9dfa-d6c429c894ba",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T20:00:00Z"
+      },
+      {
+        "id": "19316d55-5021-4d1e-8012-e0b4e4762896",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T22:50:00Z"
+      },
+      {
+        "id": "47bbe012-8c31-45d2-ab55-e39cf4825d39",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T19:10:00Z"
+      },
+      {
+        "id": "cd4e9adb-bff9-4bda-aea3-190cee216baa",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T18:30:00Z"
+      },
+      {
+        "id": "b6fded4f-7a06-49e2-94d6-2d0a85a1d440",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T18:05:00Z"
+      },
+      {
+        "id": "b06b56d9-bfc8-4118-8f37-f95bc7e9d749",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T22:10:00Z"
+      },
+      {
+        "id": "07625a2e-8577-4186-b676-0733cb2dc981",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T12:15:00Z",
+        "note": "Nonfiction notes"
+      },
+      {
+        "id": "4d711cb0-9611-41e5-bdd9-5734696c9a5b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T18:05:00Z"
+      },
+      {
+        "id": "5a93ed17-fe02-406c-9c4d-d9faedc159aa",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T18:00:00Z"
+      },
+      {
+        "id": "13a7322c-b2ff-429d-8510-2ab02b06c40d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T21:45:00Z"
+      },
+      {
+        "id": "e6dea3d7-ce22-4c3f-a915-84fdde7121f1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T21:40:00Z"
+      },
+      {
+        "id": "b20f2e2f-ba15-4807-9e5d-b1a7a12ce55e",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T20:00:00Z"
+      },
+      {
+        "id": "04cc8460-b099-4336-b641-a501c36de4ca",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T12:20:00Z"
+      },
+      {
+        "id": "9f1628f5-ae6f-47aa-be4a-397a4bdd252a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T22:40:00Z"
+      },
+      {
+        "id": "bfd81ddb-76ae-4001-b78a-38adb5b6f1b5",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T08:50:00Z"
+      },
+      {
+        "id": "f1548645-7ca3-4284-be03-2ac99b21d0a8",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T22:20:00Z"
+      },
+      {
+        "id": "fc5c84e4-b6d7-4d25-9e25-856b237fe992",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T08:45:00Z"
+      },
+      {
+        "id": "a7749f80-ff3b-4d24-81e8-ef5e09031062",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T22:00:00Z"
+      },
+      {
+        "id": "89c0345e-d0a8-4ed9-a0a7-825c7505f067",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T18:20:00Z"
+      },
+      {
+        "id": "097c117e-02c9-4a28-9ef5-c737c42ccff4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T21:30:00Z"
+      },
+      {
+        "id": "f8093577-aa1d-4f64-b364-10eaab4f1db7",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T07:50:00Z"
+      },
+      {
+        "id": "9ab3e90e-447b-46a2-a483-78d6a0fb6338",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T21:30:00Z"
+      },
+      {
+        "id": "e0deb6fb-f2c4-48a3-a3ee-3ff25d922d34",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T06:30:00Z"
+      },
+      {
+        "id": "a5657dd2-dcc8-407b-bd19-ea6ad8e9b930",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T17:00:00Z"
+      },
+      {
+        "id": "62813f7d-f8e7-4636-9db7-cd623334ea74",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T22:50:00Z"
+      },
+      {
+        "id": "b8f93140-db47-4331-aec3-5e5ac958aac2",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T06:20:00Z"
+      },
+      {
+        "id": "39f96c48-85d8-4eb5-97bf-bba4cc6cfbf9",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T20:30:00Z"
+      },
+      {
+        "id": "8ce38c68-ca68-40fb-ab4f-19730bb78002",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T08:15:00Z"
+      },
+      {
+        "id": "fe6f05b1-e100-4e14-911b-78f1893dbba4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:05:00Z"
+      },
+      {
+        "id": "c72c82e6-3e0f-4600-b33b-cdfee0424257",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T21:40:00Z"
+      },
+      {
+        "id": "ae4b0d77-37c6-4ea2-b1bc-0d263fdd7c3a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T07:00:00Z"
+      },
+      {
+        "id": "72665dc6-04c8-4597-9eb6-723a63b1cd7e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T06:10:00Z"
+      },
+      {
+        "id": "44a289c9-1f8f-4bc7-a7a0-18547bf04aa6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T17:10:00Z"
+      },
+      {
+        "id": "ea322c55-7c52-4e35-872e-38a67fa3c81b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:15:00Z"
+      },
+      {
+        "id": "b089afba-0b63-48a2-9176-290d3f6528df",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T06:30:00Z"
+      },
+      {
+        "id": "db442e70-5daa-43da-8722-32df331f09b1",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T17:30:00Z"
+      },
+      {
+        "id": "adafd533-c0d6-436a-a944-1b8b660b3711",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T07:15:00Z"
+      },
+      {
+        "id": "51c77d4c-6b12-452a-9909-7167d48f622d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T20:15:00Z"
+      },
+      {
+        "id": "8a62c73d-0ed5-44fd-ae6b-0aceb9aac08b",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T07:30:00Z"
+      },
+      {
+        "id": "ccf58938-ae5c-4fa4-ad53-d0b7064435b7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T19:30:00Z"
+      },
+      {
+        "id": "4fbc5b8c-10ac-449e-84fe-2ffd6b95de18",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:20:00Z"
+      },
+      {
+        "id": "23765014-649f-470f-8153-fa9120fbb0ba",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:40:00Z"
+      },
+      {
+        "id": "44f3ac3c-2715-47df-b632-c1f5aa20c834",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T06:10:00Z"
+      },
+      {
+        "id": "e0181047-da62-4fca-9d5c-42cba81af8d8",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T19:45:00Z"
+      },
+      {
+        "id": "ded1bee2-973f-411b-9b04-4cc77f07ec89",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T12:10:00Z"
+      },
+      {
+        "id": "5a63ad8a-d931-4f60-aa87-72c92143172e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T06:00:00Z"
+      },
+      {
+        "id": "9b0983d1-9b03-42ee-91cc-9813f7278e99",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T18:40:00Z"
+      },
+      {
+        "id": "6e9e6b6a-5f65-41f8-b277-6b51b8517641",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T06:20:00Z"
+      },
+      {
+        "id": "555467c3-4e0f-4cd6-a71e-139d18ebf59c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T08:20:00Z"
+      },
+      {
+        "id": "b7f0cbdd-187a-44aa-a6a9-479d766cccff",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T18:40:00Z"
+      },
+      {
+        "id": "1c4dbf0a-59be-4992-9f61-f834b4e9007e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T17:10:00Z"
+      },
+      {
+        "id": "244b4925-c8f9-460e-89fb-4734367130b6",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T12:20:00Z"
+      },
+      {
+        "id": "bc423ca5-438f-4bf3-adba-85d5ba279c84",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T08:30:00Z"
+      },
+      {
+        "id": "fdd8b871-90a2-4503-9e34-4c498d437893",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T17:45:00Z"
+      },
+      {
+        "id": "608fca5f-c32d-4553-b19e-b04088abbb9a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T22:05:00Z"
+      },
+      {
+        "id": "9088a69e-7f8f-4c8e-8f99-981c1bf4c70d",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T07:10:00Z"
+      },
+      {
+        "id": "86dfb005-937d-4499-9722-474c38ce784e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T08:20:00Z"
+      },
+      {
+        "id": "ad87f6e8-58e7-490b-b390-f3be076b5d4d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T06:45:00Z"
+      },
+      {
+        "id": "0bdb2c8b-ce16-4899-b546-d0adb77702ae",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T06:10:00Z"
+      },
+      {
+        "id": "45ea976c-45cf-484b-ac8d-cef24a5fa3e6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T17:45:00Z"
+      },
+      {
+        "id": "65324376-09a3-4978-9ad0-fc668abec1ab",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T07:20:00Z"
+      },
+      {
+        "id": "2c8a7d46-eb09-460a-9ffe-6c1807bfd26e",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T08:15:00Z"
+      },
+      {
+        "id": "b604ed69-bac1-4b6d-a602-52887a8049d9",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T18:10:00Z"
+      },
+      {
+        "id": "491cc41b-d5bb-493e-b0b3-4b48869d925f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T18:15:00Z"
+      },
+      {
+        "id": "5373312b-005c-48a0-8b5c-df912e43e224",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T17:40:00Z"
+      },
+      {
+        "id": "d75057e3-dda5-415b-a17f-39668efaf49f",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T17:50:00Z"
+      },
+      {
+        "id": "f3f5e3d5-62c8-467c-85e3-4ed35a7eddc9",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T21:30:00Z"
+      },
+      {
+        "id": "7412a98b-81fb-4445-ade8-176048b44295",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T08:45:00Z"
+      },
+      {
+        "id": "5259be20-3769-479a-b6bf-e7e43444a49b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T20:00:00Z"
+      },
+      {
+        "id": "b98d9afe-d372-4a1d-82ca-11c3b446bf7d",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T22:20:00Z"
+      },
+      {
+        "id": "34c4a24c-058e-44ea-a78c-6be6677cbd5b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T06:50:00Z"
+      },
+      {
+        "id": "140adf8b-02aa-4783-a634-4ce7fb943eb7",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T08:15:00Z"
+      },
+      {
+        "id": "0b77b52d-2bb7-47a4-b1b4-17026524a0c4",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T21:40:00Z"
+      },
+      {
+        "id": "f81541ed-a105-46ba-9f30-73c6a1d16e0e",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T21:00:00Z"
+      },
+      {
+        "id": "47b3423f-fc31-4629-99db-12e0e3b5164d",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T22:50:00Z"
+      },
+      {
+        "id": "17540b0e-2664-4fa0-9f0d-0fe6241b67b0",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T17:00:00Z"
+      },
+      {
+        "id": "e2153157-0a98-4c90-92b5-cc44568835e7",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T06:20:00Z"
+      },
+      {
+        "id": "52ef4016-9ff6-4a3a-b185-6469ecf32db6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T12:50:00Z"
+      },
+      {
+        "id": "aa650bf6-ae99-407a-963f-f92a71fedaef",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T08:45:00Z"
+      },
+      {
+        "id": "e234a2bb-e63e-425a-8f86-2bf8b00b193e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T20:05:00Z"
+      },
+      {
+        "id": "83fbaf01-d2fb-4027-b32d-ff3b80cf775e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T07:20:00Z"
+      },
+      {
+        "id": "b6584272-70c9-4e23-b105-fafeb08e12aa",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T18:45:00Z"
+      },
+      {
+        "id": "24d7c042-8bd1-4ed3-b888-ca407907a170",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T06:05:00Z"
+      },
+      {
+        "id": "b63b8fab-9f71-4c6a-b3d1-31c54f71bddd",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T07:40:00Z"
+      },
+      {
+        "id": "597a5603-7ab4-4b2a-903f-a1a7fe4fb1f5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T08:45:00Z"
+      },
+      {
+        "id": "7f3fb7f7-116a-44ae-8367-e0639e52eec5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T21:40:00Z"
+      },
+      {
+        "id": "d0b310f8-0a7a-4dba-8573-8eb19f79d122",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T19:50:00Z"
+      },
+      {
+        "id": "d9e3406c-9788-4dc5-a3ae-c5f765882510",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T08:10:00Z"
+      },
+      {
+        "id": "6e253124-53db-404c-b97e-1b5fdacb8004",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T08:40:00Z"
+      },
+      {
+        "id": "b25ef3f6-1246-4bd4-9174-1f49b79d43e3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T08:50:00Z"
+      },
+      {
+        "id": "64f06ef0-ffee-4ec7-9871-a0e12ab1c66e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T17:30:00Z"
+      },
+      {
+        "id": "10e776d5-7187-4a13-aa4e-8b0e65d6409e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T22:20:00Z"
+      },
+      {
+        "id": "56427c12-6c30-4dda-89e6-ff84d0664602",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T07:00:00Z"
+      },
+      {
+        "id": "b84dac95-6fbf-48a6-881f-c686afeb8eb4",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T17:30:00Z"
+      },
+      {
+        "id": "8fc468ee-0ac7-4f51-b214-17498b17571d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T21:05:00Z",
+        "note": "Nonfiction notes"
+      },
+      {
+        "id": "0f889ae7-bb4e-4f35-b12d-373da0f26343",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T22:00:00Z"
+      },
+      {
+        "id": "07ca666e-61a3-403c-b203-90008b72a30d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T17:10:00Z"
+      },
+      {
+        "id": "a9a073e6-00d3-47b3-a3b8-ceefa2233275",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:10:00Z"
+      },
+      {
+        "id": "7d7c2bae-1236-410e-9c9e-07b83025a62c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T19:05:00Z"
+      },
+      {
+        "id": "748f75ee-738a-4142-95d0-953cddcb73fd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:10:00Z"
+      },
+      {
+        "id": "0a94f6a5-e65d-40c6-b428-e7fefac2ab29",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T19:10:00Z"
+      },
+      {
+        "id": "7a36da99-86b7-4c3b-a28f-5832f8d13f24",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T06:15:00Z"
+      },
+      {
+        "id": "62c794b1-3087-42d8-a243-5f0e1c3d73cf",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:00:00Z"
+      },
+      {
+        "id": "32d26e2f-0dbf-4a22-864c-e3cd87c57c08",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T08:15:00Z"
+      },
+      {
+        "id": "cb732d68-9bcc-4560-9869-a6e19da1018e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T06:00:00Z"
+      },
+      {
+        "id": "46bfe714-932b-415b-9b22-8f06620c5056",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T07:05:00Z"
+      },
+      {
+        "id": "36f0d455-a3d9-40c7-b588-37431e287400",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T12:10:00Z"
+      },
+      {
+        "id": "fb29e61f-22cc-4302-af87-50e7cea4f188",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T20:05:00Z"
+      },
+      {
+        "id": "065da778-f8eb-463b-b627-9d3d9311958f",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T08:30:00Z"
+      },
+      {
+        "id": "0459b6d3-01c9-4708-94a5-029dc8b6b4a6",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T17:10:00Z"
+      },
+      {
+        "id": "c7a6180c-d806-4e8c-82f6-d3a194fb715a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T08:20:00Z"
+      },
+      {
+        "id": "8c8ff388-c09f-437c-a596-2342383c5397",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T21:10:00Z"
+      },
+      {
+        "id": "4e428a00-2018-4302-a18f-1e23ad0c9b94",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T08:10:00Z"
+      },
+      {
+        "id": "36966720-9103-4164-b4c6-46f008edb07e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T21:45:00Z"
+      },
+      {
+        "id": "21e40e55-8f16-4060-924f-5ab752c6348a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T06:00:00Z",
+        "note": "Low energy but showed up"
+      },
+      {
+        "id": "e532f4ee-c257-4fbc-b22e-9f8890ad08ec",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T22:50:00Z"
+      },
+      {
+        "id": "eb6c6a8f-4035-426d-98a1-0ba69b5c15f2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T19:15:00Z"
+      },
+      {
+        "id": "ffc41308-f77a-437a-97e2-f82f8c3ce4fe",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T21:10:00Z"
+      },
+      {
+        "id": "14475a58-647f-4d73-8c68-85ccec48d2d2",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T21:05:00Z"
+      },
+      {
+        "id": "5465ad94-f67a-4567-a189-cd34e8ab8789",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T07:30:00Z"
+      },
+      {
+        "id": "75351612-ec62-42d4-83ac-c446981b38f1",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T19:15:00Z"
+      },
+      {
+        "id": "851345d1-159b-4311-97f3-a8f2a1c66040",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T12:50:00Z"
+      },
+      {
+        "id": "8acfc090-7bc8-4076-9d58-f22978771b75",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T12:20:00Z"
+      },
+      {
+        "id": "cef06177-1c81-41c9-bc19-4c78c3de4280",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T07:50:00Z"
+      },
+      {
+        "id": "582596ea-9d64-42d6-a44b-e8aafaefe0bd",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T22:15:00Z"
+      },
+      {
+        "id": "c1c6db49-0cff-430b-b1ee-eb1461d868da",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T21:15:00Z"
+      },
+      {
+        "id": "ae5aa236-5e4b-42f2-94c7-b1624d579fca",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T07:10:00Z"
+      },
+      {
+        "id": "659bb307-2d85-4de3-9fc4-82bd4c4d36a7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T19:05:00Z"
+      },
+      {
+        "id": "dfd2920c-6fd1-4978-8101-b1572f721b27",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T07:30:00Z"
+      },
+      {
+        "id": "254a6c67-49fa-4382-ab31-78d01d9d4529",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T06:20:00Z"
+      },
+      {
+        "id": "63aafa37-9ff8-491a-8b45-715a52551ec1",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T21:15:00Z"
+      },
+      {
+        "id": "9c756754-6002-44df-8f3c-6fc461a3523c",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T19:45:00Z"
+      },
+      {
+        "id": "09744a97-dcc6-40ca-a1ec-1bf955ff2016",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T08:10:00Z"
+      },
+      {
+        "id": "52538a2a-ebfe-4a2f-9748-c2cdfc8cc2c7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T07:20:00Z"
+      },
+      {
+        "id": "df8cf115-eb67-4ccb-ab63-84b40f488152",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T08:20:00Z"
+      },
+      {
+        "id": "c5b96644-5547-487c-871d-8d44558c39f0",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T17:05:00Z"
+      },
+      {
+        "id": "362c5006-aa79-4dda-bf29-89c0e45f4ffd",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T20:50:00Z"
+      },
+      {
+        "id": "284fc5d4-0186-4d5a-941f-7c49fd213e23",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T12:10:00Z"
+      },
+      {
+        "id": "44dbaa4b-b7d4-4f05-a7b1-585831f8f068",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T08:50:00Z"
+      },
+      {
+        "id": "21f46e12-4174-4c38-ba39-fdcde769db2d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T20:40:00Z"
+      },
+      {
+        "id": "da7c72a4-b728-40f1-b2be-ea4cc83febbd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T21:50:00Z"
+      },
+      {
+        "id": "59c52f0d-6450-4be1-8613-c50a8abb44df",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T08:00:00Z"
+      },
+      {
+        "id": "1bc20f32-6892-4d14-83ea-1983780ae981",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T07:00:00Z"
+      },
+      {
+        "id": "7da315df-dc2e-49b0-9405-60940f751790",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T08:50:00Z"
+      },
+      {
+        "id": "98e36557-348b-4615-8adb-d7965e204874",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T17:20:00Z"
+      },
+      {
+        "id": "977dea5b-5b36-4225-b7ce-0792f39fe652",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T19:30:00Z"
+      },
+      {
+        "id": "d9032586-6b28-43ae-8963-51fdfc51c1f4",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T17:10:00Z"
+      },
+      {
+        "id": "990367df-be9c-4076-ab5a-cf552538ead6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T08:00:00Z"
+      },
+      {
+        "id": "234819a4-6c85-44ce-8de3-e22b3a1e0b1d",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T19:50:00Z"
+      },
+      {
+        "id": "0d322b9b-9e70-40ac-89fc-91232a019195",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T07:20:00Z"
+      },
+      {
+        "id": "9ee7629f-bd9b-4db6-9480-e99a75337e0b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T21:45:00Z"
+      },
+      {
+        "id": "2e307095-af35-43f6-9816-160a94d1dd76",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T17:00:00Z"
+      },
+      {
+        "id": "52ffa521-15ad-4f6f-b53c-f967e433c38f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T08:30:00Z"
+      },
+      {
+        "id": "d74447bc-b929-4182-b2fa-e10aed3b484e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T22:40:00Z"
+      },
+      {
+        "id": "f6db31b9-5cd4-4684-ae02-249bdc08e072",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T20:50:00Z"
+      },
+      {
+        "id": "bffb76e6-c483-4146-80b5-c636c03a11d0",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T18:40:00Z"
+      },
+      {
+        "id": "d7ac282f-77b8-4ba3-9028-03629a0bfe0e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T08:50:00Z"
+      },
+      {
+        "id": "e9f9e8ac-67eb-4ca8-99a9-1250b476494e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T06:50:00Z"
+      },
+      {
+        "id": "b6accb6b-f742-441d-b7f8-6f13ed30126d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T22:00:00Z"
+      },
+      {
+        "id": "b244a100-e377-40a9-b954-d33b3c32745a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T08:40:00Z"
+      },
+      {
+        "id": "8eebaf4f-ab8f-42dc-97a6-5b48992aa0fd",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T19:10:00Z"
+      },
+      {
+        "id": "ecdf5108-b19d-4515-b40c-3927ab92f9b6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T18:05:00Z"
+      },
+      {
+        "id": "356f609e-fafc-4402-a199-8f6ae845d2bb",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T17:10:00Z"
+      },
+      {
+        "id": "792c0597-5d9c-4d59-8616-4e4a4bebeaf2",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T18:30:00Z"
+      },
+      {
+        "id": "38e26388-faff-4e1f-93ab-8eac1076e0ff",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T18:30:00Z"
+      },
+      {
+        "id": "b656f149-7b94-4199-b01f-2a12c10018c1",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T22:15:00Z"
+      },
+      {
+        "id": "2e9624a8-3761-4ac5-8632-248d577ba3e2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T19:00:00Z"
+      },
+      {
+        "id": "5adc3740-aef8-41a6-989f-8a86dc44e277",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T20:05:00Z"
+      },
+      {
+        "id": "cfe7a455-f744-4b0d-9efb-b0ad7d916933",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T12:20:00Z"
+      },
+      {
+        "id": "b1927728-3045-4ed8-9766-a1d4c3b5aa19",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T17:40:00Z"
+      },
+      {
+        "id": "983308fc-30c9-4ccc-82a1-615f3f32b8ea",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T08:40:00Z"
+      },
+      {
+        "id": "728a0732-aa09-477c-b12b-0717f4266f7a",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T19:10:00Z"
+      },
+      {
+        "id": "b767dfa8-8a84-45d1-9a5b-d43d221cca7f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T19:00:00Z"
+      },
+      {
+        "id": "e89617f5-9f99-4990-bfac-d03f7c9e57af",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T08:15:00Z"
+      },
+      {
+        "id": "b5878982-e7e3-4364-bf43-856cf3be6349",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T12:30:00Z"
+      },
+      {
+        "id": "bb76d5d6-3394-4b21-a90a-b3a7660e55d1",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T21:40:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "b112ad9c-04ae-4a92-a1fb-33ddd0eb6399",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T18:05:00Z"
+      },
+      {
+        "id": "98c26439-a1cf-4fbc-aab2-7ff2a7ecd878",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T18:00:00Z"
+      },
+      {
+        "id": "e1e0597a-1554-424b-8eec-0a3b2cd7ab06",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T20:50:00Z"
+      },
+      {
+        "id": "6c4a6888-6dac-4920-a706-ef097ca4b76d",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T21:30:00Z"
+      },
+      {
+        "id": "ce842a5a-7880-4067-a03d-b1bbef717ffb",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T12:50:00Z"
+      },
+      {
+        "id": "f6b1bee5-4dac-4c70-b3ea-bed31a7017b5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T12:45:00Z"
+      },
+      {
+        "id": "e4414314-d1a6-4cbb-a586-6495a63feca5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T08:10:00Z"
+      },
+      {
+        "id": "bdf95923-18da-40da-bf8b-898f02887691",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T18:00:00Z"
+      },
+      {
+        "id": "3319c0b4-7680-4913-8467-6773a1c0625a",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T22:20:00Z"
+      },
+      {
+        "id": "45d0fe39-0df3-46d6-a858-3a18fb95c8b0",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T08:40:00Z",
+        "note": "Reviewed groceries"
+      },
+      {
+        "id": "40df15b3-ca41-4b9d-b0e8-1424792523fe",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T07:45:00Z"
+      },
+      {
+        "id": "0bfee6d5-4260-4271-98a4-9730b9b532f6",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T20:30:00Z"
+      },
+      {
+        "id": "7a505913-9f54-4104-b229-6b1187b47e5e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T20:45:00Z"
+      },
+      {
+        "id": "d5498fd1-5d78-450f-ba0e-8265806f747f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T20:50:00Z"
+      },
+      {
+        "id": "13a8ff6d-f9d0-4c31-9a63-b879d1b2281e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:20:00Z"
+      },
+      {
+        "id": "4406c04b-ac40-4c1c-9ad4-2e7e914ccaaa",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T18:05:00Z"
+      },
+      {
+        "id": "467684b3-ba22-4331-ae47-65cdc2746e8e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:15:00Z"
+      },
+      {
+        "id": "170c0376-b953-426c-baad-f809c06e4e64",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:50:00Z"
+      },
+      {
+        "id": "080593f3-f0a8-4add-97dd-a52d0395e339",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T08:50:00Z"
+      },
+      {
+        "id": "4c5507b4-8c8b-4c42-a4e5-e8bdc8b788c0",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:20:00Z"
+      },
+      {
+        "id": "fdd3c940-2527-45bb-aec8-bd69edea5b0f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:05:00Z"
+      },
+      {
+        "id": "924b3727-f476-4e02-9ecc-1df1e6b53552",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T08:00:00Z"
+      },
+      {
+        "id": "b95cfa35-e0cc-43d6-aba3-b238d813572f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T08:45:00Z"
+      },
+      {
+        "id": "f5bac92b-24fc-4325-9e63-2f7c8f4fb5a7",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T19:20:00Z"
+      },
+      {
+        "id": "6340a66a-f98f-4db3-890f-f6cb36ee6ff3",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T22:15:00Z"
+      },
+      {
+        "id": "d0dd993a-28ab-4f7c-b1ad-08542b60067e",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T19:40:00Z"
+      },
+      {
+        "id": "4684b428-5f07-47d2-ad23-780b4d9755f4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T17:20:00Z"
+      },
+      {
+        "id": "bd8ba23a-4fbd-4f27-888a-0c737d186e8d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T07:00:00Z"
+      },
+      {
+        "id": "6de98bb1-fd94-4a1b-90ed-7fd387716202",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T07:15:00Z"
+      },
+      {
+        "id": "3ca801b3-8f8d-484c-a2e3-60a527a69ba3",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T08:50:00Z"
+      },
+      {
+        "id": "c2b12c2b-bc75-4c2e-a284-edf2d85de793",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T12:50:00Z"
+      },
+      {
+        "id": "ed9dba03-3d68-424e-bfc6-a563030ddca1",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T22:00:00Z"
+      },
+      {
+        "id": "71fb3aba-3b62-41f2-9f2f-dd7df7505775",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T19:30:00Z"
+      },
+      {
+        "id": "3f7973fa-0c14-455a-8f63-3e619011bd80",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T18:40:00Z"
+      },
+      {
+        "id": "f9b116a7-543b-4941-9497-3011d16bc90b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T08:15:00Z"
+      },
+      {
+        "id": "1e6dec28-8616-4d11-aea1-d7f0428111b6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T06:40:00Z"
+      },
+      {
+        "id": "b18f674f-71e4-4fc7-aa46-54ba60054f14",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T08:30:00Z"
+      },
+      {
+        "id": "46cb937c-3264-4965-a280-e1763e5a6ded",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T08:40:00Z"
+      },
+      {
+        "id": "a3a64419-d6ad-43b3-adc3-7e48969f4fa9",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T18:30:00Z"
+      },
+      {
+        "id": "c72ba629-34e7-4c09-9b63-86290accdac4",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T19:40:00Z"
+      },
+      {
+        "id": "af5987bb-7085-4e76-8b76-9ba79566ee44",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T17:45:00Z"
+      },
+      {
+        "id": "2f29d21c-d736-4603-90d9-af2938fe189f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T08:15:00Z"
+      },
+      {
+        "id": "d7f00e7a-cf5c-4c1c-8162-8258b58f9046",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T12:10:00Z"
+      },
+      {
+        "id": "ecff8f85-a9a7-4d96-9747-033914f94849",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T20:00:00Z"
+      },
+      {
+        "id": "236a9c02-fee0-4bab-98c2-c98c1b12fa2a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T12:15:00Z"
+      },
+      {
+        "id": "13ebef54-f9bf-4320-b07d-1e91f907a765",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T21:40:00Z"
+      },
+      {
+        "id": "913edd6e-d75f-4ada-8958-22edc5094521",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T08:45:00Z"
+      },
+      {
+        "id": "c2017446-73be-4632-8e21-8b39bc9860d7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T18:05:00Z"
+      },
+      {
+        "id": "53562e6c-535a-46d8-987d-e342f56f7d03",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T12:40:00Z"
+      },
+      {
+        "id": "2e8ad16c-2327-4c76-9435-0a147ab0d6aa",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T18:05:00Z"
+      },
+      {
+        "id": "9864f6d1-f38e-435a-9f63-acfddf116601",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T07:00:00Z"
+      },
+      {
+        "id": "e06bb42a-2b18-4677-b276-3619ef4cc5e1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T12:10:00Z"
+      },
+      {
+        "id": "1dc7580b-1332-4f48-930b-dce2ddbbc758",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T17:40:00Z"
+      },
+      {
+        "id": "f45537f2-f093-40ee-a94f-483e4e4fc498",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:00:00Z"
+      },
+      {
+        "id": "f4aa94a3-b322-4ecd-8917-464aa7acb0ac",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:05:00Z"
+      },
+      {
+        "id": "bf79d895-b053-4ef2-8836-95f5408b131e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T22:30:00Z"
+      },
+      {
+        "id": "394eaf5b-28b3-4482-8b77-f39be30bdec8",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T17:50:00Z"
+      },
+      {
+        "id": "d2834abe-2f01-4f4a-8507-e77240244389",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T07:45:00Z"
+      },
+      {
+        "id": "4c97bfed-a353-44e8-8962-cc4b7ea6d999",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T19:00:00Z"
+      },
+      {
+        "id": "a55d2630-6217-4b83-9346-bcec70fd808f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T08:30:00Z"
+      },
+      {
+        "id": "cbbdd7fe-723f-45cb-aa0c-682e69ba73ef",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T19:10:00Z"
+      },
+      {
+        "id": "5b2afb6b-50b3-46e2-b630-dac64d63a736",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T07:15:00Z"
+      },
+      {
+        "id": "e4e326ca-4421-4959-8135-591c08c9c7bd",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T17:20:00Z"
+      },
+      {
+        "id": "0aaba5fa-3d3f-4d2b-9fcb-0a2b2c561dcb",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T06:15:00Z"
+      },
+      {
+        "id": "d889ec5e-4b91-4c97-ae36-acf8c798ac68",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T07:00:00Z"
+      },
+      {
+        "id": "3c74d019-429c-409e-80b0-cb551669acc8",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T19:05:00Z"
+      },
+      {
+        "id": "eac85181-1c66-4dba-9aec-645dac43193b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T17:15:00Z"
+      },
+      {
+        "id": "d4f44c5d-69bf-49e8-a48e-c22b6d3dd8f9",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T07:45:00Z"
+      },
+      {
+        "id": "76ca0a19-3963-4df6-adec-ae7d179b90e5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T21:05:00Z"
+      },
+      {
+        "id": "90e78a70-7faf-4f9e-a326-19e9c34d4afc",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T18:00:00Z"
+      },
+      {
+        "id": "2889fcbb-ad89-4604-b4ca-1161ef28f875",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T08:40:00Z"
+      },
+      {
+        "id": "9c3a665f-769f-4e8e-bc33-d7f9edb5cb62",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T07:05:00Z"
+      },
+      {
+        "id": "c20dbbf3-a003-41fe-a54f-f08c55610edc",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T20:30:00Z"
+      },
+      {
+        "id": "ae714b04-02dc-42c0-94f5-dd1e2d1ee7a8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T08:00:00Z"
+      },
+      {
+        "id": "8339535d-fddc-4423-94e1-08946d745eee",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T06:15:00Z"
+      },
+      {
+        "id": "9b310e0e-87c4-4ac1-93b9-20e8cfb31aa9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T18:30:00Z",
+        "note": "Short entry, still counts"
+      },
+      {
+        "id": "a8a64738-1010-4427-8d5a-822ad7ce4055",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T19:40:00Z"
+      },
+      {
+        "id": "e7bcb65d-2b76-48a0-988d-1fe14915d6bc",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T08:15:00Z"
+      },
+      {
+        "id": "1aa0fc4c-b19d-42d3-8f5f-a333623ce5f2",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T21:40:00Z"
+      },
+      {
+        "id": "5cbe3190-864c-45bb-b4c2-194f19a1f8d5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T07:05:00Z"
+      },
+      {
+        "id": "fceec709-bdc9-4aa3-b2fe-59ebc2e045be",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T12:15:00Z"
+      },
+      {
+        "id": "0ef66c83-e1d5-4278-aafd-dfd31c73110d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T20:40:00Z"
+      },
+      {
+        "id": "a8ab7eea-81b2-4a74-b793-40139ab98622",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T06:40:00Z"
+      },
+      {
+        "id": "cd4f8c60-9b2f-4c3f-a47f-8e8b2017b3d8",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T22:40:00Z"
+      },
+      {
+        "id": "96f669fc-5548-48ea-9a29-512bfb8c4af9",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T22:10:00Z"
+      },
+      {
+        "id": "4e8040a4-82af-4744-a297-4caa60a047d6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T22:00:00Z"
+      },
+      {
+        "id": "a3c3e36c-8280-4b5b-9fa0-7dcfe239b871",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T17:30:00Z"
+      },
+      {
+        "id": "3acce7a7-c232-43e0-8468-dfaad33ba84a",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T22:15:00Z"
+      },
+      {
+        "id": "79f1bd4e-cc97-41fe-8cce-cd5083996e37",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T12:05:00Z"
+      },
+      {
+        "id": "9695fdcb-104f-4d15-9ee1-e9ef4e9cfdf6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T18:05:00Z"
+      },
+      {
+        "id": "4393c1d7-3d24-438d-8897-16a1bc0c2ce3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T19:00:00Z"
+      },
+      {
+        "id": "e20cae78-676a-4fc0-8204-6c54976e9e30",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T17:05:00Z"
+      },
+      {
+        "id": "e4346069-9de0-4d3d-abe3-35e36b27b9d0",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T06:20:00Z"
+      },
+      {
+        "id": "63348d08-076d-4c40-a2f9-a8d72826748d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T19:00:00Z"
+      },
+      {
+        "id": "ea3193d5-d9b9-41a8-835f-8c31e1203c11",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T21:00:00Z"
+      },
+      {
+        "id": "716de2ba-93ff-4bca-874e-d3c7c4935532",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T17:00:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "8658824b-3cae-4aba-bbf1-d6f533194453",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T18:45:00Z"
+      },
+      {
+        "id": "b9a7d87d-8f36-452d-87fa-f75c9feee623",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T17:00:00Z"
+      },
+      {
+        "id": "2d8d792b-eb08-4eb0-b5eb-a6dccfe5b192",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T08:05:00Z"
+      },
+      {
+        "id": "a3568626-b9a4-4c8b-b77d-818a485c3372",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T12:50:00Z"
+      },
+      {
+        "id": "f2ff2e3f-c628-4a55-bf15-94032ec69792",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T22:40:00Z"
+      },
+      {
+        "id": "a2012f39-a21a-415d-86ef-8c6c40eb5850",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T06:10:00Z"
+      },
+      {
+        "id": "528f2f56-60d7-4832-a95e-dff6e6df19cc",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T21:30:00Z"
+      },
+      {
+        "id": "0d4fd648-47c7-4864-acec-d568fa43b934",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T17:10:00Z"
+      },
+      {
+        "id": "664e15f7-7c7d-4c76-ab7c-e0241e6b1dc7",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T12:05:00Z"
+      },
+      {
+        "id": "6ba42c1b-48b8-4366-ba42-64bccb98b39f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T19:30:00Z"
+      },
+      {
+        "id": "d30b2aa1-3007-464d-89f7-2970d2724c06",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T12:45:00Z"
+      },
+      {
+        "id": "58199242-f64b-4a38-9e22-aa365afbc5ca",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T20:40:00Z"
+      },
+      {
+        "id": "e4752e16-f617-476e-bab6-35dd9d6159b4",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T07:45:00Z"
+      },
+      {
+        "id": "42253a5d-e308-47a0-83a9-ab7c424f1d46",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T18:50:00Z"
+      },
+      {
+        "id": "38450db6-7766-4cb8-9a4c-bf4b11aff455",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T06:05:00Z"
+      },
+      {
+        "id": "c9b23a01-c4bd-455e-8657-da8ff8e9f6bf",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T17:10:00Z"
+      },
+      {
+        "id": "a0f8846b-be10-48b3-8352-27282ad33a5b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T21:10:00Z"
+      },
+      {
+        "id": "2d17cdc8-8c25-422c-a3f0-3e664a4ee0d1",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T12:10:00Z"
+      },
+      {
+        "id": "f4565e45-d84f-4a78-86da-a4eac698471c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T12:05:00Z"
+      },
+      {
+        "id": "2924fe7b-3851-46d6-aa62-91af13c6aad4",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:00:00Z"
+      },
+      {
+        "id": "eb6d672c-2319-483f-8db3-0b043e2c12cb",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T20:20:00Z"
+      },
+      {
+        "id": "f94e1f36-4f01-41fa-9497-a7f6ace672f5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T22:45:00Z"
+      },
+      {
+        "id": "35ba56bd-bb9c-4c75-8245-4bedd8b04baf",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T06:10:00Z"
+      },
+      {
+        "id": "dd2d40b4-0ce4-4981-b034-014a2d46591f",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:00:00Z"
+      },
+      {
+        "id": "bd29fa83-615d-4007-b465-7b6a7fb38d72",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:15:00Z"
+      },
+      {
+        "id": "c10ea60b-c74f-46e0-be37-8f42782cd6a3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T08:20:00Z"
+      },
+      {
+        "id": "72cb781d-8c17-4159-94dc-cae17fb16d4e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T22:15:00Z"
+      },
+      {
+        "id": "a3d2c241-d57e-4b52-a40e-185cc40ae182",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:05:00Z"
+      },
+      {
+        "id": "e44726b3-6fab-434a-8fcc-1b6f86fc74c3",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T17:45:00Z"
+      },
+      {
+        "id": "07176161-75f7-43c0-b8b1-d95be56b378a",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T12:05:00Z"
+      },
+      {
+        "id": "44c09f88-23d9-4540-8635-537b3dda9287",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T20:20:00Z"
+      },
+      {
+        "id": "4e53919b-284f-422a-8ea2-644ae427b27c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T08:15:00Z"
+      },
+      {
+        "id": "fb34f7c6-8437-4947-b08a-86c5b8bb3710",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T21:50:00Z"
+      },
+      {
+        "id": "dcc2a1d5-d7ec-41f7-a497-ddad6edef07f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T18:30:00Z"
+      },
+      {
+        "id": "5be68a37-db40-4bce-8180-067c4581c6c0",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T18:10:00Z"
+      },
+      {
+        "id": "4545c27b-2e01-40ba-a1c4-fb1b689e352e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T06:20:00Z"
+      },
+      {
+        "id": "69071280-f8fa-41d4-b256-259725fb8023",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T21:45:00Z"
+      },
+      {
+        "id": "cb8d420a-1c92-4284-bbc2-895c3e5f0641",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T22:05:00Z"
+      },
+      {
+        "id": "18875f18-3a0c-48a2-a598-2773328f013f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T22:50:00Z"
+      },
+      {
+        "id": "0fbd5c5f-08d1-4231-a099-02588a67738b",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T08:50:00Z"
+      },
+      {
+        "id": "0cc2b1a7-7190-41fa-963f-57ce66233569",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T19:10:00Z"
+      },
+      {
+        "id": "1020bec7-6a47-42e5-b8c5-1c0dac08ca5d",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T07:40:00Z"
+      },
+      {
+        "id": "78e0a53f-0613-49f6-8407-2f844a004cc6",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T18:00:00Z"
+      },
+      {
+        "id": "ca1193b1-ea18-4d7f-b793-49d63eabceaf",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T20:05:00Z"
+      },
+      {
+        "id": "7218d805-5d9d-4af4-b762-b6ef229ba8d7",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T12:50:00Z"
+      },
+      {
+        "id": "12a364a1-96f5-45af-a464-fcc1bec517cd",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T17:30:00Z"
+      },
+      {
+        "id": "254d0284-4d56-41de-a020-dbe1e92ca69f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T18:30:00Z"
+      },
+      {
+        "id": "f2cf0116-90a3-4259-a32d-7391231ee402",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T19:20:00Z"
+      },
+      {
+        "id": "404e0e4e-926d-4a05-9af6-806c03206119",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T21:00:00Z"
+      },
+      {
+        "id": "7cce194f-1004-45ca-8904-5c29c24aa740",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T12:15:00Z"
+      },
+      {
+        "id": "426f4b00-cf9f-45d4-82b7-890e34aee9ac",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T21:05:00Z"
+      },
+      {
+        "id": "c5c774df-4f13-4c42-ac33-0de6c260e271",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T18:45:00Z"
+      },
+      {
+        "id": "da7adeb8-6609-4785-9ba0-71b419948d1d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T06:20:00Z"
+      },
+      {
+        "id": "b4d25b3b-9d17-4fe3-bb90-d2c78426a156",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T18:50:00Z"
+      },
+      {
+        "id": "114259f7-8177-4538-a8c0-a604b1bbe125",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T08:10:00Z"
+      },
+      {
+        "id": "ac6fa8f2-5702-40d7-92b5-c39c38df5b24",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T20:05:00Z"
+      },
+      {
+        "id": "dcb99b4c-933d-4e46-beed-297be4fd6c8a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T17:45:00Z"
+      },
+      {
+        "id": "b8ab2776-691a-409a-90e6-44e0063dbe13",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T17:00:00Z"
+      },
+      {
+        "id": "51610301-8a55-4824-b09d-3735fdea91cb",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T20:10:00Z"
+      },
+      {
+        "id": "b4f6d272-1a6a-400d-a7ea-6e0f2d55c851",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T12:05:00Z"
+      },
+      {
+        "id": "86e4d19b-25b2-4d72-8591-05774dd72e75",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T08:10:00Z"
+      },
+      {
+        "id": "15174028-81be-45ac-91fe-abffd7fc938d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T19:50:00Z"
+      },
+      {
+        "id": "fd59036c-6589-4ebd-9f13-77ac345ac9ef",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T06:30:00Z"
+      },
+      {
+        "id": "88c87e43-b62d-440b-b89b-e36de80eb2ac",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T19:50:00Z"
+      },
+      {
+        "id": "a55a5de6-40c4-4c83-87bf-b0593cd1749e",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T17:50:00Z"
+      },
+      {
+        "id": "6cf9da10-b963-4215-8b1a-bcc4d6e922e7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T20:45:00Z"
+      },
+      {
+        "id": "24d91ffd-c041-4c76-ab87-faf109bf29ba",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T06:05:00Z"
+      },
+      {
+        "id": "dcd99440-6122-4b24-b439-acfb18dd63a6",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T08:10:00Z"
+      },
+      {
+        "id": "ae5c66f3-71c6-40ec-bdf0-803083fb0246",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T21:05:00Z"
+      },
+      {
+        "id": "98b0d40b-319a-47d5-a6fa-fa78c556bec5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T18:15:00Z"
+      },
+      {
+        "id": "fc8dbaf3-3e75-4c65-b559-44fcf43f552c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T22:05:00Z"
+      },
+      {
+        "id": "5896acbb-8d1d-4f38-a702-0eeaa4d2a9c2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T06:40:00Z"
+      },
+      {
+        "id": "0deaf549-f0d6-4122-a20e-850fb4acf1a4",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T22:20:00Z"
+      },
+      {
+        "id": "5d4b7ddd-c673-4291-a449-d83579c23285",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T21:05:00Z"
+      },
+      {
+        "id": "905cbab3-4e3a-47b3-b325-54b5d72a2b71",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T17:10:00Z"
+      },
+      {
+        "id": "247e7347-1877-4482-9d90-e81ea800e144",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T20:50:00Z"
+      },
+      {
+        "id": "44f38f3e-5b08-4dd4-81ee-eb1353beabde",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T12:40:00Z"
+      },
+      {
+        "id": "3f525fb4-a907-430c-8b58-e695cd773b2e",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T19:50:00Z"
+      },
+      {
+        "id": "e2ba33dd-3769-4609-90ca-a2d515c1a6e8",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T19:00:00Z"
+      },
+      {
+        "id": "1edec9b3-843c-4893-b900-5a0fbeebb855",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T08:00:00Z"
+      },
+      {
+        "id": "659c5897-a9d7-46bb-8ffc-d66325c70351",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T19:50:00Z"
+      },
+      {
+        "id": "be145d8e-7db9-46eb-b8c2-16069f8411d4",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T21:50:00Z"
+      },
+      {
+        "id": "e9be4401-c782-4a97-b92d-8a200f8c7738",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T20:15:00Z"
+      },
+      {
+        "id": "e817dfd0-3b54-464e-9321-c2eaab7d4055",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T07:40:00Z"
+      },
+      {
+        "id": "7642011f-a280-4264-a9b7-9bf881986115",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T06:45:00Z"
+      },
+      {
+        "id": "5be05db3-da89-4af2-a315-377cc10f852e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T12:45:00Z"
+      },
+      {
+        "id": "1ac5d543-de89-40a9-920c-3d2c475a24fa",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T19:00:00Z"
+      },
+      {
+        "id": "5f209208-e99f-4b45-acce-c62cd30b4263",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T22:10:00Z"
+      },
+      {
+        "id": "32f3878d-e8dd-452d-b2c5-1f3d3178a6d1",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T20:50:00Z"
+      },
+      {
+        "id": "2613df5d-55df-4bc2-911a-87e4df8fdb1a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T18:00:00Z"
+      },
+      {
+        "id": "faaa165e-ceb5-4d60-957d-c0a1b76f16ca",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T19:20:00Z"
+      },
+      {
+        "id": "a92a851c-1650-4d5e-9a3d-6b4146999e6c",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T20:05:00Z"
+      },
+      {
+        "id": "b3fc618b-a5be-4aab-bc09-878d2acbc170",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T20:20:00Z"
+      },
+      {
+        "id": "b44460cb-8d28-46b4-9b5d-52b6d87d730d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T07:45:00Z"
+      },
+      {
+        "id": "30dff32c-472a-4d38-bde5-5e17361cfbdc",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T07:20:00Z"
+      },
+      {
+        "id": "1179841b-e941-4282-a1f8-c15cd97bfceb",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T12:40:00Z"
+      },
+      {
+        "id": "329155d9-0f9e-45b0-ab81-8ef2fed1e3ec",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T19:10:00Z"
+      },
+      {
+        "id": "e13b2a0d-b631-4a7e-944f-eecde200db50",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T06:20:00Z"
+      },
+      {
+        "id": "0dfcd5ae-bb13-4981-bad3-5cf3ae82fe17",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T06:45:00Z"
+      },
+      {
+        "id": "ddd276f8-bc0a-4c43-927b-7ca4e61d9c48",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T20:30:00Z"
+      },
+      {
+        "id": "09e1cbb2-a75a-4315-a118-421d0f130f76",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T22:10:00Z"
+      },
+      {
+        "id": "ab6b16cb-41f0-43d5-a658-390c66489b88",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T18:30:00Z"
+      },
+      {
+        "id": "8e6007fc-9f72-4d21-93da-617b71597238",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T07:10:00Z"
+      },
+      {
+        "id": "b84cde2a-c2c2-4a88-840a-e2f960117680",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T08:30:00Z"
+      },
+      {
+        "id": "6bcc48fa-b26c-407f-a5a7-ef336b08f7d0",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T20:40:00Z"
+      },
+      {
+        "id": "e270806c-1bd6-470a-b100-9daf1d911c90",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T12:30:00Z"
+      },
+      {
+        "id": "055d86c2-bf6d-4eb9-bf13-7b78bf627a04",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T07:15:00Z"
+      },
+      {
+        "id": "deb0e47e-b4e9-4bc2-af1b-e567e2bda38a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T21:45:00Z"
+      },
+      {
+        "id": "108cc3bc-fa36-42f2-8e27-098f1338a24d",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T12:45:00Z"
+      },
+      {
+        "id": "00659ebd-f861-4ccb-adec-e4c1cfcc4bb7",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T20:50:00Z"
+      },
+      {
+        "id": "d4f654e4-0cb8-4df7-8447-e7c8a427ad81",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T19:40:00Z"
+      },
+      {
+        "id": "904b4658-c7c1-4cd8-842b-24fe55f244a6",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T08:05:00Z"
+      },
+      {
+        "id": "19a79ad7-24df-43c9-9c31-40c7ca09fec4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T06:40:00Z"
+      },
+      {
+        "id": "1bff238a-6fc2-40cc-9b0b-0302cea1dc65",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T19:50:00Z"
+      },
+      {
+        "id": "52dd87b5-4c75-42c2-bc7a-26c65a931284",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T07:30:00Z"
+      },
+      {
+        "id": "e61dfbb5-9139-456f-be8f-1bc07f774790",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T18:45:00Z"
+      },
+      {
+        "id": "62f1dddb-8b1f-4a97-9443-012cb5149a25",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T06:50:00Z"
+      },
+      {
+        "id": "a17a27c8-6910-41ad-a020-baf5f1ed60d2",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T21:10:00Z"
+      },
+      {
+        "id": "9af594b6-30d6-4be4-8104-53d3b61ce2e1",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T21:30:00Z"
+      },
+      {
+        "id": "5ad6cc0f-8ee8-41a6-b2f8-e202b7c3f3fd",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T20:40:00Z"
+      },
+      {
+        "id": "775ee777-7aa0-47bb-b4b6-83c0e3e84859",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T22:45:00Z"
+      },
+      {
+        "id": "5108c5f6-eba6-4d96-a130-d17aab6d75c4",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T21:05:00Z"
+      },
+      {
+        "id": "33597a70-a745-41ea-86ec-30fb298ad3cf",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T07:10:00Z"
+      },
+      {
+        "id": "3b02b05a-b195-4e6a-bc2d-09756ad729de",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T08:10:00Z"
+      },
+      {
+        "id": "6ec297f1-f2c8-455e-b426-10c43917c508",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T12:00:00Z"
+      },
+      {
+        "id": "b2a53927-210d-45cf-abb1-bc318b3c4b9b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T08:40:00Z"
+      },
+      {
+        "id": "64c154dc-87ad-4ed8-b1cf-e7fd661eb938",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T21:45:00Z"
+      },
+      {
+        "id": "2748c51e-c847-4081-996f-751ea732f8bd",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T12:20:00Z"
+      },
+      {
+        "id": "55eef8e9-9c57-4cb0-bf13-803b669278a4",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T06:00:00Z"
+      },
+      {
+        "id": "2dd5f07b-c455-4523-be77-2cb16fb5be2d",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T12:00:00Z"
+      },
+      {
+        "id": "6b8b500b-bea3-43ee-b321-d6f3da38ac00",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T21:45:00Z"
+      },
+      {
+        "id": "c8567d56-b22b-482d-9ad7-b609a9cd6230",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T08:40:00Z",
+        "note": "Updated budget categories"
+      },
+      {
+        "id": "116c099d-ccb2-4388-966f-2b1741f5db80",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T17:45:00Z"
+      },
+      {
+        "id": "8aa735d9-78c3-4765-90ac-de23ae3176c2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T20:40:00Z"
+      },
+      {
+        "id": "07bd6231-35b4-401e-bc8e-225295d04564",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T18:05:00Z"
+      },
+      {
+        "id": "53b07be7-c92a-4a99-9033-b6bd9b8bad0f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T20:30:00Z"
+      },
+      {
+        "id": "00a76bcf-a6d5-43a5-897b-1849ead6636d",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T17:00:00Z"
+      },
+      {
+        "id": "a7491299-5bf4-4e27-8a92-ed62c9009aeb",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T19:50:00Z"
+      },
+      {
+        "id": "001af777-565d-4f09-8632-f70cfeeef477",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T18:00:00Z"
+      },
+      {
+        "id": "9a369c9e-93b5-435e-887c-3675204e86cf",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T22:40:00Z"
+      },
+      {
+        "id": "47140491-c0f2-49f5-9d09-565eee6768b6",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T08:45:00Z"
+      },
+      {
+        "id": "e2745239-3b97-4830-a0cd-8a9a96b9f46f",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T17:05:00Z"
+      },
+      {
+        "id": "1b11fb22-f5de-4771-998f-797a81f58f84",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T17:20:00Z"
+      },
+      {
+        "id": "dd65e8be-579f-4b1d-bea3-480ebdfd7251",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T22:05:00Z"
+      },
+      {
+        "id": "e1b36857-65c8-4b15-a97c-75e31430bad1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T08:45:00Z"
+      },
+      {
+        "id": "234d79d4-86ec-4c4c-94d6-877ccb8e004e",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T07:00:00Z"
+      },
+      {
+        "id": "1804deb1-7a98-438c-8ee3-49794a0eafe1",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T19:05:00Z"
+      },
+      {
+        "id": "6c4355d5-d8ef-403a-853c-bf8c9b0b2200",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T17:45:00Z"
+      },
+      {
+        "id": "4cb5c682-835d-4655-beed-8494a081980e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T06:30:00Z"
+      },
+      {
+        "id": "b7884175-a5ff-44ac-9bee-55bc11b3422c",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T19:50:00Z"
+      },
+      {
+        "id": "17699e27-1219-4e10-b54d-6e1ebf8748fa",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T22:15:00Z"
+      },
+      {
+        "id": "758ab9d4-15f1-4ba3-b8d7-913ae125f837",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T06:05:00Z"
+      },
+      {
+        "id": "b09ee787-9258-47a5-86cb-c6a82a23d566",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T17:45:00Z"
+      },
+      {
+        "id": "8a664677-30a8-4cd0-84a1-ef388a1c86f9",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T06:05:00Z"
+      },
+      {
+        "id": "2ef54608-85e6-42f0-b098-c5c708048c20",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T08:05:00Z"
+      },
+      {
+        "id": "073939c9-5237-497d-a7fa-1740f5eea5ce",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T17:45:00Z"
+      },
+      {
+        "id": "ef1d00b5-c9af-4bd0-89e9-cff459140655",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T18:40:00Z"
+      },
+      {
+        "id": "252accdb-117c-4717-943e-ca3ea36f43a3",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T17:50:00Z"
+      },
+      {
+        "id": "8ff8c784-1170-4905-befb-916499c9bb8b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T06:30:00Z"
+      },
+      {
+        "id": "38ee5bb3-3865-4f2f-a003-59e59cfdd4c1",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T07:15:00Z"
+      },
+      {
+        "id": "064ec4d2-5b95-4f21-9c10-6e2fa8c553a7",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T08:50:00Z"
+      },
+      {
+        "id": "bdcb80f3-d4f2-42f3-95f2-20bad80274c6",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T21:20:00Z"
+      },
+      {
+        "id": "caa60318-f21f-4ee9-b1f6-4357f42533c4",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T17:45:00Z"
+      },
+      {
+        "id": "ab2951d3-2b6b-4a39-86ac-996a523a01a5",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T19:45:00Z"
+      },
+      {
+        "id": "1ccede74-b737-4f89-a609-4905de40962f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T22:50:00Z"
+      },
+      {
+        "id": "e42d41e7-5d68-4339-9635-dd505e02322d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T17:15:00Z"
+      },
+      {
+        "id": "1363a553-28d4-4097-96e5-d1c20147dcbd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T21:30:00Z"
+      },
+      {
+        "id": "c1ff41b7-4cf9-4481-86b7-ef1c56cb8291",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T06:30:00Z"
+      },
+      {
+        "id": "d834a869-47c7-43b7-a10f-a96da35e50da",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T19:30:00Z"
+      },
+      {
+        "id": "c39d8524-575c-4aa1-be0f-4a02fca02055",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T21:30:00Z"
+      },
+      {
+        "id": "5934e92a-eb8a-45a1-839a-1d2dbeb3a0a7",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T22:40:00Z"
+      },
+      {
+        "id": "5e7bbfae-821f-4296-973d-cc7f3348dcbb",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T07:45:00Z"
+      },
+      {
+        "id": "d02bf2af-5c10-45ac-a812-e0c63a5347c0",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T20:50:00Z"
+      },
+      {
+        "id": "2cf40c2f-d380-4e68-98d4-ae949a8af312",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T21:40:00Z"
+      },
+      {
+        "id": "055e9fc8-413f-4f24-9d5a-00c3ab1aea70",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T08:15:00Z"
+      },
+      {
+        "id": "ac6895f5-0daa-436f-b0b0-229591210d7a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T07:45:00Z"
+      },
+      {
+        "id": "08a126b2-667f-44aa-be4c-edd874efe695",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T18:50:00Z"
+      },
+      {
+        "id": "9c6ea0ff-e372-490f-9290-1fcdab392b20",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T17:15:00Z"
+      },
+      {
+        "id": "7fd6e52a-66ce-4f28-8934-f9b0af43fddd",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T22:40:00Z"
+      },
+      {
+        "id": "35401d4c-5e0e-4974-9519-0e4488ca2ee6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T06:15:00Z"
+      },
+      {
+        "id": "7c73aa6b-d005-4389-ace0-f954dad0ca32",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T06:05:00Z"
+      },
+      {
+        "id": "16702508-845e-4d3e-875f-681ddccf8a1b",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T19:40:00Z"
+      },
+      {
+        "id": "8049731e-6b7d-4bbb-9a63-53407be48e00",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T20:50:00Z"
+      },
+      {
+        "id": "0c8bbd6c-cbca-40ed-9163-70ff63d05eea",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T08:10:00Z"
+      },
+      {
+        "id": "0c5b9f83-0815-44c8-ae7e-d307a8b581eb",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T07:45:00Z"
+      },
+      {
+        "id": "1c9dda7a-b480-4ca5-9dc8-8acfd8567288",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T18:10:00Z"
+      },
+      {
+        "id": "e6edaac7-df7a-4a15-896b-b05c91be15df",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T19:45:00Z"
+      },
+      {
+        "id": "92f1e503-1d26-46db-b001-52861e921f61",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T22:10:00Z"
+      },
+      {
+        "id": "e06cb460-88e7-45a3-bcbb-6e3eff9f8fa2",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T06:50:00Z"
+      },
+      {
+        "id": "81420d1f-f9ae-4b97-9710-d41fcf8a81cc",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T06:05:00Z"
+      },
+      {
+        "id": "ecb61794-6eae-4958-b42a-1d8a7a8bf380",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T21:45:00Z"
+      },
+      {
+        "id": "15dc71c5-bf25-4c4e-a07d-f6b2e28c9835",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T19:10:00Z"
+      },
+      {
+        "id": "8f4d33c0-ba05-4d72-bac1-2ec93f8995b8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T08:05:00Z"
+      },
+      {
+        "id": "e1fac4f3-c575-4470-9279-dfe4267ae2f6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T20:00:00Z"
+      },
+      {
+        "id": "7abd444e-82f4-4296-b0c6-47b54d2f25e2",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T18:20:00Z"
+      },
+      {
+        "id": "9500b8de-00bd-4c19-a073-baa1747ec994",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T17:45:00Z"
+      },
+      {
+        "id": "120e3cdd-e706-4513-bd03-f0cc5d15aa5a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T08:20:00Z"
+      },
+      {
+        "id": "cf8dd270-9e83-4c08-9836-f5cc35a08a52",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:50:00Z"
+      },
+      {
+        "id": "297d0616-8911-4a4f-b69a-d4782b018cca",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T18:45:00Z"
+      },
+      {
+        "id": "828f19b2-8b6c-4999-811b-06d9c7bb0eae",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T07:45:00Z"
+      },
+      {
+        "id": "b3955780-6ecb-449f-81a4-555718f85922",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T12:50:00Z"
+      },
+      {
+        "id": "d128bf3d-dd92-483a-94c5-b6fb89b470dc",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T07:00:00Z"
+      },
+      {
+        "id": "8753b26a-30b2-4c3a-8250-2ed34223ca2a",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T12:10:00Z"
+      },
+      {
+        "id": "47b48c9b-2732-43b8-befa-62efe23b1bfd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T17:50:00Z"
+      },
+      {
+        "id": "ee0a8a61-7edb-4777-ba12-0a3ac8934227",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T12:50:00Z"
+      },
+      {
+        "id": "2dc4dba3-a195-4e4f-aa6b-900e00d0b4ee",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T06:40:00Z"
+      },
+      {
+        "id": "29a1379d-2194-43b1-b159-ffbae1c1608d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T19:50:00Z"
+      },
+      {
+        "id": "ee107c4c-b28c-41d8-97ca-8758e5a26002",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T17:50:00Z"
+      },
+      {
+        "id": "f8aad454-0039-45e3-86bf-4a5de23b0145",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T20:00:00Z"
+      },
+      {
+        "id": "4fafb2c3-1d4d-4294-a802-ae31814dc565",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T21:20:00Z"
+      },
+      {
+        "id": "3168d404-795c-4ce2-a421-9ed7503f648c",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T19:05:00Z"
+      },
+      {
+        "id": "91be143a-541b-4e15-ba1f-6d1ad25f3b7c",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T18:00:00Z"
+      },
+      {
+        "id": "da88966f-01fa-4cb3-b0ca-49da79d45873",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T20:00:00Z"
+      },
+      {
+        "id": "5143ba77-0921-4d54-a623-96321681065e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T19:20:00Z"
+      },
+      {
+        "id": "a9eae0e8-53ca-4d04-a4e0-c0b97b80119e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T12:30:00Z"
+      },
+      {
+        "id": "8aeb47d6-03c1-4ea6-af12-9ef53c97b254",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T06:30:00Z"
+      },
+      {
+        "id": "6af90fc1-ca98-4197-8a71-9c08fe90ee10",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T18:50:00Z"
+      },
+      {
+        "id": "1bffa702-7882-49f8-86b7-5157ffc054bf",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T22:05:00Z"
+      },
+      {
+        "id": "1a904204-028e-4a6d-9ced-a63251402c55",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T20:05:00Z"
+      },
+      {
+        "id": "f371c493-9eac-493c-83c5-523ba4907d50",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T18:20:00Z"
+      },
+      {
+        "id": "fd9ed107-6793-46fe-8e1e-74b1aaea3d10",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T20:00:00Z"
+      },
+      {
+        "id": "f13a1865-1bc8-4807-a0fe-46e1adb146cd",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T06:15:00Z"
+      },
+      {
+        "id": "7ecadd14-9fdb-4bbe-b1ca-3d815fefdde5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T07:10:00Z"
+      },
+      {
+        "id": "1bda498b-9038-46f2-8a04-54e6141b7c73",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T20:45:00Z"
+      },
+      {
+        "id": "fb741afb-37e5-46c4-849c-f680d3727c23",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T19:00:00Z"
+      },
+      {
+        "id": "8f7409c1-52a6-4c02-a40e-9f65c5460b29",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T21:05:00Z"
+      },
+      {
+        "id": "e453813f-9fe0-4c4b-b74e-6e5a9776f121",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T22:40:00Z"
+      },
+      {
+        "id": "ddb46eed-b715-4376-9487-deae50e7b557",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T17:45:00Z"
+      },
+      {
+        "id": "42145088-ce20-40cd-9903-b3e6f2936813",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T08:40:00Z"
+      },
+      {
+        "id": "282064ae-3f15-490c-9f55-3d8969c76122",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T12:40:00Z"
+      },
+      {
+        "id": "7b2ea596-26ee-4d4b-81fb-fb042680802d",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T19:00:00Z"
+      },
+      {
+        "id": "f1fa9a98-f007-4c7a-aed4-053d3adec2b8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T18:50:00Z"
+      },
+      {
+        "id": "bf87c85a-5f86-4f75-8013-f1bc5c3b4b6d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T08:10:00Z"
+      },
+      {
+        "id": "d40890a9-1b5a-472e-8bcc-424f4dbbe7b3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T17:20:00Z"
+      },
+      {
+        "id": "9a0c1462-5552-4c38-9794-c7a7455b13e6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T17:45:00Z"
+      },
+      {
+        "id": "d1ab0d64-02aa-416c-b87f-5b8b45abc143",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T22:40:00Z"
+      },
+      {
+        "id": "ab9e7e78-de07-470d-ace4-76a6ec7278cc",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T12:40:00Z",
+        "note": "Reviewed groceries"
+      },
+      {
+        "id": "59d95ee4-a44b-4332-8893-59f2404e1532",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T17:50:00Z"
+      },
+      {
+        "id": "9d1290fc-0332-4951-bda3-e16f0ea17a97",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T21:50:00Z"
+      },
+      {
+        "id": "a6f8b033-80c9-48aa-9622-74d321f0400d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T08:00:00Z"
+      },
+      {
+        "id": "3c38fcc3-bbff-4f8f-9d53-8dca51d5b1f6",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T06:10:00Z"
+      },
+      {
+        "id": "4d5c92b1-3582-42f1-ab90-003070bb854a",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T07:45:00Z"
+      },
+      {
+        "id": "cbd79b14-6133-4322-b65c-3debaed8ba5f",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T12:30:00Z"
+      },
+      {
+        "id": "ec26ff15-66e6-4c85-84da-c13e1f61ecaf",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T08:05:00Z"
+      },
+      {
+        "id": "303b8feb-e275-43db-936b-aaddb0e91222",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T07:40:00Z"
+      },
+      {
+        "id": "5b404895-1295-42d9-ba0b-2d0bacf3f5fd",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T17:10:00Z"
+      },
+      {
+        "id": "6fcdd42c-15aa-4d5b-bf7d-da7834229fb5",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T07:00:00Z"
+      },
+      {
+        "id": "cbc20924-5b85-4dce-b992-f5d39f0748f0",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T21:50:00Z"
+      },
+      {
+        "id": "46621293-0036-4f18-909e-16d3fe975465",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T22:50:00Z"
+      },
+      {
+        "id": "77e02496-8896-4ef7-98ec-faccbb5b3ed1",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T22:50:00Z"
+      },
+      {
+        "id": "f1f0c4e6-426f-4a09-bb74-52fdc834e32e",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T07:15:00Z"
+      },
+      {
+        "id": "4150bc48-95de-4adb-ae59-414ec231cffc",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T08:30:00Z"
+      },
+      {
+        "id": "e4c5f92f-7592-4b26-8aa5-275d271d86dc",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T17:45:00Z"
+      },
+      {
+        "id": "acc684e7-e48a-4bed-be4d-4f706f1b06d8",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T08:00:00Z"
+      },
+      {
+        "id": "091273dd-bd1e-497b-b75d-e818220041e9",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T18:05:00Z"
+      },
+      {
+        "id": "2871498d-c717-47e0-a7f3-620f389643c7",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T22:20:00Z"
+      },
+      {
+        "id": "980b0158-ae29-4b45-9d0b-6ea63d8d5a75",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T21:05:00Z"
+      },
+      {
+        "id": "678fbba3-061f-41fc-9891-ec776b43c5bf",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T08:20:00Z"
+      },
+      {
+        "id": "5a308422-9b64-41a9-88bd-f6a92a7cbb86",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T08:10:00Z"
+      },
+      {
+        "id": "3fcba01d-bd5b-4140-97fc-af4aac2b9440",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T21:15:00Z"
+      },
+      {
+        "id": "8fdde8e4-4842-465d-9170-3be3abd7d9c3",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T17:50:00Z"
+      },
+      {
+        "id": "789fb9ed-56c2-44f9-b4b8-77e787284274",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T18:15:00Z"
+      },
+      {
+        "id": "31516a4e-3b31-4b0a-bac3-becaf8f6a904",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T18:05:00Z"
+      },
+      {
+        "id": "e829fe24-b4ee-44bd-924f-5bedd5fa64e2",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T21:50:00Z"
+      },
+      {
+        "id": "fe4f63d7-4902-43b2-a3d5-c75f369794e0",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T06:50:00Z"
+      },
+      {
+        "id": "df81cb82-6653-4bd0-8b66-f3c0d27e0ac8",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T17:00:00Z"
+      },
+      {
+        "id": "00373d24-4db1-4b86-a94e-c3b81adf2b6b",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T20:15:00Z"
+      },
+      {
+        "id": "3fdcc40e-4e5e-4fb3-993b-0817cea5d2f0",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T12:10:00Z"
+      },
+      {
+        "id": "422c2085-9cd4-44f5-829c-bfac8d28ff52",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:20:00Z"
+      },
+      {
+        "id": "6b06349a-54a1-4226-9586-11b0ba0f40ae",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T06:05:00Z"
+      },
+      {
+        "id": "f14ba86e-5539-44c6-88ed-2b1c30ae038f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T17:05:00Z"
+      },
+      {
+        "id": "6b31d86c-e795-4e21-bbd5-f1231766d15b",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:15:00Z"
+      },
+      {
+        "id": "259bcf6a-8898-41cd-8333-133a439579a0",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T17:00:00Z"
+      },
+      {
+        "id": "22c69c03-c7bd-4031-ac61-16720a308f2e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T06:00:00Z"
+      },
+      {
+        "id": "96e695d8-5744-45a3-828d-8f85b86fcaa8",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T19:40:00Z"
+      },
+      {
+        "id": "c7dcf2ef-0360-4406-8f4a-e29f79f1290d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T19:20:00Z"
+      },
+      {
+        "id": "735ca8e5-0b6f-4e54-bf04-8ba4a758f700",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:15:00Z"
+      },
+      {
+        "id": "e9e407cb-779e-4111-9ca2-d78ad99cc4ba",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:40:00Z"
+      },
+      {
+        "id": "74c58c7d-41c2-4e64-8bda-e8f95822988e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T17:15:00Z"
+      },
+      {
+        "id": "0f080a02-b485-4fc4-82f4-c09b5d302336",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:05:00Z"
+      },
+      {
+        "id": "0a170b2b-e745-43c2-8848-8b45f48d8847",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T22:05:00Z"
+      },
+      {
+        "id": "fcab2b26-32ea-46b2-8c63-0aa53651b830",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T18:20:00Z"
+      },
+      {
+        "id": "e48319cb-542b-4d61-8979-c0dd8ddefa7d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T18:20:00Z"
+      },
+      {
+        "id": "8c7cf2b6-7e76-417b-bb62-0497a66a67d1",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:30:00Z"
+      },
+      {
+        "id": "5a1d1826-d73c-47d4-bc29-988f3cbe3ef3",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T19:00:00Z"
+      },
+      {
+        "id": "c915362c-0309-4993-ab73-9c313d30f409",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:30:00Z"
+      },
+      {
+        "id": "87425b5e-33cc-4e40-be3c-eaff9b626c42",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T06:50:00Z"
+      },
+      {
+        "id": "99f01181-2113-4af7-b4e9-51bfdd65d9df",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T07:00:00Z"
+      },
+      {
+        "id": "8806ac42-06d5-48a9-9401-a9f2977e8f6e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T17:10:00Z"
+      },
+      {
+        "id": "bb878e32-6df6-4662-8b10-e909ea5a17c6",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T07:00:00Z"
+      },
+      {
+        "id": "4efee657-5b9f-4226-bad0-29810d95144e",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T17:45:00Z"
+      },
+      {
+        "id": "9dc9c09b-b09c-4cfe-a40f-c64823614888",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T17:10:00Z"
+      },
+      {
+        "id": "d0197dd6-07a2-4be7-8c94-20403bdd78f9",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T18:05:00Z"
+      },
+      {
+        "id": "62b91c54-afc2-430b-b51f-6dde7ed7440b",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T19:40:00Z"
+      },
+      {
+        "id": "6cdd1f43-2af9-4e30-ab6a-4874d8fe5123",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T22:10:00Z"
+      },
+      {
+        "id": "e6f69209-8a50-4070-9774-855915bfab7b",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T12:10:00Z"
+      },
+      {
+        "id": "0cc6cf54-8b99-4b6e-8332-d74e026a819a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T21:40:00Z"
+      },
+      {
+        "id": "6aae082e-254b-4d50-a5d4-c6013efcd3e6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T08:10:00Z"
+      },
+      {
+        "id": "1873d2c6-87f5-434b-9d0b-1470e0c23ac8",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T12:50:00Z"
+      },
+      {
+        "id": "2b48e33d-7bb2-4796-8a3d-77bcc62e59ff",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T20:15:00Z"
+      },
+      {
+        "id": "5507195c-71cc-43ff-9485-78f47693b088",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T07:30:00Z"
+      },
+      {
+        "id": "f86a6ec3-3a41-4a0e-9881-7f6d9320a39f",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T08:00:00Z"
+      },
+      {
+        "id": "7d01e55b-b1a8-4f6e-ba7f-9cc5cdcbb773",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T20:10:00Z"
+      },
+      {
+        "id": "84abf85d-57e4-471b-99f7-51c086db132f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T20:10:00Z"
+      },
+      {
+        "id": "b49c5bb8-525b-4ff5-8f03-e34b550113f4",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T21:40:00Z"
+      },
+      {
+        "id": "229c82bd-3b1c-4ef0-9509-6444241e8037",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T06:00:00Z"
+      },
+      {
+        "id": "547c350a-c44e-40d7-81a9-b10285d23235",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T06:30:00Z"
+      },
+      {
+        "id": "48928fc4-e712-41f4-9503-bf71b0ca5d2a",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T17:20:00Z"
+      },
+      {
+        "id": "6fbad6d8-5da0-4a32-9206-ad6d6e58482d",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T21:20:00Z"
+      },
+      {
+        "id": "cc887497-7d70-4751-aaa7-e62da69a2947",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T08:05:00Z"
+      },
+      {
+        "id": "b1adaa94-f6df-40e8-9596-8ded7a1aa897",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T19:05:00Z"
+      },
+      {
+        "id": "7cf83122-0e99-4c95-96a9-2000dfc6cf4a",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T06:20:00Z"
+      },
+      {
+        "id": "9ec41ef1-9ae5-4286-a352-457c809ac1ec",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T06:30:00Z"
+      },
+      {
+        "id": "3ae2ed82-757f-4428-945b-59408d471413",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T06:30:00Z"
+      },
+      {
+        "id": "fe2ebf03-c7ba-4807-9858-9c5ffed05851",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T22:00:00Z"
+      },
+      {
+        "id": "23e25a01-74da-4320-b6de-b119f145744e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T22:20:00Z"
+      },
+      {
+        "id": "269f754d-7203-4bf3-a5fe-8b1783bddb13",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T12:40:00Z"
+      },
+      {
+        "id": "0d45e0f3-c200-43d7-b33d-fcc8495e59a2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T18:10:00Z"
+      },
+      {
+        "id": "ad549608-8887-4c6b-8cce-714fced5baa6",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T17:10:00Z"
+      },
+      {
+        "id": "ae537c83-acc8-4b50-9406-ba6a30ee310d",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T20:10:00Z"
+      },
+      {
+        "id": "dd731f80-ff91-443a-a3aa-6e598c0d270a",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T08:40:00Z"
+      },
+      {
+        "id": "0a6ef620-0f15-4717-9ed5-1ce6f0e868f5",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T21:50:00Z"
+      },
+      {
+        "id": "33e0a66e-5ae8-4ad8-a785-7283b9ee9863",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T06:45:00Z"
+      },
+      {
+        "id": "093df137-00cf-401f-ba44-7d7524524ba5",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T22:40:00Z"
+      },
+      {
+        "id": "eedc0887-ba0f-4a97-813b-d7d1f2f72332",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T18:50:00Z"
+      },
+      {
+        "id": "35425df4-4217-4201-b417-8f8d2fae9c85",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T19:00:00Z"
+      },
+      {
+        "id": "3e1571b6-7a08-457c-ab7e-368ef57c56bf",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T12:05:00Z"
+      },
+      {
+        "id": "13d3005e-fa68-4376-a67f-4b03bba03bf9",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T07:20:00Z"
+      },
+      {
+        "id": "31b83e7b-5fa0-4602-b5e7-c2160fcdd1ea",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T17:15:00Z"
+      },
+      {
+        "id": "00d146c3-b550-4890-a4e2-c37a8936cf72",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T17:50:00Z"
+      },
+      {
+        "id": "ba839d5b-5745-4dbf-92ca-755810fcb0ff",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T12:05:00Z"
+      },
+      {
+        "id": "48fc5d0e-3c88-45da-abdd-b8c7c9620994",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T21:05:00Z"
+      },
+      {
+        "id": "1b741098-159c-4881-ac75-e1214c955adb",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T12:00:00Z"
+      },
+      {
+        "id": "dd300560-7aee-412b-a789-139f0316a462",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T21:50:00Z"
+      },
+      {
+        "id": "10c22ce3-b943-4497-89f9-2b6fd3491210",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T07:00:00Z"
+      },
+      {
+        "id": "889d2589-a0de-43a6-b99c-07866f1f87a3",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T20:45:00Z"
+      },
+      {
+        "id": "4bd184a5-a70a-4e81-a1c3-ee86f1e19b70",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T17:40:00Z"
+      },
+      {
+        "id": "8b6534ef-5d58-4962-b0a7-4056ee19aae9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T08:40:00Z"
+      },
+      {
+        "id": "e81dc1b2-2ade-497d-843e-ae98208a0ef7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T21:40:00Z"
+      },
+      {
+        "id": "b50f6245-0dfd-435e-ba35-91b566b3b78a",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T21:00:00Z"
+      },
+      {
+        "id": "0371544f-a2b6-4f5f-8d78-7c9ce5efe17c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T20:00:00Z"
+      },
+      {
+        "id": "c88ae23f-5122-47f0-934f-40b165e9c79b",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T22:10:00Z"
+      },
+      {
+        "id": "c77bcb61-aec3-4204-8ce7-bacf26ef3b23",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T08:15:00Z"
+      },
+      {
+        "id": "ea266979-aebb-4fd3-b851-c473b7152665",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T20:00:00Z"
+      },
+      {
+        "id": "17347caa-6dc8-4cdc-ba4c-4c963f245022",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T18:50:00Z"
+      },
+      {
+        "id": "386e7e57-904c-41f3-b7b4-db4deb932c03",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T18:30:00Z"
+      },
+      {
+        "id": "ef2fb43b-42a4-44c1-86b6-c49a670b052d",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T12:05:00Z"
+      },
+      {
+        "id": "3a1c8da9-677d-42cc-ac7c-8af890115d15",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T18:45:00Z"
+      },
+      {
+        "id": "51b56b9c-28e9-4237-91fc-ba49007691f8",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T22:45:00Z"
+      },
+      {
+        "id": "3d3fab57-07e6-470f-a0c1-d55d616a0e23",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T19:50:00Z"
+      },
+      {
+        "id": "f7f3ad01-1345-4b60-ab8f-a8db091ed2f3",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T06:40:00Z"
+      },
+      {
+        "id": "fa5d74d2-0e9d-49c1-bfdb-0caa8de28543",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T12:15:00Z"
+      },
+      {
+        "id": "67f4b47f-cfe4-4896-b36c-65a68170966d",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T07:30:00Z"
+      },
+      {
+        "id": "70f15490-495c-4ba7-ba23-8e1876ed1ba7",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T08:00:00Z"
+      },
+      {
+        "id": "671f0dd9-a165-40e4-bcdf-01cbaea630f0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T08:15:00Z"
+      },
+      {
+        "id": "350679cc-ded4-4355-ab91-324dddfe3c5a",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T17:20:00Z"
+      },
+      {
+        "id": "bb0b9c57-6e91-4132-a8cb-cb5a69f9f8b4",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T08:15:00Z"
+      },
+      {
+        "id": "796675db-6339-4fbe-94b0-b67ac87846af",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T07:00:00Z"
+      },
+      {
+        "id": "5feb4e13-98c3-4df4-a6f0-f0194969b423",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T19:15:00Z"
+      },
+      {
+        "id": "df579514-19d8-4adb-96b2-3f62056c8341",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T08:50:00Z"
+      },
+      {
+        "id": "a66a3b41-5ed0-4d8b-b98b-2544c1d06035",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T08:10:00Z"
+      },
+      {
+        "id": "9ff771d6-5e43-4084-90ac-d97d3de7dc54",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T07:20:00Z"
+      },
+      {
+        "id": "79a514a8-0ef0-4126-a75a-bf0a8cb642c5",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T20:30:00Z"
+      },
+      {
+        "id": "a46a10a4-6ed7-4d4d-b6a8-c623f2e9974a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T07:45:00Z"
+      },
+      {
+        "id": "823e8aa7-3c8f-4d37-bdfd-ed325c996036",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T06:45:00Z"
+      },
+      {
+        "id": "ebf9b208-b4b6-48d6-a0d5-fe0420162e62",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T17:15:00Z"
+      },
+      {
+        "id": "3439ddf0-66ce-44de-bbfe-54d86acfc829",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T21:20:00Z"
+      },
+      {
+        "id": "4f4f633b-1bdd-4c03-932d-8b332daacff6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T06:50:00Z"
+      },
+      {
+        "id": "554b4001-2675-4cd6-9b14-61d35c304e7e",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T19:15:00Z"
+      },
+      {
+        "id": "fd4bb20d-f7a6-4e92-82d4-35eeccbc58cc",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T19:30:00Z"
+      },
+      {
+        "id": "70d728be-9b50-4f08-a4be-b047a15f975d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T12:45:00Z"
+      },
+      {
+        "id": "d6e38fc8-0869-4e14-b87d-122324c06fa3",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T19:20:00Z"
+      },
+      {
+        "id": "1491512a-f617-41db-ab61-0d61e90f4f67",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T07:00:00Z"
+      },
+      {
+        "id": "f5427d2a-1350-4b7e-999c-d5297a25ac20",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T07:05:00Z"
+      },
+      {
+        "id": "b985f6ad-6a86-4a14-9083-cd2f011def70",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T21:50:00Z"
+      },
+      {
+        "id": "09977bf6-b92e-44b5-bb10-9a0b6c7052fb",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T07:50:00Z"
+      },
+      {
+        "id": "be0c459a-7087-40b7-b1d0-b3f987865e1c",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T18:00:00Z"
+      },
+      {
+        "id": "9be2160a-d836-4af3-a383-2793dde2708a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T19:40:00Z"
+      },
+      {
+        "id": "ef730df9-a265-44d4-85d5-1d69049e7eae",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T18:30:00Z"
+      },
+      {
+        "id": "6cdc1a24-5876-4929-af73-18fd67e0079e",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T19:05:00Z"
+      },
+      {
+        "id": "5f2db546-98f5-4865-939c-8af1b334a2ad",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T08:50:00Z"
+      },
+      {
+        "id": "6a05b55e-0e27-4ea9-aa3d-abf3d5fb97fe",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:05:00Z"
+      },
+      {
+        "id": "e3756be5-6179-4990-948e-20ee8b35658c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T21:45:00Z"
+      },
+      {
+        "id": "d91c7f45-abd4-4194-a3fd-15103c8bf442",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T12:00:00Z"
+      },
+      {
+        "id": "45e99cae-240e-4dbf-aaf2-97109e0ca6f6",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T06:45:00Z"
+      },
+      {
+        "id": "8b07fa46-7055-4e74-9f46-a5c963454134",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T19:15:00Z"
+      },
+      {
+        "id": "5ee22152-26f2-4aa7-9462-3440beb76060",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T17:15:00Z",
+        "note": "Updated budget categories"
+      },
+      {
+        "id": "c74fcbcf-8c04-4227-a365-13e27b2f5389",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T20:45:00Z"
+      },
+      {
+        "id": "116637b7-e979-423d-af86-dd3df7122241",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T18:05:00Z"
+      },
+      {
+        "id": "75fb3fc7-4c19-409c-8b94-f0b364444a09",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:45:00Z"
+      },
+      {
+        "id": "fe4e3c16-cb0d-4c1a-a4c9-7c903f40713f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T08:10:00Z"
+      },
+      {
+        "id": "8914e076-bd63-4231-9ffc-a22055b406b6",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T21:50:00Z"
+      },
+      {
+        "id": "889ce590-3e72-450d-b221-30a540466894",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T12:20:00Z"
+      },
+      {
+        "id": "e96603cf-6864-4ce3-af84-4c9dfc13013a",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T18:10:00Z"
+      },
+      {
+        "id": "dbe7d52a-a3b2-449a-ad3e-0fb52476c15a",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T18:40:00Z"
+      },
+      {
+        "id": "3915889c-a013-4ed5-a4cf-ecf83fd457ed",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T12:50:00Z"
+      },
+      {
+        "id": "103a2b1d-69b4-4e92-8cb8-b741e2efdd06",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T08:40:00Z"
+      },
+      {
+        "id": "ac0bb52f-b6e2-4433-a0cb-4319b85b9848",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T12:10:00Z"
+      },
+      {
+        "id": "3773bb71-c8f8-4edb-ade7-851e03d1cf22",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T08:30:00Z"
+      },
+      {
+        "id": "156fb155-9afe-427e-8555-ac1f814fc78d",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T20:10:00Z"
+      },
+      {
+        "id": "d3edd8b8-f74e-4deb-9640-f3ff061694e9",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T20:50:00Z"
+      },
+      {
+        "id": "dd42a4f7-0539-4ccc-ab60-b15d7ff5844d",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T06:10:00Z"
+      },
+      {
+        "id": "539f24f3-fe14-4e48-b2f9-aa7a016d5986",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T22:00:00Z"
+      },
+      {
+        "id": "f802ab5c-b9be-4fa1-9f72-94dea7741932",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T20:10:00Z"
+      },
+      {
+        "id": "14bd4d54-99cb-4061-b4b8-503b45fc71f7",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T18:40:00Z"
+      },
+      {
+        "id": "c54a13dd-217e-4231-b2d8-4942bbec4fd4",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T12:20:00Z"
+      },
+      {
+        "id": "d3f1e31f-660f-4c04-ba78-42de2c6c8fc7",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T08:00:00Z"
+      },
+      {
+        "id": "f695ddfb-d878-480b-9a64-4dc9bf394b78",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T06:50:00Z"
+      },
+      {
+        "id": "f848b92e-9d28-42ae-a3ef-6e0f17b4a936",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T20:10:00Z"
+      },
+      {
+        "id": "76276004-a86b-4a2c-a249-d766f7b73467",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T21:40:00Z"
+      },
+      {
+        "id": "5641d903-ff78-4eaf-a987-ebe1bcd1af86",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T18:45:00Z"
+      },
+      {
+        "id": "53f7d9fa-f398-4a3d-a91a-08f98dab5501",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T20:30:00Z"
+      },
+      {
+        "id": "9e2eb396-0394-459f-a812-10d6687391b3",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T21:05:00Z"
+      },
+      {
+        "id": "5d0119c3-2498-4a3e-a39b-947e17af8376",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T21:45:00Z"
+      },
+      {
+        "id": "eefc38af-f763-46ce-af1c-0d8544e44f8b",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T22:05:00Z"
+      },
+      {
+        "id": "63cd6fe8-3be4-4496-859d-2f7e0224a503",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T06:10:00Z"
+      },
+      {
+        "id": "733ec660-ae64-4e39-8e4f-61cc3356f21d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T12:20:00Z"
+      },
+      {
+        "id": "a426a73e-fa3b-455f-8a31-1b9ad1dd6e28",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T20:05:00Z"
+      },
+      {
+        "id": "aba06526-20a8-4455-814a-5ce88cf70830",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T20:40:00Z"
+      },
+      {
+        "id": "06bd3c9f-623e-4222-8cc4-c133e835bd6c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T22:45:00Z"
+      },
+      {
+        "id": "ee80c16f-7051-474f-b700-546280b5e24e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T19:40:00Z"
+      },
+      {
+        "id": "5d7fce10-a727-455e-b82e-baa43e1bae09",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T19:00:00Z"
+      },
+      {
+        "id": "a606944f-e2d3-4b6b-a964-418a1b835aa2",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T19:30:00Z"
+      },
+      {
+        "id": "acc66d8e-1d98-4184-91de-4d1f078a9de0",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T20:15:00Z"
+      },
+      {
+        "id": "42747683-8d3f-4ce5-81ca-d0285d44019a",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:45:00Z"
+      },
+      {
+        "id": "f0f489d0-6a21-4d56-9f70-c4315d8e244f",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T22:30:00Z"
+      },
+      {
+        "id": "e9a266f5-bfa9-4fed-abad-235ec077fc55",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:10:00Z"
+      },
+      {
+        "id": "e296cc39-71c8-4cf6-9915-de61a2631373",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T20:05:00Z"
+      },
+      {
+        "id": "1c203c58-f118-45bb-a7ec-a3e196788024",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:00:00Z"
+      },
+      {
+        "id": "51799f2f-9626-431e-8196-c57e97326e6e",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:20:00Z"
+      },
+      {
+        "id": "f956a1f1-a0e7-44bb-82ad-4989c7d2db7f",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T17:15:00Z"
+      },
+      {
+        "id": "1ee851fd-7f80-4ddf-be89-126482eec64f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T08:05:00Z"
+      },
+      {
+        "id": "391fd893-56f9-4e38-a256-3a725aa47892",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T06:00:00Z"
+      },
+      {
+        "id": "5208b32e-2059-49a9-b7db-1876ec527330",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T17:50:00Z"
+      },
+      {
+        "id": "6b537789-10fa-492b-b010-40d67cf9b65d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T17:05:00Z"
+      },
+      {
+        "id": "d1e45317-6c3f-4949-b95d-6881a160c7cc",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:15:00Z"
+      },
+      {
+        "id": "45d2defe-5dfc-4e60-9527-358b30235443",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T20:20:00Z"
+      },
+      {
+        "id": "49f3296a-6253-46e8-b430-85f84855a742",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T06:45:00Z"
+      },
+      {
+        "id": "07eb8e89-37db-4bfc-92dc-91121d57fb12",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T12:05:00Z"
+      },
+      {
+        "id": "68a73fca-938c-403d-a9bb-78e7d1c49e28",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T06:45:00Z"
+      },
+      {
+        "id": "c75b17b0-4431-4b9d-88ca-044672f37823",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T21:10:00Z"
+      },
+      {
+        "id": "e130a4b3-01e4-4874-b387-0dcbdd8bdb21",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T06:05:00Z"
+      },
+      {
+        "id": "abb307a3-a4f3-4698-8296-630d7ea46ac6",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T17:00:00Z"
+      },
+      {
+        "id": "f3263055-5beb-4608-be2c-d064b6d18476",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T18:10:00Z"
+      },
+      {
+        "id": "6ad968ea-b3ac-47f9-be57-e3c98eede561",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T19:30:00Z"
+      },
+      {
+        "id": "c4315b53-562d-4fda-847b-b7397608e4d3",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T07:05:00Z"
+      },
+      {
+        "id": "7a6b49d7-2c50-45f4-9e0e-480fbfa78196",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T08:00:00Z"
+      },
+      {
+        "id": "8563d344-5f28-4205-bb95-441b0a9fd2ea",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T12:10:00Z"
+      },
+      {
+        "id": "6e55398a-9993-4510-9e97-9ff04d55fec8",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T08:40:00Z"
+      },
+      {
+        "id": "ae40f7e8-fe02-4218-baf3-a1ee11c4c866",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T08:10:00Z"
+      },
+      {
+        "id": "51187841-bb40-418a-a8cd-7037632620c7",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T19:05:00Z"
+      },
+      {
+        "id": "e9561f08-a4ec-4ad4-99fa-4bc677dec0c6",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T18:10:00Z"
+      },
+      {
+        "id": "adb5b4ba-54dd-4f98-b0f3-bc153654b507",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T18:20:00Z"
+      },
+      {
+        "id": "1e431a92-b9bf-4d4a-8fec-556ad980384a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T22:10:00Z"
+      },
+      {
+        "id": "2aa04fdf-aa5d-409b-9266-2ab2a770762b",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T17:30:00Z"
+      },
+      {
+        "id": "7a7595f5-d98c-478b-b570-ab0de273b34c",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T12:50:00Z"
+      },
+      {
+        "id": "76eb27cf-ce1c-46dc-9c57-cc6d45f088bf",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T08:00:00Z"
+      },
+      {
+        "id": "35c45ef2-12da-482b-88a3-28a49e6bb7a9",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T20:10:00Z"
+      },
+      {
+        "id": "39bde6ba-e983-492b-9035-3d66d4fd0eb3",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T06:10:00Z"
+      },
+      {
+        "id": "aefe63e8-2644-4686-a121-b183117c387a",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T20:05:00Z"
+      },
+      {
+        "id": "71fa4b69-6df9-4d37-9916-78576c2c6a68",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T08:10:00Z"
+      },
+      {
+        "id": "95b31929-b7ed-4cad-bae2-b18725da35a6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T18:50:00Z"
+      },
+      {
+        "id": "e102714c-8070-4906-91d5-557ffc500cdd",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T12:50:00Z"
+      },
+      {
+        "id": "6bd2d8ff-4ef1-413d-8269-ef8752c8e4de",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T19:50:00Z"
+      },
+      {
+        "id": "5c41e5c8-267b-4926-bca7-6566c2d9f12c",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T19:45:00Z"
+      },
+      {
+        "id": "87c54ca7-a48c-4e72-a50f-c965b21a1044",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T07:20:00Z"
+      },
+      {
+        "id": "50c98292-e22b-4b65-8fd1-b2953a0bb329",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T06:30:00Z"
+      },
+      {
+        "id": "35eb55f2-1471-4be5-b4ec-95de030225db",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T22:30:00Z"
+      },
+      {
+        "id": "8009ba98-3d4d-404f-a1e9-29acc1e70f3e",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T07:20:00Z"
+      },
+      {
+        "id": "15606373-5377-4e8c-90e5-8456d19f562a",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T08:05:00Z"
+      },
+      {
+        "id": "f5f21eb9-4fed-4beb-924b-5ea924c22e28",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T19:50:00Z"
+      },
+      {
+        "id": "597d3fb7-28d6-41d3-8a04-8a9d87445993",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T22:40:00Z"
+      },
+      {
+        "id": "dcac0922-6597-47cb-b278-227196dac9a1",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T17:50:00Z"
+      },
+      {
+        "id": "452877f4-7263-455d-b6b8-656e7273abb8",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T19:10:00Z"
+      },
+      {
+        "id": "eb432a4d-bed3-4a46-90d3-39df656c67f2",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T20:15:00Z"
+      },
+      {
+        "id": "33fb4717-0b38-49fc-8b0f-e200ac64fd96",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T07:45:00Z"
+      },
+      {
+        "id": "768e158d-03ef-4746-9a71-7e2dc2b042df",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T20:30:00Z"
+      },
+      {
+        "id": "414045ad-7d2d-4419-a846-860d4075ff48",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T07:20:00Z"
+      },
+      {
+        "id": "90e2a7aa-a7f6-4700-83dc-58f9aafc1007",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T22:40:00Z"
+      },
+      {
+        "id": "f5eb742b-4fb2-4f3f-bef1-b28ddc0f730d",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T07:30:00Z"
+      },
+      {
+        "id": "dfa56780-f501-49a0-b20a-a769c1026027",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T08:05:00Z"
+      },
+      {
+        "id": "db438429-542b-4bed-9d63-ae0468d26bb1",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T17:15:00Z"
+      },
+      {
+        "id": "c75c9d0e-f165-4c3d-b292-3962c0ddb09e",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T07:10:00Z"
+      },
+      {
+        "id": "dba31d84-6b0d-4cfa-a0ef-867c202e8a21",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T12:40:00Z"
+      },
+      {
+        "id": "0c44c338-629d-4660-b0a2-a20a209f89fe",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T07:30:00Z"
+      },
+      {
+        "id": "055f58f8-3abe-4f1a-b706-6c7cd35015d6",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T17:40:00Z"
+      },
+      {
+        "id": "5297e929-e0f2-4f55-bb2b-3a34b46b39b8",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T17:50:00Z"
+      },
+      {
+        "id": "e8236323-c10a-4339-9b1a-f818e2dd2597",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T20:45:00Z"
+      },
+      {
+        "id": "3e976873-edc2-4b77-a320-a438ea0567a1",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T22:45:00Z"
+      },
+      {
+        "id": "3f65d1a9-6972-4cec-ab0b-b3152ce7ed7f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T18:10:00Z"
+      },
+      {
+        "id": "9f17c906-b527-47fb-bc08-37f869e5361a",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T08:20:00Z"
+      },
+      {
+        "id": "bcfbdb0b-794f-45e3-a414-80d30a49e99c",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T21:40:00Z"
+      },
+      {
+        "id": "dd35c66d-d731-4236-9c89-18b655db2e59",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T12:20:00Z"
+      },
+      {
+        "id": "7c15e832-d319-4e15-9af5-2ff02c0f3a0b",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T06:50:00Z"
+      },
+      {
+        "id": "d8d829ab-111b-4b96-a10a-62b4452bfeba",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T20:10:00Z"
+      },
+      {
+        "id": "8be43ba4-8cfb-41c0-8814-68b21d7eee3c",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T07:20:00Z"
+      },
+      {
+        "id": "c6bb32ff-b529-44c0-95e5-b65d34f0e193",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T19:30:00Z"
+      },
+      {
+        "id": "b178dd25-c51c-4cfc-bdf6-7462bb67b3ca",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T19:10:00Z"
+      },
+      {
+        "id": "7aa1dcdc-3ac0-4ede-adc3-b3073b219af5",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T06:05:00Z"
+      },
+      {
+        "id": "3e3aa2b6-1c22-42e9-bfae-6a38ccaae718",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T19:30:00Z"
+      },
+      {
+        "id": "9c78545c-1a43-4271-9b42-0c890e6eb245",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T06:05:00Z"
+      },
+      {
+        "id": "52dc27c5-8a7f-4d05-a10c-465b605a0a96",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T21:40:00Z"
+      },
+      {
+        "id": "b277a8c1-d4d7-4797-a5d8-0701b54f6a51",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T06:30:00Z"
+      },
+      {
+        "id": "96a87c1d-cd54-4606-b376-5b9e0b2e4354",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T21:30:00Z"
+      },
+      {
+        "id": "788d5300-f26a-4e4f-b34f-c36ee63dcf71",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T22:15:00Z"
+      },
+      {
+        "id": "95e422f9-4e38-4e30-9a1b-dbd32bc7f590",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T20:40:00Z"
+      },
+      {
+        "id": "cbb03f71-f146-4987-89c4-bb7b84da964f",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T18:30:00Z"
+      },
+      {
+        "id": "c3fe32c4-2eff-468f-b79b-06e5150d716d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T07:30:00Z"
+      },
+      {
+        "id": "b62ac342-24a4-4156-a80a-e04b861be4dd",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T17:30:00Z"
+      },
+      {
+        "id": "ce5bb25d-b4eb-407a-806d-75a15ac3f0e2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T07:30:00Z"
+      },
+      {
+        "id": "f10625cf-9413-4cbb-a245-ddd374f295c8",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T06:20:00Z"
+      },
+      {
+        "id": "4a9de028-44a8-4df6-a559-d5383f6e1c44",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T12:05:00Z"
+      },
+      {
+        "id": "af383a3c-0ec6-4dc6-b053-2d8b7cf5dbf5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T19:20:00Z"
+      },
+      {
+        "id": "6367a40c-f7a7-441f-8068-e857e3ab4c47",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T22:05:00Z"
+      },
+      {
+        "id": "4142405f-8747-457a-90b2-563770d23f9c",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T19:20:00Z"
+      },
+      {
+        "id": "cdab810d-b8f9-4eb2-9a54-41590692e760",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T20:10:00Z"
+      },
+      {
+        "id": "fce6f555-2f89-49e6-86cd-4e059156a714",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T08:05:00Z"
+      },
+      {
+        "id": "255d70ce-4b24-4a7a-bf22-19f034c38826",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T22:50:00Z"
+      },
+      {
+        "id": "328daf78-5d2d-45a0-abbc-516f0647660c",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T17:40:00Z"
+      },
+      {
+        "id": "0da8fee8-253b-48a4-be96-3a81cd9b26e2",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T07:50:00Z"
+      },
+      {
+        "id": "eadadd29-63f4-4d76-aee5-a9b250aa5452",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T19:30:00Z"
+      },
+      {
+        "id": "c5958a2c-4e8c-440d-9da0-811f76f54cbc",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T17:15:00Z"
+      },
+      {
+        "id": "a587811b-e4f4-437f-b519-a02a66367fe6",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T12:50:00Z"
+      },
+      {
+        "id": "db77bba4-d738-4b15-9903-fb9824306c8d",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T18:40:00Z"
+      },
+      {
+        "id": "cedc56c0-5652-4e2f-9bc1-3b89eeb6b65e",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T19:50:00Z"
+      },
+      {
+        "id": "bd898f20-2c9d-46c4-8943-0b2be8ba664e",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T12:30:00Z"
+      },
+      {
+        "id": "e0af57ab-862a-4df4-9630-ecf0bc3a279b",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T08:45:00Z"
+      },
+      {
+        "id": "9bbe087b-9308-4793-b84a-af42352151f6",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T18:20:00Z"
+      },
+      {
+        "id": "f4267b8c-ef12-461e-a063-7acec9591b56",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T08:40:00Z"
+      },
+      {
+        "id": "115930f9-b3a1-407e-b4bf-df3e54b1d46f",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T21:00:00Z"
+      },
+      {
+        "id": "95d93341-b166-4f7c-a0bb-338494f8eba5",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T22:10:00Z"
+      },
+      {
+        "id": "9c913c17-d1db-4af7-acd3-26b9ee55b180",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T17:15:00Z"
+      },
+      {
+        "id": "fd23c2d7-9a7e-418f-a079-da1e19639b48",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T21:40:00Z"
+      },
+      {
+        "id": "b2dd0f2c-580e-4508-bced-7eaeecfccedd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T21:30:00Z"
+      },
+      {
+        "id": "1c7b129b-b7f8-4235-8d6a-d63c282be464",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T22:20:00Z"
+      },
+      {
+        "id": "25af9ee6-4d62-482d-968f-8c10d45e4534",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T06:15:00Z"
+      },
+      {
+        "id": "840ae58c-33d0-4949-98c9-71846d8d6df3",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T08:10:00Z"
+      },
+      {
+        "id": "525535bb-3199-4ad9-a7da-5799bdbbc8fe",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T07:15:00Z"
+      },
+      {
+        "id": "cacf7ce8-f9cd-4ebe-af56-ccf9ef2d798f",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T07:30:00Z"
+      },
+      {
+        "id": "6bf46366-923b-405c-b8cd-599cc04d57c1",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T08:45:00Z"
+      },
+      {
+        "id": "c3024b96-cc1a-493a-a3ab-7446714264b5",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T17:30:00Z"
+      },
+      {
+        "id": "b96a3b2d-0d31-4bf0-98d6-705fb8bf6d96",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T22:50:00Z"
+      },
+      {
+        "id": "c3b4d0c1-5e79-4ab4-b4e9-ccba98155198",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T08:50:00Z"
+      },
+      {
+        "id": "1249db88-b713-4673-a263-1e3a8ee54ffd",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T19:10:00Z"
+      },
+      {
+        "id": "1b7269af-d575-4915-b7e0-845cc963cf01",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T19:50:00Z"
+      },
+      {
+        "id": "d9d3a8d8-e4ef-4a42-afe8-d56c9df12f66",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T17:15:00Z"
+      },
+      {
+        "id": "0ec994fc-f9f6-4f93-a6dd-c61a5ab10194",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T08:05:00Z"
+      },
+      {
+        "id": "b69b90d5-58fc-4db3-bdf6-749807847aeb",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T07:30:00Z"
+      },
+      {
+        "id": "02109de7-0b6a-40c3-ae6b-88a037c8ba6f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T20:50:00Z"
+      },
+      {
+        "id": "87da70b0-cc70-4358-b616-a4df8fbcb2e6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T22:45:00Z"
+      },
+      {
+        "id": "fe9d79bc-8d00-4e94-ae64-3af93d759e07",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T17:15:00Z"
+      },
+      {
+        "id": "ecf1ae92-3b49-4b8c-9099-00abeaab7c6c",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T12:45:00Z"
+      },
+      {
+        "id": "4419df1a-f4d4-498e-8fba-6f26f90f6488",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T22:15:00Z",
+        "note": "Good reset today"
+      },
+      {
+        "id": "ccfa873b-1586-4c52-a24b-2b7837f2e9fd",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T21:15:00Z",
+        "note": "Caught a duplicate charge"
+      },
+      {
+        "id": "a1603521-ab99-42ad-8413-56d460467aff",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T08:45:00Z"
+      },
+      {
+        "id": "a4293af2-5379-4424-9627-82e8daf1b79f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T18:20:00Z"
+      },
+      {
+        "id": "239fcbdc-d8ce-4a8d-a9ff-91ff6a22099a",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T20:45:00Z"
+      },
+      {
+        "id": "268df075-06be-4b96-ae74-d1456002f46d",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T06:15:00Z"
+      },
+      {
+        "id": "40318af9-124a-427d-84d1-d7e3784af6dc",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T07:45:00Z"
+      },
+      {
+        "id": "9e11f516-e5ad-4c6f-a30d-4c013ba38fcb",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T08:10:00Z"
+      },
+      {
+        "id": "a5bd1375-7a28-49b9-a3f8-440456f73722",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T22:30:00Z"
+      },
+      {
+        "id": "14a06636-18b4-48b4-8bdd-55d8a7aa71f4",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T22:40:00Z"
+      },
+      {
+        "id": "a5c56cc1-83fb-498b-b497-d604b62ce709",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T12:45:00Z"
+      },
+      {
+        "id": "a9201131-7dae-48ef-9832-84af51b7fabf",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T17:00:00Z"
+      },
+      {
+        "id": "84d9e92a-a3ec-48e1-b103-2c26a6738de9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T19:50:00Z"
+      },
+      {
+        "id": "4cec0a94-9c72-44f6-8d14-ef0b34fb2cc2",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T06:20:00Z"
+      },
+      {
+        "id": "cea82a86-6a90-40d8-833c-5d0a831a00df",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T19:50:00Z"
+      },
+      {
+        "id": "19e6465e-6139-4068-8df6-d4dadb284377",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T22:40:00Z"
+      },
+      {
+        "id": "6577a1e6-8de2-41d3-ac68-a94fc53bed7e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T18:20:00Z"
+      },
+      {
+        "id": "e28696ea-4507-4dc8-a132-414b93351ce5",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T07:10:00Z"
+      },
+      {
+        "id": "42134227-7071-4217-87d6-549f306fc0df",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T18:45:00Z"
+      },
+      {
+        "id": "453287ec-fee3-43b3-872c-8ffa951021a2",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T20:40:00Z"
+      },
+      {
+        "id": "bf36213e-ae3d-47fe-80e2-35da73fe8f21",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T06:15:00Z"
+      },
+      {
+        "id": "de0019de-4781-489c-89c3-2f2732cf0ed4",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T18:15:00Z"
+      },
+      {
+        "id": "2d95b394-63e0-42ac-96f9-1363bf241396",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T20:40:00Z"
+      },
+      {
+        "id": "8e389f46-329d-49f4-92a1-6a4f25c4b231",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T17:05:00Z"
+      },
+      {
+        "id": "962cda86-6bda-4b0d-b973-cb5c1495ccb4",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T08:50:00Z"
+      },
+      {
+        "id": "31d13398-20f5-4943-9150-a0e8c19f6b16",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T17:15:00Z"
+      },
+      {
+        "id": "08ea8ad9-2bf1-4887-be7f-2293889d7152",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T08:00:00Z"
+      },
+      {
+        "id": "c55e0f3d-8dad-4884-8c2f-70e457a13528",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T21:15:00Z"
+      },
+      {
+        "id": "a32644aa-77d1-494b-8db9-7811effb72b0",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T18:00:00Z"
+      },
+      {
+        "id": "b4d82fbd-fff6-4f62-8416-5430f38eca5c",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T19:50:00Z"
+      },
+      {
+        "id": "42bd2b2f-73cb-4b4b-a592-230e34aeebcc",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T17:05:00Z"
+      },
+      {
+        "id": "625b62c3-7584-4126-8b6f-af852800fe5f",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T17:50:00Z"
+      },
+      {
+        "id": "7e3ab7cd-eae9-4567-a5a3-1a6f24c9ecb7",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T06:15:00Z"
+      },
+      {
+        "id": "b422ffc7-65b2-440e-af51-193f9dee84bd",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T07:15:00Z"
+      },
+      {
+        "id": "5ee35951-571b-4626-9995-8892ff9a95cc",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T20:10:00Z"
+      },
+      {
+        "id": "f77a14b2-8450-41fe-903b-79e6bf8dd1ac",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T19:05:00Z"
+      },
+      {
+        "id": "08b9e536-3a03-4c82-bb81-ed797a6303e2",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T06:15:00Z"
+      },
+      {
+        "id": "a1aa989e-4b3b-4e84-bf7d-8e752e9c738d",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T21:45:00Z"
+      },
+      {
+        "id": "855439c8-79d0-408e-9e42-2c462f69144f",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T12:05:00Z"
+      },
+      {
+        "id": "27fb1035-bf14-4f0b-a9c0-7498810fb4e2",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T07:10:00Z"
+      },
+      {
+        "id": "ffac4693-aeeb-42c1-b54a-9e72f749b186",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T08:10:00Z"
+      },
+      {
+        "id": "5fa52f74-04e3-4d67-bcf1-f01131db879c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T17:50:00Z"
+      },
+      {
+        "id": "4523e720-cb29-4636-bb05-bc46260cfd04",
+        "habitId": "ec061794-eae4-46f2-aae4-20fd56270217",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T07:15:00Z"
+      },
+      {
+        "id": "b651a399-10fb-45f8-9e5e-3605051f10b4",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T18:05:00Z"
+      },
+      {
+        "id": "75bca8a2-ba4c-4209-b787-5460a64995a1",
+        "habitId": "269419f6-6d19-4a52-ab52-31ee2efff934",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T19:45:00Z"
+      },
+      {
+        "id": "97c7c1d2-5eae-4a87-bd35-a1c8c963a090",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T19:20:00Z"
+      },
+      {
+        "id": "80765281-bd66-4e48-89c0-88422dd2a2a9",
+        "habitId": "36c92496-8d3e-42ad-9b0b-447404a37e3a",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T17:05:00Z"
+      },
+      {
+        "id": "413f2065-ca5c-492f-9403-3680262794a7",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T12:30:00Z"
+      },
+      {
+        "id": "baf180ad-7c7f-4bbb-968a-cb7457e752e9",
+        "habitId": "907f1997-0f2e-4630-aa49-6e8b7f08437f",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T07:20:00Z"
+      },
+      {
+        "id": "7b11bf92-fcd7-4c67-a467-d043c73dd9e2",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T22:40:00Z"
+      },
+      {
+        "id": "d90af890-8152-4704-ab84-0d7349c424b9",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T21:30:00Z"
+      },
+      {
+        "id": "85de795b-93b4-4c03-83ec-56ad2150909c",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T06:20:00Z"
+      },
+      {
+        "id": "91cede06-abdd-4aca-a637-6f15be4d40aa",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T17:15:00Z"
+      },
+      {
+        "id": "7ee4eb1e-4489-42ee-997b-3dc109a05d76",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T20:45:00Z"
+      },
+      {
+        "id": "4cf16bef-9c07-4799-b27d-5850ecb367bd",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T22:30:00Z"
+      },
+      {
+        "id": "02765d97-e7d4-4de0-b863-0e5d904d2965",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T19:15:00Z"
+      },
+      {
+        "id": "94a132cc-dc22-4869-909d-8797fb4444fa",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T20:15:00Z"
+      },
+      {
+        "id": "dd097e6f-f284-41b9-996c-67a3b72bf7b1",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T07:00:00Z"
+      },
+      {
+        "id": "c6598f23-bc8b-45a7-a2be-81c15add439b",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T21:20:00Z"
+      },
+      {
+        "id": "8c900597-c3ed-475b-a1d2-678d61a4c1c5",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T20:50:00Z"
+      },
+      {
+        "id": "bf698ff1-c420-4ed7-a2a5-0476f5e92053",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T20:45:00Z"
+      },
+      {
+        "id": "ff1dfcaa-d50a-4265-b21b-afbe94f4b52b",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T08:00:00Z"
+      },
+      {
+        "id": "7fe55460-a1d1-4c46-98f5-56b686c82a3d",
+        "habitId": "779db954-9b0d-4474-b078-38699fc33c86",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T22:05:00Z"
+      },
+      {
+        "id": "1902e5d3-5a04-40e2-963c-5a60580d2492",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T07:10:00Z"
+      },
+      {
+        "id": "48af87b4-c0ae-42a4-b971-c698d2251f34",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T18:30:00Z"
+      },
+      {
+        "id": "6249c993-4cec-4139-8252-94b3a8d8fd28",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T21:50:00Z"
+      },
+      {
+        "id": "2bfbad61-f6a8-406a-b54d-31b78fdcbf7e",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T21:00:00Z"
+      },
+      {
+        "id": "219a27af-5129-4108-a7c6-15e90e80d4a2",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T08:50:00Z"
+      },
+      {
+        "id": "2a9cc85c-eb01-49e8-9727-841bfd44e542",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T12:05:00Z"
+      },
+      {
+        "id": "5cc9cf29-2503-4a74-b397-467a3a0e673e",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T17:40:00Z"
+      },
+      {
+        "id": "6bdeaa8a-d4cb-45f1-a572-0dd9f779f5e6",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T22:20:00Z"
+      },
+      {
+        "id": "f5f914b0-40d2-460b-a82c-6e0a41d4a62f",
+        "habitId": "fefc1a72-0f54-497d-b706-4fc96ec20396",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T07:30:00Z"
+      },
+      {
+        "id": "0e2ad218-87c8-4902-9473-62a41eba803f",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T07:20:00Z"
+      },
+      {
+        "id": "907f34a3-5fcd-46b3-8212-f29066fe002f",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T07:40:00Z"
+      },
+      {
+        "id": "2c74e39a-42d9-43c3-9e22-8e86c4b52b12",
+        "habitId": "0ad551a3-0e6b-416d-8d0f-233c241c7a73",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T06:05:00Z"
+      },
+      {
+        "id": "f1dea4d7-e50b-4b0f-9855-8ceb8ac9c8d8",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T19:40:00Z"
+      },
+      {
+        "id": "e90d8588-2006-410b-87a8-978df6bc7a4e",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T08:50:00Z"
+      },
+      {
+        "id": "653e56bb-1e48-4530-ab3a-7dff07f6c21e",
+        "habitId": "4e843dbf-9eb7-466d-9298-4d6dc6930235",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T12:15:00Z"
+      },
+      {
+        "id": "13329e6d-a0b4-41e2-8248-50e9627b55d6",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T20:30:00Z"
+      },
+      {
+        "id": "4f28bf43-0ddd-4d35-9e01-ac81ce4e384b",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T06:20:00Z"
+      },
+      {
+        "id": "dbf2bb65-8efe-49d1-97cb-875de8b9e3dc",
+        "habitId": "a87bdffa-64d7-4534-adff-3410f3e202e7",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T07:20:00Z"
+      },
+      {
+        "id": "20f85290-6934-4397-a490-7101cd403e84",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T20:20:00Z"
+      },
+      {
+        "id": "0d483ad8-dc47-490d-8bd3-228b2d9a6d62",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T08:05:00Z"
+      },
+      {
+        "id": "fd642b43-0dc8-42ca-95da-dc001299f5d9",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T08:20:00Z"
+      },
+      {
+        "id": "d887810b-baa2-4692-a277-dc126bfe9b85",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T12:40:00Z"
+      },
+      {
+        "id": "3549a41c-ddec-4693-91e6-7fb52d671949",
+        "habitId": "05f30262-3f55-4c53-8c69-e8644b5993e3",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T21:05:00Z"
+      },
+      {
+        "id": "6446da51-403d-44ed-a14d-95f5022c3011",
+        "habitId": "09721c12-9d83-463b-8639-3db3646fdfdf",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T20:10:00Z"
+      },
+      {
+        "id": "981c2d90-808f-4d9d-9ae4-909735a8c2ab",
+        "habitId": "1c2580c0-af20-4ce1-bc3d-23afa6c842d0",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T12:40:00Z"
+      },
+      {
+        "id": "7a208e46-1c67-4c44-a596-8d0c36a20a79",
+        "habitId": "2c1e8ec2-5c2f-4371-a25f-96a5ba9e2086",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T12:10:00Z"
+      },
+      {
+        "id": "32fbdcb7-843e-4573-99bf-64adda171ba8",
+        "habitId": "31d7fde4-78f5-4ddd-90da-dbec3c98367e",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T22:15:00Z"
+      },
+      {
+        "id": "a8598a91-a918-42e9-9255-1978ba269e21",
+        "habitId": "547d1bb6-2cb7-43f4-957a-6e76f01b2543",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T22:30:00Z"
+      },
+      {
+        "id": "61aa6453-dbf4-4fbb-a990-bf3addeca1fd",
+        "habitId": "7e90190d-fe36-45a4-9780-98fc08061944",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T18:05:00Z"
+      },
+      {
+        "id": "fd7c7ad9-4109-4fbb-b1f4-cbb0ad2778ef",
+        "habitId": "982f2b9e-d8e5-47f4-98da-cc8c1a208cd2",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T08:10:00Z"
+      },
+      {
+        "id": "9350282b-937b-4b00-bd67-84d22485ecf6",
+        "habitId": "a9b47bf1-7a81-466a-bc79-c6f41cd30d41",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T08:50:00Z"
+      },
+      {
+        "id": "e63003e5-db4b-4eb5-98b5-983c879e8ee0",
+        "habitId": "c58ff22d-7fa5-4a14-8f3e-20674c0acbd4",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T07:20:00Z"
+      },
+      {
+        "id": "429ebd68-596d-41e2-a42f-a381724f81c5",
+        "habitId": "c982b6b6-99f2-4ddd-b726-b10ea7cad391",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T18:20:00Z"
+      },
+      {
+        "id": "f259181e-f54d-42e9-96df-6aaa42277e0b",
+        "habitId": "cd868b72-98a5-4d0b-9dbc-41099e18aab6",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T06:30:00Z"
+      },
+      {
+        "id": "332027e5-5846-400a-81f5-2c100fa09d93",
+        "habitId": "e676e2e4-3816-4de7-9803-87d9869c0c96",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T07:50:00Z"
+      },
+      {
+        "id": "fd381933-7d33-408b-8b66-928388f0fe4c",
+        "habitId": "e83dbb6d-2723-456c-8148-a87d4fdd1756",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T06:05:00Z"
+      },
+      {
+        "id": "316bd625-7c9b-491a-bc19-da65554e76bc",
+        "habitId": "ec3ad70e-d211-4719-8dec-15bb73e38a59",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T08:05:00Z"
+      }
+    ],
+    "settings": {
+      "id": "user_settings",
+      "theme": "system",
+      "weekStartsOn": 1,
+      "showStreaks": true,
+      "showCompletionRate": true,
+      "defaultView": "today",
+      "createdAt": "2025-08-15T12:00:00Z",
+      "updatedAt": "2026-02-25T15:30:00Z"
+    }
+  }
+}

--- a/public/sample-data/habitflow-sample-standard.json
+++ b/public/sample-data/habitflow-sample-standard.json
@@ -1,0 +1,5831 @@
+{
+  "version": "1.0",
+  "exportedAt": "2026-02-25T15:30:00Z",
+  "app": "HabitFlow",
+  "data": {
+    "habits": [
+      {
+        "id": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "name": "Morning Walk",
+        "icon": "\ud83d\udeb6",
+        "color": "#10b981",
+        "frequency": "daily",
+        "sortOrder": 0,
+        "isArchived": false,
+        "createdAt": "2025-08-15T12:00:00Z",
+        "updatedAt": "2025-12-13T12:00:00Z",
+        "description": "20-minute walk after coffee",
+        "reminderTime": "07:30",
+        "category": "Health"
+      },
+      {
+        "id": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "name": "Read 20 Minutes",
+        "icon": "\ud83d\udcda",
+        "color": "#3b82f6",
+        "frequency": "daily",
+        "sortOrder": 1,
+        "isArchived": false,
+        "createdAt": "2025-08-16T12:00:00Z",
+        "updatedAt": "2025-12-14T12:00:00Z",
+        "description": "Fiction or nonfiction, no doomscrolling",
+        "reminderTime": "21:00",
+        "category": "Learning"
+      },
+      {
+        "id": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "name": "Strength Training",
+        "icon": "\ud83c\udfcb\ufe0f",
+        "color": "#ef4444",
+        "frequency": "specific_days",
+        "sortOrder": 2,
+        "isArchived": false,
+        "createdAt": "2025-08-17T12:00:00Z",
+        "updatedAt": "2025-12-15T12:00:00Z",
+        "description": "Mon/Wed/Fri strength block",
+        "targetDays": [
+          1,
+          3,
+          5
+        ],
+        "reminderTime": "18:00",
+        "category": "Fitness"
+      },
+      {
+        "id": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "name": "Meditation",
+        "icon": "\ud83e\uddd8",
+        "color": "#8b5cf6",
+        "frequency": "weekdays",
+        "sortOrder": 3,
+        "isArchived": false,
+        "createdAt": "2025-08-18T12:00:00Z",
+        "updatedAt": "2025-12-16T12:00:00Z",
+        "description": "10 minutes guided breathing",
+        "reminderTime": "08:00",
+        "category": "Mindset"
+      },
+      {
+        "id": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "name": "Meal Prep",
+        "icon": "\ud83e\udd57",
+        "color": "#14b8a6",
+        "frequency": "weekends",
+        "sortOrder": 4,
+        "isArchived": false,
+        "createdAt": "2025-08-19T12:00:00Z",
+        "updatedAt": "2025-12-17T12:00:00Z",
+        "description": "Prep lunches for the week",
+        "reminderTime": "11:00",
+        "category": "Health"
+      },
+      {
+        "id": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "name": "Practice Guitar",
+        "icon": "\ud83c\udfb8",
+        "color": "#f59e0b",
+        "frequency": "x_per_week",
+        "sortOrder": 5,
+        "isArchived": false,
+        "createdAt": "2025-08-20T12:00:00Z",
+        "updatedAt": "2025-12-18T12:00:00Z",
+        "description": "At least 15 minutes practice",
+        "targetCount": 4,
+        "reminderTime": "20:30",
+        "category": "Creative"
+      },
+      {
+        "id": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "name": "Journal",
+        "icon": "\u270d\ufe0f",
+        "color": "#ec4899",
+        "frequency": "daily",
+        "sortOrder": 6,
+        "isArchived": false,
+        "createdAt": "2025-08-21T12:00:00Z",
+        "updatedAt": "2025-12-19T12:00:00Z",
+        "description": "3 lines minimum",
+        "reminderTime": "22:00",
+        "category": "Mindset"
+      },
+      {
+        "id": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "name": "Language Practice",
+        "icon": "\ud83d\udde3\ufe0f",
+        "color": "#06b6d4",
+        "frequency": "specific_days",
+        "sortOrder": 7,
+        "isArchived": false,
+        "createdAt": "2025-08-22T12:00:00Z",
+        "updatedAt": "2025-12-20T12:00:00Z",
+        "description": "Spanish lessons + review",
+        "targetDays": [
+          0,
+          2,
+          4,
+          6
+        ],
+        "reminderTime": "12:30",
+        "category": "Learning"
+      },
+      {
+        "id": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "name": "Budget Check-in",
+        "icon": "\ud83d\udcb8",
+        "color": "#84cc16",
+        "frequency": "x_per_week",
+        "sortOrder": 8,
+        "isArchived": false,
+        "createdAt": "2025-08-23T12:00:00Z",
+        "updatedAt": "2025-12-21T12:00:00Z",
+        "description": "Review spending and subscriptions",
+        "targetCount": 2,
+        "reminderTime": "19:00",
+        "category": "Admin"
+      },
+      {
+        "id": "010be66a-0553-467e-a698-135588d654dd",
+        "name": "Stretching",
+        "icon": "\ud83e\uddce",
+        "color": "#f97316",
+        "frequency": "daily",
+        "sortOrder": 9,
+        "isArchived": false,
+        "createdAt": "2025-08-24T12:00:00Z",
+        "updatedAt": "2025-12-22T12:00:00Z",
+        "description": "8-minute mobility routine",
+        "reminderTime": "06:45",
+        "category": "Mobility"
+      },
+      {
+        "id": "545e7898-3286-42fa-a182-3f617f56f553",
+        "name": "Call Family",
+        "icon": "\ud83d\udcde",
+        "color": "#a855f7",
+        "frequency": "specific_days",
+        "sortOrder": 10,
+        "isArchived": false,
+        "createdAt": "2025-08-25T12:00:00Z",
+        "updatedAt": "2025-12-23T12:00:00Z",
+        "description": "Sunday check-in call",
+        "targetDays": [
+          0
+        ],
+        "reminderTime": "17:30",
+        "category": "Relationships"
+      },
+      {
+        "id": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "name": "Inbox Zero",
+        "icon": "\ud83d\udce5",
+        "color": "#0ea5e9",
+        "frequency": "weekdays",
+        "sortOrder": 11,
+        "isArchived": false,
+        "createdAt": "2025-08-26T12:00:00Z",
+        "updatedAt": "2025-12-24T12:00:00Z",
+        "description": "Clear email backlog before wrap-up",
+        "reminderTime": "16:30",
+        "category": "Work"
+      },
+      {
+        "id": "9763e598-306f-47b6-87b5-4d7c0a542dd0",
+        "name": "30-Day Cold Showers",
+        "icon": "\ud83e\uddca",
+        "color": "#64748b",
+        "frequency": "daily",
+        "category": "Challenge",
+        "description": "Completed challenge and archived",
+        "sortOrder": 12,
+        "isArchived": true,
+        "createdAt": "2025-09-01T10:00:00Z",
+        "updatedAt": "2025-10-05T10:00:00Z"
+      }
+    ],
+    "completions": [
+      {
+        "id": "9f4f8a4f-4188-48dd-b6fd-43d5d769f461",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T22:50:00Z"
+      },
+      {
+        "id": "e00b61d4-4f79-4866-a39c-5eb669be2ca5",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T07:30:00Z"
+      },
+      {
+        "id": "ffcde4c9-49e7-4156-8c55-90118a1bc5f5",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T07:00:00Z"
+      },
+      {
+        "id": "de1d2247-d096-484b-b934-03131392ad37",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T06:00:00Z"
+      },
+      {
+        "id": "ce6299f7-d0d5-475a-8216-8223d745f2a2",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T22:50:00Z"
+      },
+      {
+        "id": "35098cb8-44bb-430a-8c55-71dd1a660801",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T08:30:00Z"
+      },
+      {
+        "id": "319ec9de-d474-42d6-a655-df5bb7aee11b",
+        "habitId": "9763e598-306f-47b6-87b5-4d7c0a542dd0",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T08:20:00Z"
+      },
+      {
+        "id": "dca9f270-de85-42d3-b0dd-f5d403e3a50b",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-09-28",
+        "completedAt": "2025-09-28T06:20:00Z"
+      },
+      {
+        "id": "90713613-f3d6-4e4e-ba56-87723e6fa838",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T21:40:00Z"
+      },
+      {
+        "id": "0ec0f84e-390f-4b15-b3b9-39cb02e97a4f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T08:00:00Z"
+      },
+      {
+        "id": "c0dc1d00-eca6-4790-acae-a5254679f7c0",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:30:00Z"
+      },
+      {
+        "id": "9e82150b-1b4b-475e-96fa-257ffbbc7ecf",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T08:30:00Z"
+      },
+      {
+        "id": "c0e958de-d9ce-439c-848a-27ca68fb2f85",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T07:40:00Z"
+      },
+      {
+        "id": "4329d52e-e1b2-4c20-9197-ba7c7eab0fd2",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T21:30:00Z"
+      },
+      {
+        "id": "11269b1f-631c-49d8-9874-b2acb3a989a2",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-09-29",
+        "completedAt": "2025-09-29T22:10:00Z"
+      },
+      {
+        "id": "8b5c3006-cfce-463a-b564-3c1b12e06af7",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T12:40:00Z"
+      },
+      {
+        "id": "e0491555-e222-41bc-a0ec-42460d7e5ae2",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T21:40:00Z"
+      },
+      {
+        "id": "c1598cae-6101-4a9d-84ee-e2f806b55f6f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T06:20:00Z"
+      },
+      {
+        "id": "abfa1308-0328-4ec5-b404-943c590a7524",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T06:50:00Z"
+      },
+      {
+        "id": "deff18f8-dccf-4f22-b007-207255c1648b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T06:40:00Z"
+      },
+      {
+        "id": "a65145fc-8021-4e84-9f34-6504c1d94f3a",
+        "habitId": "9763e598-306f-47b6-87b5-4d7c0a542dd0",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T22:50:00Z"
+      },
+      {
+        "id": "a2155bdb-a94f-41f3-bc42-7c02fb980345",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-09-30",
+        "completedAt": "2025-09-30T20:50:00Z"
+      },
+      {
+        "id": "f0e5a0e8-badb-4a21-a12f-933091db087b",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T07:10:00Z"
+      },
+      {
+        "id": "1791c380-6152-4e36-b7f1-43ce120a28c6",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T18:40:00Z"
+      },
+      {
+        "id": "dfe0001c-d1e0-4d48-b8f0-bffeabce5c4b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T06:50:00Z"
+      },
+      {
+        "id": "a8ad91e4-d695-4139-a4fb-3e9469727ecb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T12:00:00Z"
+      },
+      {
+        "id": "630bc795-af42-40ba-a016-20a94619d3fa",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T07:30:00Z"
+      },
+      {
+        "id": "cf8601d9-1428-49d9-934a-fcb89383afb1",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-01",
+        "completedAt": "2025-10-01T18:50:00Z"
+      },
+      {
+        "id": "6a3e4f6f-c965-4c65-8c6c-ee433e34fd8c",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T06:30:00Z"
+      },
+      {
+        "id": "f8923824-79e3-4ffb-a74a-1ff240f4acd4",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T06:20:00Z"
+      },
+      {
+        "id": "9cc29778-d3af-4e02-971a-796a0f749ad5",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T12:20:00Z"
+      },
+      {
+        "id": "ce0f659c-7917-4f4f-b3f5-693411092167",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T06:20:00Z"
+      },
+      {
+        "id": "d805d7fd-cfd9-4ad9-902d-e46b2a4a8456",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T12:00:00Z"
+      },
+      {
+        "id": "b0230c0a-6738-46bb-ba64-7376e46ba305",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-02",
+        "completedAt": "2025-10-02T06:40:00Z"
+      },
+      {
+        "id": "35dc97bc-5592-4946-89cf-5656078060a3",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T20:00:00Z"
+      },
+      {
+        "id": "2e622780-ffea-4479-b071-195385754fea",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T12:00:00Z"
+      },
+      {
+        "id": "bcbc689e-ba9f-4065-aef2-3cad00e2cea5",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T06:20:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "a6733d50-a843-4b42-a329-116cd3ec9a16",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T18:30:00Z"
+      },
+      {
+        "id": "90c65b42-17ad-47f9-82d1-1aca71af9590",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T07:40:00Z",
+        "note": "Canceled trial subscription"
+      },
+      {
+        "id": "366b3a07-ffd7-4ebc-8899-153672a515c4",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T18:40:00Z"
+      },
+      {
+        "id": "58d2c15f-44db-42b3-afc8-c9fa95df5aea",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T06:40:00Z"
+      },
+      {
+        "id": "771437ec-af52-4b78-af6e-83f62af350d1",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-03",
+        "completedAt": "2025-10-03T18:50:00Z"
+      },
+      {
+        "id": "91da6638-2b69-48f7-b45f-30e7c3a971ea",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T12:30:00Z"
+      },
+      {
+        "id": "2187ae55-99a0-4520-8003-9117808d4d56",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T06:30:00Z"
+      },
+      {
+        "id": "b1f77fe8-e0f8-4f4e-a43a-291d618d00e3",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T21:00:00Z",
+        "note": "Reviewed grocery spending"
+      },
+      {
+        "id": "efe74187-de7f-4893-beef-a1cf5ac8e084",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T12:00:00Z"
+      },
+      {
+        "id": "4c0c149b-963d-4ea0-a2fc-85f44695092e",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-04",
+        "completedAt": "2025-10-04T12:50:00Z"
+      },
+      {
+        "id": "5f40474a-b9ee-4a63-9e8a-f15b74921557",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T08:30:00Z"
+      },
+      {
+        "id": "c5b64cfc-15f4-4fcb-aa58-d1ec0b86171d",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T07:30:00Z"
+      },
+      {
+        "id": "35393230-ae00-47c2-942f-ea6950d167eb",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T21:50:00Z"
+      },
+      {
+        "id": "bf362ff3-b27c-432a-8635-387c5d9f3502",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T12:40:00Z"
+      },
+      {
+        "id": "8ce5ff80-b8c9-4362-a72e-59950e33c3c1",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T08:10:00Z"
+      },
+      {
+        "id": "060db9ce-ae63-446e-bdf8-3e2abae3402e",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-05",
+        "completedAt": "2025-10-05T06:40:00Z"
+      },
+      {
+        "id": "b87d64d5-99ee-4ae6-84e0-ef2e2222fcc3",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T08:30:00Z"
+      },
+      {
+        "id": "eb29f866-ec74-4c4a-a402-4490150dbbfc",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T22:10:00Z"
+      },
+      {
+        "id": "eaf29120-6032-4903-bd93-74af4b6c4f1c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T12:20:00Z"
+      },
+      {
+        "id": "6ca396e1-202f-462f-8b1b-b30ceebedc52",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T06:10:00Z"
+      },
+      {
+        "id": "912c4693-b5d6-480e-814a-cee20b3addc2",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-06",
+        "completedAt": "2025-10-06T20:20:00Z"
+      },
+      {
+        "id": "3b098455-524a-4a93-bb38-2b09be690346",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T12:40:00Z"
+      },
+      {
+        "id": "ba77c555-f52d-4b19-8c85-717035ccc019",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T08:10:00Z"
+      },
+      {
+        "id": "41c0a3e3-28a4-4de1-8d92-929467d0a5c5",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T06:50:00Z"
+      },
+      {
+        "id": "77ac28b4-ba43-4dd4-b086-4469d18d306c",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T06:20:00Z"
+      },
+      {
+        "id": "5efe5780-c9ba-4883-b67f-21fe2b864b8d",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T12:10:00Z"
+      },
+      {
+        "id": "264870b6-2cac-4fdb-8b40-332f12c5a71f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T08:20:00Z"
+      },
+      {
+        "id": "62df8055-4971-4e60-9d68-8877f205090b",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-07",
+        "completedAt": "2025-10-07T12:10:00Z"
+      },
+      {
+        "id": "ea8a3387-778e-44cc-a25b-3c202b68a342",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T20:10:00Z"
+      },
+      {
+        "id": "69281b92-bf3a-4aaa-9872-6304db73f32e",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T08:30:00Z"
+      },
+      {
+        "id": "88ffb8b9-e731-4aac-9377-68e7c27ce372",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T08:20:00Z",
+        "note": "Reviewed grocery spending"
+      },
+      {
+        "id": "d2120aff-05b8-4e84-8448-bd599fbc546f",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T06:20:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "f20d3f4e-1f7a-4aad-a1d0-4dfdaba14ce8",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T07:40:00Z"
+      },
+      {
+        "id": "bec5f2a0-ddca-41fc-9554-2f4f420de073",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-08",
+        "completedAt": "2025-10-08T07:40:00Z"
+      },
+      {
+        "id": "59dbc953-2556-4d97-a1d1-9186b94fcb3d",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T20:50:00Z"
+      },
+      {
+        "id": "6c5415e2-e5ae-4900-bae4-a169dadd6641",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T07:50:00Z"
+      },
+      {
+        "id": "783a7537-b7e8-4297-aadb-ffdb7a687335",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T22:50:00Z"
+      },
+      {
+        "id": "498cf66e-102f-441f-8160-b3a4e304da6c",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T18:30:00Z"
+      },
+      {
+        "id": "c29fd183-ba29-4f69-8735-f75394a40e9f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T08:00:00Z"
+      },
+      {
+        "id": "9d9c7c30-3866-4711-b245-3b80b01e9315",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T06:50:00Z"
+      },
+      {
+        "id": "da3d45c1-502c-4a88-96b3-372c86f65751",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-09",
+        "completedAt": "2025-10-09T08:30:00Z"
+      },
+      {
+        "id": "a7ab6eb7-3206-47f3-b8ab-e63e014cd787",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T18:00:00Z"
+      },
+      {
+        "id": "72686f16-c783-419b-9d07-8f884822b725",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T06:50:00Z"
+      },
+      {
+        "id": "3045a3e4-84b9-43fc-bf47-2cad500ee616",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T20:10:00Z"
+      },
+      {
+        "id": "1802f9ed-d716-4754-a36d-85de38ecb4eb",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T21:50:00Z"
+      },
+      {
+        "id": "43e9fe0d-0cd8-4456-b172-cc9737039db7",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:40:00Z"
+      },
+      {
+        "id": "83ef9d43-3057-4f3e-b1dc-cf28d2e979ca",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T12:20:00Z"
+      },
+      {
+        "id": "fcee32ea-2668-40dc-8e22-d72dc828a08c",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T20:50:00Z"
+      },
+      {
+        "id": "234b7d76-52a2-44de-877d-085934783f97",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-10",
+        "completedAt": "2025-10-10T08:10:00Z"
+      },
+      {
+        "id": "27090b4d-34ea-414c-862e-a219c690b827",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T20:50:00Z"
+      },
+      {
+        "id": "185d7e24-20e2-4391-a43d-b8c8c390bb68",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T21:00:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "838f29e5-968d-4853-9f53-914e9a4f8495",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T18:40:00Z"
+      },
+      {
+        "id": "9d8f2f6e-6ae4-4c51-ac3f-faade4f961de",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T18:30:00Z"
+      },
+      {
+        "id": "301ad276-c070-4aad-9658-b8239d430819",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T07:40:00Z"
+      },
+      {
+        "id": "891aa9b3-5ee1-442e-bb7d-f1b7c498a08c",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T22:40:00Z"
+      },
+      {
+        "id": "78c54569-af55-4602-8b47-a63147b31081",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-11",
+        "completedAt": "2025-10-11T08:20:00Z"
+      },
+      {
+        "id": "e6f6338c-8170-4fde-9186-ed0f4bd507f4",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T20:00:00Z"
+      },
+      {
+        "id": "352c77d4-0adf-45bb-8f66-42949f51ba9f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T07:10:00Z"
+      },
+      {
+        "id": "e5b78f4e-e32e-485e-8a27-438b322f46c3",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T20:30:00Z"
+      },
+      {
+        "id": "83e0bcd5-d5f5-46fe-8534-0167ffd56d73",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T12:00:00Z"
+      },
+      {
+        "id": "1a6ba4ba-a081-4b99-8874-bae03ca73275",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T07:50:00Z"
+      },
+      {
+        "id": "4e5b3bad-ae39-4c61-8bdd-1b66a80cafde",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T21:50:00Z"
+      },
+      {
+        "id": "b18f48ea-fd49-4e72-bd4e-67d472e94e50",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T12:30:00Z"
+      },
+      {
+        "id": "092d1487-f283-4c67-ac18-1381b0e78ade",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-10-12",
+        "completedAt": "2025-10-12T06:30:00Z"
+      },
+      {
+        "id": "bec6e1b6-012a-41c3-94d1-5ff2eec14ff9",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T20:40:00Z"
+      },
+      {
+        "id": "ea35152f-ac96-4ddb-b9fb-409310f93aa6",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T06:20:00Z"
+      },
+      {
+        "id": "8e394a67-3645-4e2b-89c8-08292c017a94",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T08:00:00Z"
+      },
+      {
+        "id": "a9e353ee-f90f-4c46-9d02-495f7c82d183",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T21:20:00Z"
+      },
+      {
+        "id": "81ce6409-80cc-459e-9464-fd655238ba72",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-13",
+        "completedAt": "2025-10-13T06:30:00Z"
+      },
+      {
+        "id": "b424ad0b-5b7a-4fa2-a017-c7fbf2085e13",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T12:20:00Z"
+      },
+      {
+        "id": "a37f83f5-7a63-4b0a-a731-096286870a07",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T22:40:00Z"
+      },
+      {
+        "id": "38a8f48f-64c5-41de-9da4-08061b827e56",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T08:00:00Z"
+      },
+      {
+        "id": "a4f7cff6-4023-47a9-a16a-236070ad854e",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T20:00:00Z"
+      },
+      {
+        "id": "dd21b30b-6bec-4faf-aab2-28ad139cc286",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T18:50:00Z"
+      },
+      {
+        "id": "056897f3-7f16-41f8-8f12-6893c4adc36a",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T22:20:00Z"
+      },
+      {
+        "id": "2cbf7058-b3b2-445a-bc88-e23272de6213",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-14",
+        "completedAt": "2025-10-14T18:10:00Z"
+      },
+      {
+        "id": "65dae658-2fae-40e9-b48c-ad1a7fb1061a",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T22:00:00Z"
+      },
+      {
+        "id": "711fdc75-7ce1-4df3-a157-844b10b7abb9",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T18:20:00Z"
+      },
+      {
+        "id": "aa6bc878-6ba1-4ec5-b281-560a85046abb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T12:50:00Z"
+      },
+      {
+        "id": "7cadb592-7f59-4dd6-b4bb-47ecb7ec8633",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T08:50:00Z"
+      },
+      {
+        "id": "ecc3b9c2-a6d0-4a72-bc9c-8fd48ca64013",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T06:30:00Z"
+      },
+      {
+        "id": "973cd4b8-0814-41ce-bc7c-bf973e8a46a6",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-15",
+        "completedAt": "2025-10-15T20:10:00Z"
+      },
+      {
+        "id": "b8eae9ba-c8aa-4a13-86fe-213d272749fc",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T07:00:00Z"
+      },
+      {
+        "id": "1f4bb4f1-1e23-4b62-9f8e-0224de8c2747",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-16",
+        "completedAt": "2025-10-16T20:00:00Z"
+      },
+      {
+        "id": "0a262295-9d78-470d-a680-c0bdc5f8f7bb",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T07:00:00Z"
+      },
+      {
+        "id": "a0d42967-f775-4ddd-a9a3-92b0fc59b700",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T07:20:00Z"
+      },
+      {
+        "id": "13828f34-1b49-4dcb-8080-69a968d34f6f",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T18:30:00Z"
+      },
+      {
+        "id": "18215364-a9cc-4b19-a856-d547a7b78f52",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-17",
+        "completedAt": "2025-10-17T18:40:00Z"
+      },
+      {
+        "id": "42417f54-106e-4429-a6aa-ecf396b02ddf",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T07:20:00Z"
+      },
+      {
+        "id": "0165aeae-d0f4-492d-b53f-f26a21885ad4",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T08:10:00Z"
+      },
+      {
+        "id": "01f207bc-2524-4797-9768-f6506d226674",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T21:40:00Z"
+      },
+      {
+        "id": "a64c5d40-e76e-4009-8799-0b8ca72aef34",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-18",
+        "completedAt": "2025-10-18T20:50:00Z"
+      },
+      {
+        "id": "698e2a74-155a-4ae1-810d-06c62a04601b",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T18:50:00Z"
+      },
+      {
+        "id": "53805919-3be8-4e86-867c-526c09e3b332",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T18:00:00Z"
+      },
+      {
+        "id": "992db8d3-bdab-4502-af02-b72b37e6b8c3",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T22:20:00Z"
+      },
+      {
+        "id": "9b758a73-24ae-4c59-8775-eecb0a2964e9",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T20:00:00Z"
+      },
+      {
+        "id": "f5e79c5f-9e20-4914-985b-08e342bdc3ed",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T12:50:00Z"
+      },
+      {
+        "id": "d8802809-692d-46af-8865-dc2eebc14360",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T07:00:00Z"
+      },
+      {
+        "id": "a609b91b-1491-40b8-87e7-ce88496a4c6d",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T18:10:00Z"
+      },
+      {
+        "id": "93a937c1-06b1-40d9-9629-19b4ddd52db4",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-19",
+        "completedAt": "2025-10-19T22:40:00Z"
+      },
+      {
+        "id": "d8788306-b442-49a5-8c6a-b1cdcd0cef54",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T08:40:00Z"
+      },
+      {
+        "id": "c7a0954f-31e4-41a4-b16f-c71715d54f4f",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T12:30:00Z"
+      },
+      {
+        "id": "8d77ebf3-2dc0-43f5-b67b-585934531246",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T06:50:00Z"
+      },
+      {
+        "id": "6f77ba52-74d5-48e2-8064-7f7733ec987b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T18:50:00Z",
+        "note": "Canceled trial subscription"
+      },
+      {
+        "id": "0fa8c767-2033-4cc7-9606-10c122bebd3e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T08:20:00Z"
+      },
+      {
+        "id": "36ab2eac-ce8f-40bb-98e7-9e4c21a733e9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T08:20:00Z"
+      },
+      {
+        "id": "3c76b29d-fc8c-41ef-a421-710f63938860",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-20",
+        "completedAt": "2025-10-20T21:10:00Z"
+      },
+      {
+        "id": "eb37e5a0-92a3-4ded-b0f5-a2c07287b3ef",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T20:30:00Z"
+      },
+      {
+        "id": "df500603-2463-4c80-9b86-3777d67d7a40",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T12:20:00Z"
+      },
+      {
+        "id": "9cb669f1-5cda-4f3b-aafa-7b3d6ec6cf2c",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T08:00:00Z"
+      },
+      {
+        "id": "a1951952-4a8e-41d4-b0c0-6ce7da5b4dcf",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T20:40:00Z"
+      },
+      {
+        "id": "582e1a36-ebc4-46a4-bc67-af7691db5b18",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-21",
+        "completedAt": "2025-10-21T22:30:00Z"
+      },
+      {
+        "id": "dbff82c1-0422-4a2e-85fe-70eebac21590",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T18:30:00Z"
+      },
+      {
+        "id": "9112093d-7f31-48b9-8b72-97d301496f4e",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T08:00:00Z"
+      },
+      {
+        "id": "40e6b51c-a951-4672-8f4b-b766e7daefa9",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T18:50:00Z"
+      },
+      {
+        "id": "f3642ca8-6c6e-49e0-867e-1c77fa5563c3",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T18:10:00Z"
+      },
+      {
+        "id": "0b593867-5146-4354-8f7d-4b3dc0415677",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-22",
+        "completedAt": "2025-10-22T07:40:00Z"
+      },
+      {
+        "id": "94bda520-b42e-481f-9d7e-249e07d49179",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T20:10:00Z"
+      },
+      {
+        "id": "08ae9ed2-8217-42b8-880b-6a152cf2d258",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T22:30:00Z"
+      },
+      {
+        "id": "6e29f8a8-358f-4489-97b6-d2683b9aab72",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T07:10:00Z"
+      },
+      {
+        "id": "6181ddef-179e-40c7-8423-49e7be88c811",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T21:00:00Z"
+      },
+      {
+        "id": "198e6120-fa95-4f8f-998c-b47e87ece031",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T20:20:00Z"
+      },
+      {
+        "id": "a8d81594-9102-46a9-bc4d-54c4b1641781",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-23",
+        "completedAt": "2025-10-23T21:10:00Z"
+      },
+      {
+        "id": "4670941a-4e3b-4833-8bb3-3fd58c020a47",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T22:00:00Z"
+      },
+      {
+        "id": "7dc07b45-c133-480f-8a4d-13df1f8dcc03",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T22:10:00Z"
+      },
+      {
+        "id": "9444d1bf-1778-4936-a73a-d80fc72bb24b",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T12:10:00Z"
+      },
+      {
+        "id": "2ecb0f04-af4a-46e8-93b9-0436933e7ac3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T22:40:00Z"
+      },
+      {
+        "id": "8a84486f-38f1-4399-b6d0-898335aa77b3",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T07:30:00Z"
+      },
+      {
+        "id": "d0fbf812-6481-4852-8aee-9cf65294d0b3",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-24",
+        "completedAt": "2025-10-24T07:10:00Z"
+      },
+      {
+        "id": "374f65ed-8539-4f1e-8d66-51624c6eb186",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T20:20:00Z"
+      },
+      {
+        "id": "c42957ca-ea7a-4ebb-a797-274342a65d81",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T21:10:00Z"
+      },
+      {
+        "id": "45b8be73-262b-481d-8349-baed8f412a30",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T12:10:00Z"
+      },
+      {
+        "id": "13ac0a82-add3-4491-b896-f50a12f0227d",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T18:00:00Z"
+      },
+      {
+        "id": "503ea709-839c-42c1-858a-2265df646864",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T07:40:00Z"
+      },
+      {
+        "id": "acfdeac8-80cd-42ab-a7df-5d01270ed825",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-25",
+        "completedAt": "2025-10-25T20:30:00Z"
+      },
+      {
+        "id": "991d8e49-1240-4284-a7a4-384ab1ce206d",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T08:40:00Z"
+      },
+      {
+        "id": "7df6e6dc-70c3-4dd6-9f7c-0394e50cdc43",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T21:30:00Z"
+      },
+      {
+        "id": "bc408d37-94eb-4d6b-8848-3873570033dc",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T21:00:00Z"
+      },
+      {
+        "id": "da79a3a5-950e-42c7-b3da-fc81481b58e3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-26",
+        "completedAt": "2025-10-26T07:20:00Z"
+      },
+      {
+        "id": "92e520fe-8803-4b20-9930-0a0aac263410",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T08:10:00Z"
+      },
+      {
+        "id": "0280250d-17cf-4573-9060-8f6648fb80c9",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T07:40:00Z"
+      },
+      {
+        "id": "892bbd29-418e-4d88-82cb-9c04c7c94ad9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T07:00:00Z"
+      },
+      {
+        "id": "7990c5ed-7bb4-4f1c-9910-3681636d2491",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-27",
+        "completedAt": "2025-10-27T22:50:00Z"
+      },
+      {
+        "id": "14622118-77a5-4188-aa7e-abbff50eeeb1",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T21:30:00Z"
+      },
+      {
+        "id": "ccec6184-b90e-4a37-b81d-7856fedc383a",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T07:10:00Z"
+      },
+      {
+        "id": "abd818a6-a68d-4395-945d-e724fac865b0",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T08:50:00Z"
+      },
+      {
+        "id": "e91a45a3-781c-4a76-abb5-5eed5d06a22a",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T22:40:00Z"
+      },
+      {
+        "id": "a605dbbf-e2f4-42b5-ab0d-6651dd579e48",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T18:50:00Z"
+      },
+      {
+        "id": "3b85af5c-c30d-4fb7-ad33-900e1eecb4ec",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T20:00:00Z"
+      },
+      {
+        "id": "30529a02-eaa5-4914-8b9c-ff56ab74bdd0",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-10-28",
+        "completedAt": "2025-10-28T22:30:00Z"
+      },
+      {
+        "id": "8672d8de-1a66-434f-949d-fca30f5cc55d",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T20:00:00Z"
+      },
+      {
+        "id": "06828336-32ef-4588-9bf3-944d1cfd1af7",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T22:20:00Z"
+      },
+      {
+        "id": "e023ba35-923b-42e4-8fbf-8966059c5863",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T12:00:00Z"
+      },
+      {
+        "id": "14b609e6-431e-466a-802e-9ff6a56bcca6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T21:20:00Z"
+      },
+      {
+        "id": "3eb7956f-5fd2-4e00-bc21-fcd80773fb0b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-29",
+        "completedAt": "2025-10-29T22:20:00Z"
+      },
+      {
+        "id": "6622cfb3-a88c-491e-9293-8f77d0b2cc7f",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T22:30:00Z"
+      },
+      {
+        "id": "9ee00e03-9dfa-4fb1-bc89-7e4712249d6b",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:20:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "872c6459-26fc-40af-9f23-9b5e51bb289a",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T18:50:00Z"
+      },
+      {
+        "id": "8dabf348-6ea4-4170-ac6c-f9ee3cd33bb8",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-10-30",
+        "completedAt": "2025-10-30T20:00:00Z"
+      },
+      {
+        "id": "17a23f0e-3efc-4245-9dab-a8b1d6f24216",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T07:20:00Z"
+      },
+      {
+        "id": "96609b5b-506b-4a35-bfdd-e167465eac94",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T06:00:00Z"
+      },
+      {
+        "id": "930ff6c2-a948-4d2b-ac98-a714b62dc8b6",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T12:30:00Z"
+      },
+      {
+        "id": "fa075b35-f7e9-4490-bea0-e4e35c18a96c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T21:50:00Z"
+      },
+      {
+        "id": "ce21edfb-a65f-4f28-823c-ab658aa5639e",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T18:20:00Z"
+      },
+      {
+        "id": "f04aa339-3497-44cc-bd8d-3bf76d50da85",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-10-31",
+        "completedAt": "2025-10-31T08:30:00Z"
+      },
+      {
+        "id": "51abce26-2f81-4ddc-94b1-fc2a4928569d",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T12:20:00Z"
+      },
+      {
+        "id": "c446c39a-73b7-4e66-8adb-2f0af094aa23",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:30:00Z"
+      },
+      {
+        "id": "70909e0e-2162-4add-a6f6-f0c8f61b7bda",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:50:00Z"
+      },
+      {
+        "id": "013db559-8179-40c8-ba26-b59113ec1332",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T07:30:00Z"
+      },
+      {
+        "id": "95488996-76a8-4b91-88df-e1c02c3143b1",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T06:00:00Z"
+      },
+      {
+        "id": "314dc5f4-1a38-4a0d-ac8c-13a7e4d9856c",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-01",
+        "completedAt": "2025-11-01T20:10:00Z"
+      },
+      {
+        "id": "ed10700c-92a5-4c03-8e4d-93cea1abb810",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T06:10:00Z"
+      },
+      {
+        "id": "be0b8add-1e6b-4168-aa52-91ab2d42a873",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T22:10:00Z"
+      },
+      {
+        "id": "56724e4e-63aa-4122-925e-493f6e31b5eb",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T18:10:00Z"
+      },
+      {
+        "id": "bb3eb6be-fc14-4f44-a7ef-95e65f22ec92",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T08:20:00Z"
+      },
+      {
+        "id": "2e285977-fc1b-4fcf-95ec-34415dbeead2",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-02",
+        "completedAt": "2025-11-02T21:40:00Z"
+      },
+      {
+        "id": "69083993-4111-4dec-bfaa-3e04ae419532",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T06:10:00Z"
+      },
+      {
+        "id": "b2f99a97-0ad9-43c8-b8dd-2aab5062eba2",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T21:10:00Z"
+      },
+      {
+        "id": "639c0f40-3767-4f85-bbab-24542ee4fab2",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T12:40:00Z"
+      },
+      {
+        "id": "6f52ce7b-3048-4190-9f3d-7f9ad2e577b1",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T20:40:00Z"
+      },
+      {
+        "id": "029c6555-9c55-4a59-8e7a-5740df74502e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T12:00:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "a704a240-9fd5-425c-b5df-517d550e962f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T21:30:00Z"
+      },
+      {
+        "id": "60af8731-08b9-4cee-a65e-a94c5d525dcf",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-03",
+        "completedAt": "2025-11-03T12:50:00Z"
+      },
+      {
+        "id": "3280473a-4f70-4054-9d75-6b6d1aa2e568",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:50:00Z"
+      },
+      {
+        "id": "e0330458-99bf-4b6a-962b-b5d5c0d87d1c",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:50:00Z"
+      },
+      {
+        "id": "9ee276c5-febc-4147-aa20-cb0dc5f26435",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T07:30:00Z"
+      },
+      {
+        "id": "f8101753-7c38-497d-86dd-e0d9f65fd1c2",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:40:00Z"
+      },
+      {
+        "id": "48c96888-f6b3-4ee7-b794-f9389580f10f",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-04",
+        "completedAt": "2025-11-04T20:10:00Z"
+      },
+      {
+        "id": "bcf64615-2d2a-4876-9fbd-4e3bc3fd6985",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T22:30:00Z"
+      },
+      {
+        "id": "b4411aef-65e9-4aed-9ab8-f05fca6834f5",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T06:40:00Z"
+      },
+      {
+        "id": "bfad8633-5dfc-4987-a416-1d9d44e4a6b3",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T12:30:00Z"
+      },
+      {
+        "id": "ace48560-f752-4245-a2dc-43d87f42de05",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T06:10:00Z"
+      },
+      {
+        "id": "7e416c2f-9cec-496e-85c2-e8fabbfcd94a",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T07:50:00Z"
+      },
+      {
+        "id": "91d696b3-f155-461a-ac40-e7627f903ea0",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T06:50:00Z"
+      },
+      {
+        "id": "204d2d32-ec8d-4e4a-a965-054aea81f69b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T08:30:00Z"
+      },
+      {
+        "id": "3e51e244-65d3-4fdf-bd57-915f70dc29fe",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-05",
+        "completedAt": "2025-11-05T07:20:00Z"
+      },
+      {
+        "id": "b721fcdb-dc7d-4b46-982c-1eff370c7faa",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:20:00Z"
+      },
+      {
+        "id": "561bb3d0-29da-4a81-8df3-c84cd088623e",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T21:00:00Z"
+      },
+      {
+        "id": "d5a9f0b1-4210-40f8-b10e-77d90b3b8499",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:00:00Z"
+      },
+      {
+        "id": "d8e9b7f1-8570-429d-a1b7-7275ec30a9ed",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-06",
+        "completedAt": "2025-11-06T18:10:00Z"
+      },
+      {
+        "id": "fd2eaef9-d582-40c7-a5bd-d1349c5d0898",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T20:40:00Z"
+      },
+      {
+        "id": "fd95ce5b-6cc1-4f58-9a77-c4a3fbdf4df1",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T06:20:00Z"
+      },
+      {
+        "id": "9c96948a-01b0-4e46-b7a5-8a95954afef8",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T21:00:00Z"
+      },
+      {
+        "id": "2b523558-1411-4884-8915-b824b3899ba3",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T07:50:00Z"
+      },
+      {
+        "id": "41e69834-5e47-45eb-986b-3383d0ffc5b9",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-07",
+        "completedAt": "2025-11-07T18:20:00Z"
+      },
+      {
+        "id": "f5892288-321a-4e21-b376-db6ef926f63b",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T12:00:00Z"
+      },
+      {
+        "id": "5931e74d-68c8-4d9a-be01-7165c70183bb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T22:20:00Z"
+      },
+      {
+        "id": "e2743099-2e22-4019-8d43-a3254017ae1c",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-08",
+        "completedAt": "2025-11-08T20:30:00Z"
+      },
+      {
+        "id": "a55cf920-00bd-45dd-904c-838cfcbd082b",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T06:50:00Z"
+      },
+      {
+        "id": "393df3db-7490-4b74-b291-7e6ee5724628",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T21:10:00Z"
+      },
+      {
+        "id": "97727a81-dc18-4cbe-bf26-db4a46ea13e7",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T21:50:00Z"
+      },
+      {
+        "id": "6035c634-c59a-4958-9508-493372afa637",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T06:10:00Z"
+      },
+      {
+        "id": "a6e5e764-3287-4593-9dcc-6abe35b1851f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T21:20:00Z"
+      },
+      {
+        "id": "b24c7104-14d6-4655-9b2d-8d0e63fe79a2",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T06:00:00Z"
+      },
+      {
+        "id": "a49f0062-3cd5-4e98-a6db-206ef529666c",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-09",
+        "completedAt": "2025-11-09T12:20:00Z"
+      },
+      {
+        "id": "056e40dd-7f35-4250-808f-53d8be640bdd",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T08:20:00Z"
+      },
+      {
+        "id": "0cc48c07-ae2b-4649-abb0-363eb9896488",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T18:40:00Z"
+      },
+      {
+        "id": "a15b2eba-5b5f-4546-be3a-55ad45454fab",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T12:20:00Z"
+      },
+      {
+        "id": "2eec9ba2-4ae7-4b1b-ae71-6adbe18bce7c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T12:10:00Z"
+      },
+      {
+        "id": "a7b26418-f387-48ab-a834-4291dd581904",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T21:10:00Z"
+      },
+      {
+        "id": "d4ce8026-7c59-43e8-859e-6203e6b5a74a",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T20:40:00Z"
+      },
+      {
+        "id": "b5bb383d-b3c1-46b4-b018-44dbe5df6de6",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-10",
+        "completedAt": "2025-11-10T18:10:00Z"
+      },
+      {
+        "id": "fbf5e9ed-3abe-42a2-9df0-8bf99642a422",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T07:40:00Z"
+      },
+      {
+        "id": "9f8b6c1c-8f86-45f5-a089-aa681bafce7a",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T07:40:00Z"
+      },
+      {
+        "id": "7109f70e-5313-429f-a9ef-641d2fda93a3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T08:10:00Z"
+      },
+      {
+        "id": "9737e6ca-54f5-41e8-8c99-a636909612da",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T08:20:00Z"
+      },
+      {
+        "id": "4a9410d5-67d9-415e-bb79-0b04474438da",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-11",
+        "completedAt": "2025-11-11T06:10:00Z"
+      },
+      {
+        "id": "ec45f6f4-fbb7-4144-8d8c-0864c5ad7c15",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T07:40:00Z"
+      },
+      {
+        "id": "5fd45860-b80a-4c63-a3a3-78300f0aa92f",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T20:40:00Z"
+      },
+      {
+        "id": "5d31e45d-a7f5-48fc-8a29-90d85bc3e670",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T21:00:00Z"
+      },
+      {
+        "id": "eab927a3-4719-45af-bff4-8a0dfb67bbf9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T12:00:00Z"
+      },
+      {
+        "id": "85822448-768b-4899-81a5-f1a8b47917a3",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T08:10:00Z"
+      },
+      {
+        "id": "2c359767-7970-4c35-b11b-7fdc355db3c7",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-12",
+        "completedAt": "2025-11-12T08:10:00Z"
+      },
+      {
+        "id": "d19a75e7-424c-494d-8372-474970870b00",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T08:50:00Z"
+      },
+      {
+        "id": "602e86b4-cc91-442b-9893-4c3fcb7bf1ab",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T18:00:00Z"
+      },
+      {
+        "id": "679cba85-75ad-4cac-8042-b8642329298b",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T06:40:00Z"
+      },
+      {
+        "id": "67b3669e-acd1-4c6e-803a-648778c16971",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T08:20:00Z"
+      },
+      {
+        "id": "ad3dce05-f4f8-4ed9-afb6-38b74eefd9fb",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-13",
+        "completedAt": "2025-11-13T20:30:00Z"
+      },
+      {
+        "id": "0c319d81-54d1-42fb-ad98-59cceb8746f2",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T07:10:00Z"
+      },
+      {
+        "id": "d87799ce-0658-4e54-91cf-fcef52ce2927",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T22:20:00Z"
+      },
+      {
+        "id": "448174a8-0e5a-4f1d-920a-8d6948e66cc8",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T12:20:00Z"
+      },
+      {
+        "id": "9fb73afc-3df8-4ca1-9a42-c3f0983526a9",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T12:50:00Z"
+      },
+      {
+        "id": "970532ae-1f32-4773-962e-9bfbb751eb8c",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T21:20:00Z"
+      },
+      {
+        "id": "d896786a-4812-4714-8012-d66b0a7df5b8",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T08:20:00Z"
+      },
+      {
+        "id": "955c6f15-1716-412a-9d5d-22e10882bfce",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T08:30:00Z"
+      },
+      {
+        "id": "a935ed59-8e64-4daa-932b-386cc0e78400",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-14",
+        "completedAt": "2025-11-14T18:40:00Z"
+      },
+      {
+        "id": "ae9d0d40-fefb-4926-a355-5233d71cdb98",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T22:50:00Z"
+      },
+      {
+        "id": "76307e61-8bb5-4b1d-a977-c1ba9cdfacef",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T07:30:00Z"
+      },
+      {
+        "id": "f806cf3c-be03-4398-8c08-65b7fe57765b",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T18:40:00Z"
+      },
+      {
+        "id": "e7bba6ee-9dfc-436f-8f59-663bdac64d27",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T20:10:00Z"
+      },
+      {
+        "id": "95c0bfe6-8bb1-45d0-bc21-183c9b41baa4",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T06:50:00Z"
+      },
+      {
+        "id": "3d384dc0-30f4-4beb-8711-434b4fdfd863",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-15",
+        "completedAt": "2025-11-15T21:30:00Z"
+      },
+      {
+        "id": "3766d70e-0cf2-4810-82d7-05f39c1f6329",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T07:20:00Z"
+      },
+      {
+        "id": "39e091f0-4ff7-4412-8ad7-25037ca374b4",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T06:30:00Z"
+      },
+      {
+        "id": "e33611c0-92ba-4f4f-bafc-aba4893f3a06",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T18:50:00Z"
+      },
+      {
+        "id": "328df8c5-e036-4c8b-b14c-e4e4e827e3e9",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T08:20:00Z"
+      },
+      {
+        "id": "2d4d08ad-63e2-49d8-883c-37526c989166",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T08:50:00Z"
+      },
+      {
+        "id": "eeeaf14c-13b7-416b-ac44-417f7ca717c1",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T06:30:00Z"
+      },
+      {
+        "id": "b4b78a14-57f9-4161-863d-4fb4f2855e02",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T06:30:00Z"
+      },
+      {
+        "id": "48869a2f-5df5-4069-9d78-005c61c2648c",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T06:00:00Z"
+      },
+      {
+        "id": "2f4aa165-49a6-4a90-88bc-235621b7fe98",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-16",
+        "completedAt": "2025-11-16T07:40:00Z"
+      },
+      {
+        "id": "08f7a81f-0a73-4eec-9e6a-804664e1265c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T20:00:00Z"
+      },
+      {
+        "id": "1c402c0a-f619-4d16-b830-9b5eb8a75017",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T20:30:00Z",
+        "note": "Updated monthly budget"
+      },
+      {
+        "id": "e9d857c2-d9a3-42dd-a7aa-70a3c0c87956",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T12:50:00Z"
+      },
+      {
+        "id": "27e2a544-71d8-4795-895a-2b1b3c71cc88",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-17",
+        "completedAt": "2025-11-17T07:30:00Z"
+      },
+      {
+        "id": "f15f6549-e3e0-4b33-8f6e-065fdbe43893",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T18:40:00Z"
+      },
+      {
+        "id": "52ef11eb-d13b-4eb1-9dd0-47866121fa61",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-18",
+        "completedAt": "2025-11-18T08:30:00Z"
+      },
+      {
+        "id": "4c19bba4-ba8f-48ac-997c-728c841a38e5",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T08:50:00Z"
+      },
+      {
+        "id": "47e450e4-70c2-4957-ace1-5e511edbf55b",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T12:00:00Z"
+      },
+      {
+        "id": "a7f616e7-949f-4a33-aa66-5317271983b2",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T12:10:00Z"
+      },
+      {
+        "id": "5ef9144d-d1f1-4b61-b2b1-db5724a02592",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T21:50:00Z"
+      },
+      {
+        "id": "955faf14-89e4-4c44-9bf0-0245c196d3ed",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T21:20:00Z"
+      },
+      {
+        "id": "c2d8ffe3-89da-4582-8725-02029be52adf",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T22:30:00Z"
+      },
+      {
+        "id": "05c77c12-4d69-41a6-902b-e0c286441abf",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-19",
+        "completedAt": "2025-11-19T12:40:00Z"
+      },
+      {
+        "id": "624a92d7-6878-4fef-ab8e-5d6a16976c77",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T20:50:00Z"
+      },
+      {
+        "id": "77fcb0d9-8472-48dd-876a-d3ac7eb67591",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T18:20:00Z"
+      },
+      {
+        "id": "144371dd-c1d0-49fe-9048-81d58a743258",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T18:00:00Z"
+      },
+      {
+        "id": "0de49459-5924-4927-86a5-13e648c47367",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-20",
+        "completedAt": "2025-11-20T20:10:00Z"
+      },
+      {
+        "id": "c6d3c5fc-a4c9-491e-af82-79e21d5ebd38",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T12:20:00Z"
+      },
+      {
+        "id": "4fccb31a-5c06-428d-bdea-9ff509aa43c1",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T08:10:00Z",
+        "note": "Stressy day, reset helped"
+      },
+      {
+        "id": "d3284359-733c-492c-b7a1-4fa23ace51f7",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T21:30:00Z"
+      },
+      {
+        "id": "5d62edb7-32a9-490d-834d-996b2ca2837a",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T18:00:00Z"
+      },
+      {
+        "id": "7b241439-d87b-463a-9817-6e11bf9558a9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T21:30:00Z"
+      },
+      {
+        "id": "55ca2342-9286-45e3-bd82-41bc3e6cf23a",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T21:20:00Z"
+      },
+      {
+        "id": "4f34ffc8-69d2-43c7-9bb9-fd6b560425a7",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-21",
+        "completedAt": "2025-11-21T07:50:00Z"
+      },
+      {
+        "id": "37fab96e-cb02-4530-a713-c00aee4f0a71",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T07:20:00Z"
+      },
+      {
+        "id": "db16e519-4ef5-4e6e-bfc1-2846a244e830",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T21:40:00Z"
+      },
+      {
+        "id": "2b109833-cfc0-4bf8-a15d-389438289038",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T06:30:00Z",
+        "note": "Canceled trial subscription"
+      },
+      {
+        "id": "f25d79e5-0b01-4df4-8fa3-6103209956b6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T22:00:00Z"
+      },
+      {
+        "id": "ca8760f0-9f48-45a6-a199-1da9b36227d0",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T21:00:00Z"
+      },
+      {
+        "id": "4b58cec3-485e-45d1-92fe-de2ef55e0df5",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-22",
+        "completedAt": "2025-11-22T18:40:00Z"
+      },
+      {
+        "id": "bcde7049-c889-4e3e-b73c-5976ec6f6f70",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T20:00:00Z"
+      },
+      {
+        "id": "9c05a9d9-fb27-4f8f-8965-48011cf92401",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T18:10:00Z"
+      },
+      {
+        "id": "9dfe07f8-eadf-43c9-bdf4-8e5f92d49605",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T07:40:00Z"
+      },
+      {
+        "id": "beb9ec42-5b55-4c69-af28-c0c739d9afb3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T12:30:00Z"
+      },
+      {
+        "id": "7d18742d-50ce-48a8-b781-57a284cf4054",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T12:40:00Z"
+      },
+      {
+        "id": "90409359-315d-45a4-9184-1762e38694a2",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-23",
+        "completedAt": "2025-11-23T22:20:00Z"
+      },
+      {
+        "id": "74b82469-97ab-42c5-a263-ac9e4a7d387e",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T20:30:00Z"
+      },
+      {
+        "id": "6c56ac2e-cca5-430a-8b41-1d1cb4df2569",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T20:40:00Z"
+      },
+      {
+        "id": "ecdddb0f-5f63-45e2-a957-00db54f04199",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T06:20:00Z"
+      },
+      {
+        "id": "24a7e482-bdf6-4d64-b69d-555917137981",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T18:50:00Z"
+      },
+      {
+        "id": "d6eb0195-0d37-42f6-8b47-a2bfdee228e0",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T18:30:00Z"
+      },
+      {
+        "id": "4eeb925c-99a3-4758-9ebd-0d8cfe641c7b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T20:40:00Z"
+      },
+      {
+        "id": "e68fa890-6bf1-4b26-b171-084de4442345",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-24",
+        "completedAt": "2025-11-24T06:00:00Z"
+      },
+      {
+        "id": "b2f554a8-60d5-4001-9f5c-b8c0fc70591a",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T12:10:00Z"
+      },
+      {
+        "id": "1a24c8f6-fec5-411f-a5d4-3e1cf98dd65e",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T22:10:00Z"
+      },
+      {
+        "id": "8cd0c8bd-bebb-4734-a4ea-d863b76b3aca",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T07:00:00Z"
+      },
+      {
+        "id": "9d3eed64-dcd0-4843-8fff-d0fd8da2b9ae",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T20:00:00Z"
+      },
+      {
+        "id": "f2048e89-ba49-4798-aa15-58ae36ec1ddc",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T12:40:00Z"
+      },
+      {
+        "id": "e4a45cb6-4ba7-4ae9-a669-e22daa29b67f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-25",
+        "completedAt": "2025-11-25T06:40:00Z"
+      },
+      {
+        "id": "ab317c6a-96b3-4551-89da-8b4a8b1ff69f",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T22:10:00Z"
+      },
+      {
+        "id": "b51bc860-2bac-4c63-90bc-a923e8366ef3",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T22:00:00Z"
+      },
+      {
+        "id": "97d97363-65bb-4df4-95c1-2c53489b4c02",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T21:50:00Z"
+      },
+      {
+        "id": "94ad0d10-661c-4efb-9618-b1835a898236",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T07:10:00Z"
+      },
+      {
+        "id": "02c95271-45ca-4495-8ba3-c9587981179d",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T07:20:00Z"
+      },
+      {
+        "id": "a9779a26-a44a-468d-9fdd-976b467199ea",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T08:50:00Z"
+      },
+      {
+        "id": "90295af5-46ee-4c8f-b077-ccb854ca03bd",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-11-26",
+        "completedAt": "2025-11-26T12:30:00Z"
+      },
+      {
+        "id": "b1ef7b83-fcee-47d0-9c68-ae2bc43de1de",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T12:00:00Z"
+      },
+      {
+        "id": "9bbd0c7a-bbb4-4c17-a7b9-17a35e9d234a",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T12:20:00Z"
+      },
+      {
+        "id": "673d9343-a636-4bbb-98bd-f5149e4d4e22",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T12:20:00Z"
+      },
+      {
+        "id": "37c3d514-3cda-40e5-82b6-2e7b3778bb49",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T12:10:00Z"
+      },
+      {
+        "id": "f9a0b6f6-95ac-4126-b648-c8ce654ca727",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T06:00:00Z"
+      },
+      {
+        "id": "be009f34-8675-4401-8637-2ff9bb751eab",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T20:10:00Z"
+      },
+      {
+        "id": "a2c503a6-32b7-426c-8d09-89b411ddbaee",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T07:10:00Z"
+      },
+      {
+        "id": "9491ab1d-6f82-42fb-8727-e86535312f58",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-27",
+        "completedAt": "2025-11-27T07:20:00Z"
+      },
+      {
+        "id": "0c25b47a-4379-4e7c-ab03-b5a2e7516043",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T12:10:00Z"
+      },
+      {
+        "id": "73262123-76a6-4490-9ed2-d976d7ae0974",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T07:30:00Z"
+      },
+      {
+        "id": "11164a19-8188-4387-9b0f-b083da013b37",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T18:00:00Z"
+      },
+      {
+        "id": "f251e4f0-2ceb-4910-87ef-7441a89ef31f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T08:50:00Z"
+      },
+      {
+        "id": "569628ea-41ff-4b7c-9aec-76fe89a0a2ff",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-11-28",
+        "completedAt": "2025-11-28T18:30:00Z"
+      },
+      {
+        "id": "266ab988-bfd4-470d-acce-aa8576c9645f",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T21:30:00Z"
+      },
+      {
+        "id": "13693ee5-2f68-4be4-9889-43f09ad4df92",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T06:40:00Z"
+      },
+      {
+        "id": "6cf85cc6-d444-46fa-a457-f60acceacd11",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T22:30:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "49eb70bd-42bd-4ace-9965-a2ab486f8afb",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-29",
+        "completedAt": "2025-11-29T20:40:00Z"
+      },
+      {
+        "id": "35d4633b-2d82-4373-b8e8-9f9d18694814",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T18:10:00Z"
+      },
+      {
+        "id": "2229f633-6ca5-4678-b5d9-9c53cab96190",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T20:00:00Z"
+      },
+      {
+        "id": "dd32486c-adfe-41b4-a442-a44d63625dcc",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T12:50:00Z"
+      },
+      {
+        "id": "8f7efebb-a6e5-4e6a-a328-567ffa1efd30",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T22:00:00Z"
+      },
+      {
+        "id": "51f1711a-6e51-4ef1-a74c-738d703b0c27",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T07:00:00Z"
+      },
+      {
+        "id": "c0fd66b5-f293-4b3f-bc4f-d9438b65bd3b",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T21:00:00Z"
+      },
+      {
+        "id": "ebb86002-2291-4139-9df5-50b95c2eb38e",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-11-30",
+        "completedAt": "2025-11-30T07:00:00Z"
+      },
+      {
+        "id": "4ee29081-fa9e-43c5-900b-2ad23db47fc6",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T08:20:00Z"
+      },
+      {
+        "id": "5645d15f-9cb2-4edd-abf9-28b7b35294ea",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T18:50:00Z"
+      },
+      {
+        "id": "d0e96838-5d4c-4be1-9d76-ba4e6e93ee78",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T06:20:00Z"
+      },
+      {
+        "id": "f7ec1cb8-9da4-4b66-9ebf-a5855339e4f8",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T21:20:00Z"
+      },
+      {
+        "id": "34bb9d18-7e5f-4775-aa18-5f1445546dba",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-01",
+        "completedAt": "2025-12-01T18:10:00Z"
+      },
+      {
+        "id": "d5093714-f30f-493c-9368-dc753099c125",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T18:50:00Z"
+      },
+      {
+        "id": "acf6bf2b-6fc2-4a7a-b4cd-00115b3a85cc",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T21:10:00Z"
+      },
+      {
+        "id": "4b08bcfd-67eb-41ed-a021-f8a7501f8c53",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T07:00:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "ff9d2ea4-84a6-49d0-b9c4-dffd3edb0cd3",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T12:50:00Z"
+      },
+      {
+        "id": "18fe24ea-a498-47a5-a972-0ae8c72c1e67",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T20:50:00Z"
+      },
+      {
+        "id": "6a5bf195-699a-4bce-ab48-17d9042eb40a",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T21:20:00Z"
+      },
+      {
+        "id": "1ddf5be5-37b9-4c5b-9fb2-f3171d6428a3",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T18:30:00Z"
+      },
+      {
+        "id": "0854ef66-e679-42ea-8cfa-616190f66cc2",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-02",
+        "completedAt": "2025-12-02T07:30:00Z"
+      },
+      {
+        "id": "582363ee-9c69-4b54-ab65-7a382586d16d",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T20:00:00Z"
+      },
+      {
+        "id": "d55b003f-b68e-4bca-ae7b-3592eb9b12d0",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:30:00Z"
+      },
+      {
+        "id": "7266710e-6c45-4289-a91b-f2fd9bbbf102",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T06:50:00Z"
+      },
+      {
+        "id": "7f888720-ab32-4441-aad2-e3eb4f125ca9",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T21:50:00Z"
+      },
+      {
+        "id": "46f9f453-b5b2-4e3b-afd0-634e8f11fc49",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T20:20:00Z"
+      },
+      {
+        "id": "349f6219-2d28-49de-b9b2-28e5729eed8b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T22:20:00Z"
+      },
+      {
+        "id": "44c0e4ae-c97f-4020-81b5-0e94bbe7c934",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-03",
+        "completedAt": "2025-12-03T12:40:00Z"
+      },
+      {
+        "id": "4ff65e3a-5116-4778-92c0-aac03968fa8b",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T06:50:00Z"
+      },
+      {
+        "id": "125d3b4a-4d57-4122-a211-8d5123e61f55",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T07:20:00Z"
+      },
+      {
+        "id": "44fe64c4-8204-466c-9db0-ad58e310256f",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T12:50:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "d5da5f1f-02d9-4447-9b5f-b26f787b9e03",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T07:50:00Z"
+      },
+      {
+        "id": "066d8a73-5020-400b-9496-c184bd95f94e",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T22:50:00Z"
+      },
+      {
+        "id": "fb1d059d-4d61-40ab-b491-21dfdc50d9c5",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-04",
+        "completedAt": "2025-12-04T08:30:00Z"
+      },
+      {
+        "id": "f4958a84-89f8-47e0-85b0-f5e6cc738a87",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T07:40:00Z"
+      },
+      {
+        "id": "d86c1596-652b-4d52-a1ec-ad7a3e41e854",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T21:00:00Z"
+      },
+      {
+        "id": "475242b7-ac19-49fd-a4ff-54f8996bf25d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T20:30:00Z"
+      },
+      {
+        "id": "7dea37f3-afd0-4d09-a822-ba9d3bcfb2af",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T20:50:00Z"
+      },
+      {
+        "id": "aac5232c-9d3e-4b1e-8c48-05484a08318c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T20:00:00Z"
+      },
+      {
+        "id": "47a724e8-7e5a-49f6-b769-5c6dc8192db7",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-05",
+        "completedAt": "2025-12-05T18:30:00Z"
+      },
+      {
+        "id": "aff30284-9a15-4425-a53d-9be726761f58",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T20:30:00Z"
+      },
+      {
+        "id": "bccc46db-cfc0-4338-8540-b1b694160527",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T20:40:00Z"
+      },
+      {
+        "id": "5ab2825f-bc47-482f-9c6e-6dde02423ee1",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-06",
+        "completedAt": "2025-12-06T12:00:00Z"
+      },
+      {
+        "id": "5fc06896-70bb-414d-970c-597128a753b6",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T21:50:00Z"
+      },
+      {
+        "id": "20910b88-fc2d-463b-8a4d-2e6211402d91",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T21:10:00Z"
+      },
+      {
+        "id": "f1c5a93a-774b-491c-9397-2ce221ac7345",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T08:30:00Z"
+      },
+      {
+        "id": "d8c69810-d8af-4fcb-a99d-4f66e8d205fa",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T12:10:00Z"
+      },
+      {
+        "id": "67278fad-8990-401a-b2b8-c1a00e4efe02",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T20:30:00Z"
+      },
+      {
+        "id": "cd4e3a9e-b06d-4da1-89f8-c4fedbb48918",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T06:10:00Z"
+      },
+      {
+        "id": "fcdec754-6c31-45be-8501-1c1f88009270",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T07:50:00Z"
+      },
+      {
+        "id": "179a422a-ce5a-4ffc-ad98-3d62dfe569ca",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-07",
+        "completedAt": "2025-12-07T07:30:00Z"
+      },
+      {
+        "id": "6c8a47c1-13de-47a4-bcfd-f1e096346657",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T12:50:00Z"
+      },
+      {
+        "id": "c0dc6706-72e0-419e-b0ce-1e2ff9e14cb7",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T07:50:00Z"
+      },
+      {
+        "id": "fad53d4b-d78e-4cb6-a47d-18eb0144473c",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-08",
+        "completedAt": "2025-12-08T07:20:00Z"
+      },
+      {
+        "id": "f05b1658-185f-4af3-9490-763cf0d03f45",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T22:20:00Z"
+      },
+      {
+        "id": "7f395ae4-6582-4aff-8c37-e78f4dd0744b",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T07:20:00Z"
+      },
+      {
+        "id": "72c99a2a-336f-4567-966f-fc1fa52a35d5",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T18:20:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "7042daed-f60a-4934-abba-0a102cbea6f7",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T12:30:00Z"
+      },
+      {
+        "id": "a7dc3409-ad05-4ddf-875c-a8614d3e862e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T06:50:00Z"
+      },
+      {
+        "id": "e60fcf7d-e10a-413f-bd69-b0f812811621",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T08:50:00Z"
+      },
+      {
+        "id": "39c76eab-7d59-41e2-ac82-a50a16c62022",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-09",
+        "completedAt": "2025-12-09T08:20:00Z"
+      },
+      {
+        "id": "a04de3d3-9c87-4dbc-9a4d-9e3ec6a9f339",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T06:20:00Z"
+      },
+      {
+        "id": "6e8b8df7-01d8-415f-823a-866cfbd7dc4a",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T06:40:00Z"
+      },
+      {
+        "id": "e4d04ea2-8839-48e3-b0c9-54b933ef0813",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T12:40:00Z"
+      },
+      {
+        "id": "a4db89d7-de8a-41aa-b7ef-461ec33b677a",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-10",
+        "completedAt": "2025-12-10T08:30:00Z"
+      },
+      {
+        "id": "45577093-1b3c-4c1b-ae0f-c5ef85379422",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T18:40:00Z"
+      },
+      {
+        "id": "86111761-f56a-4116-9149-4c7fefdc689d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T21:00:00Z"
+      },
+      {
+        "id": "dc282da0-3a30-4cf3-9f00-ea9f754a0e09",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T18:30:00Z"
+      },
+      {
+        "id": "454d325a-36e2-479a-8770-02cc1b293465",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T07:50:00Z"
+      },
+      {
+        "id": "aa7b35cd-6717-40ba-ba90-0e046d2743bb",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-11",
+        "completedAt": "2025-12-11T20:30:00Z"
+      },
+      {
+        "id": "11afdd71-45d5-480b-8f67-5b357460e707",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T08:50:00Z"
+      },
+      {
+        "id": "23fd8b34-c03d-425c-8768-e34f61907c58",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T20:20:00Z"
+      },
+      {
+        "id": "5a5e6ae7-32db-408e-987b-59fb3f703659",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T22:00:00Z"
+      },
+      {
+        "id": "ce3c5d12-1c0c-4b68-8205-2978521c9486",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T21:30:00Z"
+      },
+      {
+        "id": "910291d0-da72-47a6-a636-5e4624d564e5",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T12:00:00Z"
+      },
+      {
+        "id": "30345475-5029-4dd5-946a-eb8d3c3d5228",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T20:30:00Z"
+      },
+      {
+        "id": "f0306153-f208-4901-96da-ac9d70bfd105",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T12:00:00Z"
+      },
+      {
+        "id": "4845c4d0-e649-4054-ac24-7cdcb75e9979",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-12",
+        "completedAt": "2025-12-12T06:00:00Z"
+      },
+      {
+        "id": "fc3e501d-c2c7-407a-b965-4bcc6662d6a8",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T06:10:00Z"
+      },
+      {
+        "id": "dc70b317-08c7-438b-a1ac-23ccee26c9f1",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T06:10:00Z"
+      },
+      {
+        "id": "de4f8e8c-35e4-4cb9-82e4-47f3ecf5f5c3",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T20:40:00Z"
+      },
+      {
+        "id": "a6038ca8-9742-419c-897a-9eba91f2d2f9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T08:20:00Z"
+      },
+      {
+        "id": "3d047958-4872-4030-b82b-21b6b5a711a3",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T22:00:00Z"
+      },
+      {
+        "id": "ceb66d7a-b85f-4ab7-91ed-c9ff9c9471f5",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-13",
+        "completedAt": "2025-12-13T20:20:00Z"
+      },
+      {
+        "id": "434722b1-3607-478b-8bd5-790b25e1c9a3",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T22:10:00Z"
+      },
+      {
+        "id": "7f84015d-de90-4255-ade7-28c81bff1825",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T22:50:00Z"
+      },
+      {
+        "id": "8349d518-d960-4c9b-bd85-e48bbafbbf42",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T12:20:00Z"
+      },
+      {
+        "id": "5441a3c0-745c-4f0f-9e5f-cfc2feb12604",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T18:50:00Z"
+      },
+      {
+        "id": "f0eb80a5-3df8-4b98-9c24-d79dca487fb5",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T12:50:00Z"
+      },
+      {
+        "id": "cf46a19f-9475-4f3c-bf35-d84d0c6a98c1",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T12:20:00Z"
+      },
+      {
+        "id": "06a279af-00f1-41ed-98b2-c71202cdcf6a",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-14",
+        "completedAt": "2025-12-14T21:50:00Z"
+      },
+      {
+        "id": "ea72c05e-3356-4d57-a274-c4df1b2c7394",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T20:40:00Z"
+      },
+      {
+        "id": "ba4f976d-64c8-475f-b997-96d9357a1b4b",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T18:30:00Z"
+      },
+      {
+        "id": "50a75930-2279-494d-8058-f4574a4344e1",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T08:50:00Z"
+      },
+      {
+        "id": "5afed729-3a38-45fe-bf4d-e53baf3be0e3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T20:50:00Z"
+      },
+      {
+        "id": "0648f19f-a7fb-47bc-9fa9-b2710bdffe76",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-15",
+        "completedAt": "2025-12-15T20:10:00Z"
+      },
+      {
+        "id": "704bf13c-47f1-450f-b8ee-932dc34b9cd5",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T07:10:00Z"
+      },
+      {
+        "id": "7841dac6-c538-4b6e-8390-42b31b534238",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T20:00:00Z"
+      },
+      {
+        "id": "cc4968a3-493b-4a48-8a5c-8ff5a2ce6352",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:30:00Z"
+      },
+      {
+        "id": "572357b4-bc67-4a56-9aae-8928fffe886a",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T06:10:00Z"
+      },
+      {
+        "id": "266c605a-bbf6-48fe-9409-3ed66f8ab99b",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:50:00Z"
+      },
+      {
+        "id": "eb63e355-6efb-439b-bbbc-d8ed83b34468",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T12:10:00Z"
+      },
+      {
+        "id": "b65b9169-01a4-4dfa-8789-c75a9a2ebac1",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T08:20:00Z"
+      },
+      {
+        "id": "2360d7fc-cd5c-4c69-824c-4d2445fb5874",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-16",
+        "completedAt": "2025-12-16T22:30:00Z"
+      },
+      {
+        "id": "91356c50-e3d7-4b6c-8b47-7a576254e173",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T06:10:00Z"
+      },
+      {
+        "id": "2497cb38-84f8-490f-9308-cc8d21ed8f25",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T08:40:00Z"
+      },
+      {
+        "id": "e705334e-a877-4add-90d6-8fc49cf74872",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T06:30:00Z"
+      },
+      {
+        "id": "b2524038-169b-4099-a9f4-9b1508f888e9",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T12:30:00Z"
+      },
+      {
+        "id": "e2e65652-56ab-44ad-a843-e25713e4e4a3",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T12:50:00Z"
+      },
+      {
+        "id": "730a4544-2c4b-499c-b942-ddc2511bb0c6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T08:10:00Z"
+      },
+      {
+        "id": "d90fb6a6-f92b-432e-9450-20fb03cd0f7a",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-17",
+        "completedAt": "2025-12-17T20:10:00Z"
+      },
+      {
+        "id": "f5850a99-e174-4bd3-9290-5536c145c199",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T07:00:00Z"
+      },
+      {
+        "id": "23dc328f-ec4e-46e9-a69f-f14bc1bb193c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T06:10:00Z"
+      },
+      {
+        "id": "3969dddc-4ec0-4155-b22c-479bd00dc189",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T08:10:00Z"
+      },
+      {
+        "id": "411bdf65-e699-4fe9-8bcf-86df531f0b89",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T22:50:00Z"
+      },
+      {
+        "id": "28a68535-9671-4d26-8d85-7d7c1d3150f0",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T18:20:00Z"
+      },
+      {
+        "id": "52e3e24f-cef5-4689-8e6b-5196c0c504c3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T12:10:00Z"
+      },
+      {
+        "id": "76176081-944e-4fe2-8600-88ea7d95d380",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T20:20:00Z"
+      },
+      {
+        "id": "db520fd6-9fe0-4f86-89de-0e6b4068433d",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-18",
+        "completedAt": "2025-12-18T08:40:00Z"
+      },
+      {
+        "id": "3010ce34-f90f-4af9-8b48-5062dd7a387e",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T18:20:00Z"
+      },
+      {
+        "id": "c6243b37-be94-4bfe-bf01-5fc74e66c7a3",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T20:50:00Z"
+      },
+      {
+        "id": "11bed644-dbf8-4fe4-a956-a5bd17dd0028",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T20:50:00Z"
+      },
+      {
+        "id": "9b158ed5-9846-42b5-bb8c-0b8b690efc0f",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T22:00:00Z"
+      },
+      {
+        "id": "64b7d3ba-11ba-4a6c-904c-d5f2a10bdf45",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-19",
+        "completedAt": "2025-12-19T18:00:00Z"
+      },
+      {
+        "id": "014c1dd6-e96c-48dd-ab81-0a20973d53e9",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T07:30:00Z"
+      },
+      {
+        "id": "148199e1-8047-44f4-bc8c-a00c62c3c37d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T12:30:00Z"
+      },
+      {
+        "id": "a4527107-6f8b-4b0d-b4cf-85459384354f",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T22:10:00Z"
+      },
+      {
+        "id": "b78920c5-52e6-4b94-9f62-97aa69caf791",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T12:20:00Z"
+      },
+      {
+        "id": "a125f313-9ef2-45b1-887e-d6eab3d16279",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T06:20:00Z"
+      },
+      {
+        "id": "373fa7d9-71f7-47a7-959f-9eef3f0fe251",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T21:20:00Z"
+      },
+      {
+        "id": "a6099b6c-113a-432c-8d98-3e2e1d3478fc",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-20",
+        "completedAt": "2025-12-20T08:30:00Z"
+      },
+      {
+        "id": "6b7e329a-b774-4a04-9326-2982bcb9333e",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T08:00:00Z"
+      },
+      {
+        "id": "a9def24d-488c-4858-88d2-596df8e7ab94",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T22:20:00Z"
+      },
+      {
+        "id": "c41f9b46-9f71-4551-8198-96c622357420",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:10:00Z"
+      },
+      {
+        "id": "29cdd6b1-84ad-4744-92e5-3100f8d5332a",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:20:00Z"
+      },
+      {
+        "id": "62185194-17e6-4c8a-93af-b8b52f3ca0c1",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T07:10:00Z"
+      },
+      {
+        "id": "607ee36c-b873-4e95-8902-c7b507301236",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T12:50:00Z"
+      },
+      {
+        "id": "5e61d438-f412-4f5e-871e-aa8c172c7b8d",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T18:20:00Z"
+      },
+      {
+        "id": "ec0fb052-5449-4e65-ace4-42cde23eed75",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-21",
+        "completedAt": "2025-12-21T12:00:00Z"
+      },
+      {
+        "id": "0e127bd6-c258-4e36-8e0b-d087e56e42a9",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T06:50:00Z"
+      },
+      {
+        "id": "c5d26040-f30c-44a2-9ab0-964bbeab8a77",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T07:50:00Z"
+      },
+      {
+        "id": "7f64a789-0b16-473f-9806-45bcc993ec26",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T12:20:00Z"
+      },
+      {
+        "id": "816b41c0-ed9a-49a0-ac02-4c788f700bd7",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T22:40:00Z"
+      },
+      {
+        "id": "aaa8f27d-dbe3-43b5-8e4c-1471284330dd",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T20:30:00Z"
+      },
+      {
+        "id": "4481f7b0-3f14-4b55-97c7-7bfc37b63a92",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T22:00:00Z"
+      },
+      {
+        "id": "2148ae88-83e9-479c-9a98-52513adca285",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-22",
+        "completedAt": "2025-12-22T12:00:00Z"
+      },
+      {
+        "id": "1dc2e348-f20a-4242-9f61-45a122017660",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T06:10:00Z"
+      },
+      {
+        "id": "d0e24028-96fc-413b-8d35-adfd8c0f8dba",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T06:10:00Z"
+      },
+      {
+        "id": "aac588c6-8c09-42f6-9e4e-5beeb58c16e0",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T21:10:00Z"
+      },
+      {
+        "id": "f95da60b-fbdd-4c58-b2da-415e76e005ba",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-23",
+        "completedAt": "2025-12-23T21:20:00Z"
+      },
+      {
+        "id": "e2743098-553f-4969-9e90-c86388f4975b",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T06:50:00Z"
+      },
+      {
+        "id": "bc9ea8d1-8075-4029-b57a-12d704552c7c",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T20:50:00Z"
+      },
+      {
+        "id": "8db6c788-80b2-480b-bbfc-058c4f5e6c87",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T08:30:00Z"
+      },
+      {
+        "id": "376427c8-16dc-4474-895e-bc6ec7fec44d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T21:30:00Z"
+      },
+      {
+        "id": "2aeb0b46-4fa3-4891-bf7f-deb4ce970761",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T22:30:00Z"
+      },
+      {
+        "id": "0a8d219c-68d1-43d2-aecd-123b577d14b7",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-24",
+        "completedAt": "2025-12-24T20:20:00Z"
+      },
+      {
+        "id": "c2918c57-cbdf-46e3-95b7-0d6368ae2aaf",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T20:10:00Z"
+      },
+      {
+        "id": "2040abf5-9c16-43d4-8276-82e1ae938c19",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T06:10:00Z"
+      },
+      {
+        "id": "143aa703-f1e1-4ef4-b8cc-c609f232081b",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T21:10:00Z"
+      },
+      {
+        "id": "9356146c-f008-4811-87d0-8d157ec64a41",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T18:00:00Z"
+      },
+      {
+        "id": "c5749ca7-a192-4258-9702-22886e190a2b",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T08:40:00Z"
+      },
+      {
+        "id": "a3578962-5337-4c96-84fc-47ad36d5213d",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T07:10:00Z"
+      },
+      {
+        "id": "33e949c5-281a-46bc-9afa-f0165712a2cf",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T06:50:00Z"
+      },
+      {
+        "id": "ffbaaac9-7d3a-47a9-8500-a2034b25813e",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-25",
+        "completedAt": "2025-12-25T12:20:00Z"
+      },
+      {
+        "id": "5063322a-8dc5-48cb-8a7e-1717f79f5351",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T21:00:00Z"
+      },
+      {
+        "id": "4a0c3e2f-89f4-478a-a114-74756c5a47ec",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T21:30:00Z"
+      },
+      {
+        "id": "b49d5b09-aa71-4990-9384-1fd3dfe65e6f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T18:20:00Z"
+      },
+      {
+        "id": "5c76c61e-00e4-4168-b770-e0ac0bff3b28",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T06:20:00Z"
+      },
+      {
+        "id": "8ccf2970-1ab8-425a-8d8f-dba75a7e71c0",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T20:40:00Z"
+      },
+      {
+        "id": "07f2f964-bb1f-4262-8ad5-4182391830a6",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T20:10:00Z"
+      },
+      {
+        "id": "8333df9b-1ade-421d-8203-f23a7bd1ae3f",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-26",
+        "completedAt": "2025-12-26T20:10:00Z"
+      },
+      {
+        "id": "733816a2-c606-40d6-b557-8e40e488e6ac",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T20:30:00Z"
+      },
+      {
+        "id": "00076148-3958-419e-b9c7-b84c592c81ad",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T07:20:00Z"
+      },
+      {
+        "id": "7944b39e-d113-498e-b98f-a8acbb2a6594",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T22:20:00Z"
+      },
+      {
+        "id": "9494c6aa-3768-4a26-a609-bf23ccae0fa6",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T18:30:00Z"
+      },
+      {
+        "id": "1db09d4e-0b22-4611-85a7-197927b256ea",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T18:40:00Z"
+      },
+      {
+        "id": "8c84fe1e-3cf8-4505-b507-7126b0ba2d71",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T06:30:00Z"
+      },
+      {
+        "id": "6d10cf9a-4a5f-40cf-8c01-50515a306f26",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T20:20:00Z"
+      },
+      {
+        "id": "287e4181-9fb2-4ff9-aa13-151a9a28278f",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-27",
+        "completedAt": "2025-12-27T21:00:00Z"
+      },
+      {
+        "id": "98d359b0-fb4f-4212-a211-e0a7123f9604",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T08:40:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "813c8958-98eb-4e2d-8b59-9599bb074c6a",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T22:30:00Z"
+      },
+      {
+        "id": "75f1a3b8-57df-4c7d-9fc6-873726986ce2",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T06:10:00Z"
+      },
+      {
+        "id": "399a6148-5932-494f-91cd-0a5721088aa1",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T21:30:00Z"
+      },
+      {
+        "id": "0af14749-9b61-4686-989f-3e867894c82c",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T22:20:00Z"
+      },
+      {
+        "id": "f787c529-aece-4141-9484-bed5b0a8ca1d",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2025-12-28",
+        "completedAt": "2025-12-28T18:40:00Z"
+      },
+      {
+        "id": "919d87a6-4518-49bb-9022-43b8697d05e6",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T22:00:00Z"
+      },
+      {
+        "id": "a96bb125-1eb2-4608-8bba-28b82c181b85",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T06:10:00Z"
+      },
+      {
+        "id": "ed47e57b-9296-4726-97b9-afe01dd5d9f9",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:50:00Z"
+      },
+      {
+        "id": "1b5ef942-725c-4757-afa7-31f97cb1bc9b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T07:00:00Z",
+        "note": "Reviewed grocery spending"
+      },
+      {
+        "id": "40d8585d-522f-4970-8d54-ee671d24c457",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T21:20:00Z"
+      },
+      {
+        "id": "09fc93d7-14c5-4d6d-8389-f76de94de54f",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T07:50:00Z"
+      },
+      {
+        "id": "5f88a36c-d04c-4fde-b6dd-d1766b119383",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T18:30:00Z"
+      },
+      {
+        "id": "8b90c935-dd36-42c0-8b68-b6dff66e0583",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-29",
+        "completedAt": "2025-12-29T07:10:00Z"
+      },
+      {
+        "id": "6b68b952-e30f-460b-88ad-5e1e8ec97fe6",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T20:40:00Z"
+      },
+      {
+        "id": "1d1c1db4-ebda-45af-ab2d-1e8c1758795f",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T06:00:00Z"
+      },
+      {
+        "id": "6a325417-5983-4e9a-a214-cb7ac6843eed",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T18:00:00Z"
+      },
+      {
+        "id": "d9830765-76ed-4b46-9f9f-3d94ede21885",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T21:50:00Z"
+      },
+      {
+        "id": "b24441a5-e4c8-49e3-bf53-bb032a23f191",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T20:50:00Z"
+      },
+      {
+        "id": "5b91a1eb-751a-4928-8f39-2c9a600ca693",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T18:40:00Z"
+      },
+      {
+        "id": "d4b0575b-e867-4b76-9ea0-b0e369502c24",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T21:50:00Z"
+      },
+      {
+        "id": "ac9c0505-48bc-41ff-9479-d766335e918f",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-30",
+        "completedAt": "2025-12-30T18:20:00Z"
+      },
+      {
+        "id": "6d84c934-2a59-4c98-9867-98400da2ae48",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T20:00:00Z"
+      },
+      {
+        "id": "441e05bb-30a5-4cdb-bb64-9f0bcaae2e96",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T20:20:00Z"
+      },
+      {
+        "id": "e6205f72-b19a-4ca7-8302-d46f6d037275",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T20:30:00Z"
+      },
+      {
+        "id": "6d5fb3f1-2317-4d07-844d-027123ca9714",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T06:50:00Z"
+      },
+      {
+        "id": "9df06656-a2ae-40cf-bb2b-01a384a782c9",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T22:30:00Z"
+      },
+      {
+        "id": "09955e96-159d-458e-8392-ab556c1fe21c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T12:00:00Z"
+      },
+      {
+        "id": "8d42a3fa-e2ec-490e-971c-d87e86c5839a",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T22:10:00Z"
+      },
+      {
+        "id": "ab577208-a5ac-4852-a798-a9c26becbb22",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T08:40:00Z"
+      },
+      {
+        "id": "47dee649-4ace-48c0-8cb9-5b13986adb64",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2025-12-31",
+        "completedAt": "2025-12-31T22:40:00Z"
+      },
+      {
+        "id": "055d2294-4fec-4928-91c8-246a6e2b8070",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:10:00Z"
+      },
+      {
+        "id": "463d31af-f079-4459-8ceb-8613823a5ca5",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:40:00Z"
+      },
+      {
+        "id": "ba869183-a0c9-4341-ae03-39e46d287744",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T21:50:00Z"
+      },
+      {
+        "id": "3852d4bd-1a37-4878-8d51-d7b086037965",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:00:00Z"
+      },
+      {
+        "id": "c46a1d04-714d-4b95-a10c-dedf3bff5ad8",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T20:00:00Z"
+      },
+      {
+        "id": "0874db44-97e1-41f9-9985-aa7138d2c58b",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-01",
+        "completedAt": "2026-01-01T18:40:00Z"
+      },
+      {
+        "id": "648ec82b-65fa-40b2-b052-24594c185751",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T08:10:00Z"
+      },
+      {
+        "id": "ebf2540e-1f56-4d0a-8f5d-ad3a7d5c63ca",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T18:40:00Z"
+      },
+      {
+        "id": "c47759ec-35fc-4a15-9b23-1ca6a86be8cc",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T18:20:00Z"
+      },
+      {
+        "id": "9f550a2a-2355-42d0-b171-1d94c7bf477f",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T20:00:00Z"
+      },
+      {
+        "id": "7b7ced94-795d-4cde-80b7-64d10defe63d",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-02",
+        "completedAt": "2026-01-02T21:00:00Z"
+      },
+      {
+        "id": "dda51858-6f0b-49ec-850e-1852e6482bd2",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T07:20:00Z"
+      },
+      {
+        "id": "b9ee2df3-e50c-4fca-b4a5-79e4d9948cac",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T18:30:00Z"
+      },
+      {
+        "id": "7b1ffcf1-9c8b-433c-8f7e-45bcbb737df1",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T21:40:00Z"
+      },
+      {
+        "id": "5f2e56b5-f615-4b9f-a5e4-f0c277eaff49",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T06:30:00Z"
+      },
+      {
+        "id": "6638a717-d962-44a0-b183-ebc2f6ed47df",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-03",
+        "completedAt": "2026-01-03T21:40:00Z"
+      },
+      {
+        "id": "7ada101f-aca6-4485-b17d-3ac4f430ba92",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T18:10:00Z"
+      },
+      {
+        "id": "015af7ca-e118-4051-af46-8b01f26063a3",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T21:40:00Z"
+      },
+      {
+        "id": "53ea64c4-bd62-4091-99fe-c63c9864ee95",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T21:50:00Z"
+      },
+      {
+        "id": "a9030fcf-db8d-4b76-953e-85c6d75e5eae",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-04",
+        "completedAt": "2026-01-04T07:20:00Z"
+      },
+      {
+        "id": "ad077fef-d93a-4ca9-815c-b9828f0290be",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T08:50:00Z"
+      },
+      {
+        "id": "f4325208-cf55-49c3-a02a-02e5bcd1e802",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T20:40:00Z"
+      },
+      {
+        "id": "9ea9cff7-f47e-416a-9ad1-56dadd3ac232",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T20:40:00Z"
+      },
+      {
+        "id": "a66cb5fc-7651-4241-8134-910f54de6b8c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T06:30:00Z"
+      },
+      {
+        "id": "a07f9715-39d1-437e-bc73-dcbfece24e26",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-05",
+        "completedAt": "2026-01-05T07:00:00Z"
+      },
+      {
+        "id": "622936fc-a58a-4252-aaef-1b62ac27c0e3",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:10:00Z"
+      },
+      {
+        "id": "f81dba17-3bea-409a-8134-d9dfd492549a",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T18:30:00Z"
+      },
+      {
+        "id": "293d1990-264c-4a40-928c-98f1220c62b7",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T12:00:00Z"
+      },
+      {
+        "id": "5f42da3c-30f0-41f3-8ce4-d1fdb65ec993",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-06",
+        "completedAt": "2026-01-06T08:10:00Z"
+      },
+      {
+        "id": "b7e9a215-7f16-48c3-a84c-f393336432c7",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T12:50:00Z"
+      },
+      {
+        "id": "c5da87da-88b2-4fa3-868d-2d28a1a20af4",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T06:10:00Z"
+      },
+      {
+        "id": "5d907ff0-5241-47de-862b-663262ac50be",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T21:10:00Z"
+      },
+      {
+        "id": "d9804d65-d0e2-403b-90a7-8ab92dc1e8bf",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T20:10:00Z"
+      },
+      {
+        "id": "6bbdcca3-42f8-4f5d-bc06-3f62953201a0",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T21:10:00Z"
+      },
+      {
+        "id": "49e4a4e7-4f0f-45de-9c90-725fe399abe6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T22:00:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "9e811dc3-ed4e-4469-b5ab-8930f2a5bae9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T22:50:00Z"
+      },
+      {
+        "id": "a5ddd648-969c-4018-99da-f5842ef48058",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T21:30:00Z"
+      },
+      {
+        "id": "ee5fdf62-5d1e-4058-a755-b2a471015fa6",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-07",
+        "completedAt": "2026-01-07T08:50:00Z"
+      },
+      {
+        "id": "2959edd1-abdc-45f2-aca3-495cc2085aad",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T22:00:00Z"
+      },
+      {
+        "id": "b3da893f-451c-4b5d-9d6a-52e2655b6e63",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T08:40:00Z"
+      },
+      {
+        "id": "e95cf55c-76d3-4f07-a85e-8eaced3194e5",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T20:50:00Z"
+      },
+      {
+        "id": "2e735b8a-1ff2-4ad2-8ef0-b96f98bf35b6",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T08:00:00Z"
+      },
+      {
+        "id": "3a1f5eb7-71cd-46e3-b71d-0dba7a277c82",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T22:50:00Z"
+      },
+      {
+        "id": "15ab4e38-f1bc-448a-a429-0a64b7273b07",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-08",
+        "completedAt": "2026-01-08T22:20:00Z"
+      },
+      {
+        "id": "bec90539-10e4-46df-9602-439460199663",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T07:50:00Z"
+      },
+      {
+        "id": "1e00dc82-ae4f-4710-bb01-834d5eab7d73",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-09",
+        "completedAt": "2026-01-09T08:30:00Z"
+      },
+      {
+        "id": "a707e9d0-5196-4079-aa2f-a2654c576652",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T22:40:00Z"
+      },
+      {
+        "id": "bb7fe490-d175-4dd8-aa52-fe41ef59113f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T07:00:00Z"
+      },
+      {
+        "id": "e3107cb0-2f62-4688-a7f3-3eeb80aeb9be",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T07:10:00Z"
+      },
+      {
+        "id": "092a7063-a011-4870-ba6a-2d2c04f95bac",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T08:00:00Z"
+      },
+      {
+        "id": "39b458a5-c940-47ef-8638-beceda17c814",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T06:40:00Z"
+      },
+      {
+        "id": "11bc6e29-791d-4606-b010-d1bd233c0fe2",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-10",
+        "completedAt": "2026-01-10T20:30:00Z"
+      },
+      {
+        "id": "17acf9ac-746b-4de0-b787-c7236ccf6259",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T18:10:00Z"
+      },
+      {
+        "id": "e9a61342-442d-47b2-8df4-32af05f5deeb",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T07:50:00Z"
+      },
+      {
+        "id": "9bdb78bc-4db2-45d1-beb4-4bae21f153c9",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T08:50:00Z"
+      },
+      {
+        "id": "deae6915-2ca7-486e-bffe-0c7e7d4bf738",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T07:50:00Z"
+      },
+      {
+        "id": "f26f2962-cad6-42af-b1ca-5ccb2c422500",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T07:40:00Z"
+      },
+      {
+        "id": "d7b9c73a-347d-4fc1-bb39-29eacb4eba84",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-11",
+        "completedAt": "2026-01-11T07:40:00Z"
+      },
+      {
+        "id": "03562024-0b6c-4ddd-a4f2-75eecd77d6d5",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T22:00:00Z"
+      },
+      {
+        "id": "aa771ef2-6ed8-42d1-aa28-72f4902aec7a",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T18:30:00Z"
+      },
+      {
+        "id": "973fada9-1313-4b62-97ce-314d89fdf939",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T07:40:00Z"
+      },
+      {
+        "id": "53955184-cf9e-44b5-be95-68529b7517fb",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T20:10:00Z"
+      },
+      {
+        "id": "239c766d-37dc-4838-b728-0bb423560ad8",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-12",
+        "completedAt": "2026-01-12T21:20:00Z"
+      },
+      {
+        "id": "f0bf9749-b7a5-47c5-99f7-860fd0ba822a",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T20:10:00Z"
+      },
+      {
+        "id": "9c38ee3b-c381-4b7c-b91b-b94f76074288",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T08:40:00Z"
+      },
+      {
+        "id": "25528d6f-58b4-43a8-93e6-dd8f9b887717",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T12:10:00Z"
+      },
+      {
+        "id": "32f496c3-d4d8-4274-9e64-66963c973c1b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T18:10:00Z",
+        "note": "Canceled trial subscription"
+      },
+      {
+        "id": "826f1a3e-4c1b-4ba1-9015-54064d79bb95",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T12:10:00Z"
+      },
+      {
+        "id": "e3cd1f1b-231d-4737-8854-5d860233960f",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-13",
+        "completedAt": "2026-01-13T22:30:00Z"
+      },
+      {
+        "id": "59b93980-08a0-4d42-8e5e-e9e0bcc7d1eb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T06:00:00Z"
+      },
+      {
+        "id": "1dee09f8-a0f7-4dda-a4de-b2c0c64c16c8",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T12:20:00Z"
+      },
+      {
+        "id": "2cfcb2a0-223d-412b-aa28-83b199d1a74f",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-14",
+        "completedAt": "2026-01-14T21:00:00Z"
+      },
+      {
+        "id": "afc50e17-1952-4c4d-9d4a-2657f8838bb3",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T07:00:00Z"
+      },
+      {
+        "id": "9f4167b2-257f-47bc-9715-b61ce17d368f",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T20:40:00Z"
+      },
+      {
+        "id": "094e9c2d-404a-427c-97ad-2f0c9cf57180",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T18:10:00Z",
+        "note": "Kept it short but done"
+      },
+      {
+        "id": "fa4fdc7c-8d95-4d4b-8e23-cdd4e4207344",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T08:10:00Z"
+      },
+      {
+        "id": "9eeb266c-b1de-4b24-b082-b3e30c8839d6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T06:50:00Z"
+      },
+      {
+        "id": "0c610b6c-087f-42fd-9296-c1fca8ae8163",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T20:20:00Z"
+      },
+      {
+        "id": "8d1e58a3-21f6-49fb-aa0f-e97544672aa9",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T22:10:00Z"
+      },
+      {
+        "id": "748f2b13-e3cb-49cc-93bc-96ba3be4ddfd",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-15",
+        "completedAt": "2026-01-15T07:30:00Z"
+      },
+      {
+        "id": "a1ba556e-9830-40e4-9a58-0c7c467d6967",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T07:00:00Z"
+      },
+      {
+        "id": "a26f027a-a7d0-4bbc-bd83-064ce5d250d8",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T08:00:00Z"
+      },
+      {
+        "id": "2e4a8cbc-e604-4098-89f0-1c527b92f4c1",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-16",
+        "completedAt": "2026-01-16T20:30:00Z"
+      },
+      {
+        "id": "af1bc914-6765-4ea4-a038-14574bb5394a",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T12:40:00Z"
+      },
+      {
+        "id": "070fa970-43d8-4933-b6d6-ff58ac95c4c7",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T06:40:00Z"
+      },
+      {
+        "id": "f69b4bde-82d9-404e-9620-d6aa47207232",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T21:50:00Z"
+      },
+      {
+        "id": "ee961478-4fef-4d1f-a97e-a986256c18e7",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T08:30:00Z"
+      },
+      {
+        "id": "fbcbde2c-229c-4278-b429-56d803e35c15",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-17",
+        "completedAt": "2026-01-17T21:50:00Z"
+      },
+      {
+        "id": "077ab641-de8f-4a6c-a10c-55b9236fe909",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T18:40:00Z"
+      },
+      {
+        "id": "68eda3e5-04be-492d-8222-a80e3d1bac4c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T22:00:00Z",
+        "note": "Stressy day, reset helped"
+      },
+      {
+        "id": "b5c1e2a0-7830-4e76-b5ed-517909c4e736",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T07:50:00Z"
+      },
+      {
+        "id": "8c7e409a-8a24-4694-b25f-051ddcd2b621",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T20:50:00Z"
+      },
+      {
+        "id": "c0c0d55d-f606-40a8-ab0f-44058767a107",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T18:40:00Z"
+      },
+      {
+        "id": "96b95092-3877-427a-a8c7-fdf99d4c4a42",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T22:50:00Z"
+      },
+      {
+        "id": "bc4d4ceb-82ca-42b2-be27-654167301124",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T12:20:00Z"
+      },
+      {
+        "id": "fc6171cd-fdbc-437b-bdce-617d62facc35",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-18",
+        "completedAt": "2026-01-18T08:10:00Z"
+      },
+      {
+        "id": "118f61f6-bffa-4637-9010-a8c70b4cb258",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T08:10:00Z"
+      },
+      {
+        "id": "f64a8822-1518-4461-ad7a-bad5bee74ec2",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T22:10:00Z"
+      },
+      {
+        "id": "de5b4ad4-9f71-419a-a63a-eb578ade1c0a",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T18:10:00Z"
+      },
+      {
+        "id": "f9a4e3ed-eecd-472b-a7ad-bb611841091e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T18:10:00Z"
+      },
+      {
+        "id": "4107bb2a-886e-4489-ac05-71af48242d5a",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T21:40:00Z"
+      },
+      {
+        "id": "d70cc30e-c3d0-45fc-af05-a023ba37e38b",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T22:10:00Z"
+      },
+      {
+        "id": "8d3b4ee8-4aea-4192-ae1f-7286fbda09a2",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-19",
+        "completedAt": "2026-01-19T20:50:00Z"
+      },
+      {
+        "id": "f398eae8-0993-4f59-84fa-c348346fa98d",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T06:00:00Z"
+      },
+      {
+        "id": "7b10210b-83ff-4b8c-88f6-d56adc378b12",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T18:10:00Z"
+      },
+      {
+        "id": "ce6394ef-7cff-4dbc-9316-a091c0c56a1c",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T22:50:00Z"
+      },
+      {
+        "id": "f132c817-817a-434a-aa30-55d0849c6fb4",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T18:30:00Z"
+      },
+      {
+        "id": "7a4e437c-f2ae-43f6-a622-c6467ae7c79d",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T08:40:00Z"
+      },
+      {
+        "id": "b43fe13f-dfd0-4ebe-a077-b3c062dd2cb6",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-20",
+        "completedAt": "2026-01-20T06:50:00Z"
+      },
+      {
+        "id": "29954177-5f65-4c7e-aa6a-3e774fe917ba",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T06:30:00Z"
+      },
+      {
+        "id": "6e7679a0-19b4-46f0-8df1-6985874f89cc",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T08:50:00Z"
+      },
+      {
+        "id": "1aa836f8-1791-4cd1-ae94-53fa94fa16ef",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T12:40:00Z"
+      },
+      {
+        "id": "f4d36c95-70db-43af-bf0f-bb14836a8ee2",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T07:10:00Z"
+      },
+      {
+        "id": "abac31f3-5581-4044-a71c-c8607f45e61e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T12:30:00Z"
+      },
+      {
+        "id": "5f3cc3e9-0d61-4376-9b9c-d0ad9fa09bd1",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T22:10:00Z"
+      },
+      {
+        "id": "f8a22fa2-d1fd-4929-9787-06a821b9fd64",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T12:30:00Z"
+      },
+      {
+        "id": "67cf6c3b-2cb5-4197-b155-0a777019524e",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T21:10:00Z"
+      },
+      {
+        "id": "3bbc2271-798a-4302-919a-ece5c519e6c2",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T06:20:00Z"
+      },
+      {
+        "id": "4229b987-d291-4492-ae5c-71bbce3c5e09",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T08:00:00Z"
+      },
+      {
+        "id": "b50ccd2f-7956-4ca4-bdc3-55b13fae919a",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T06:20:00Z"
+      },
+      {
+        "id": "704621df-5609-4472-a357-ed59af772a86",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:50:00Z"
+      },
+      {
+        "id": "167f83d3-9b5e-4799-bfd0-9d4b65a13cde",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:50:00Z"
+      },
+      {
+        "id": "cedde949-7c10-447b-aae0-d363ae55d370",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T06:30:00Z"
+      },
+      {
+        "id": "99621907-e39a-4fe2-9426-b71f9f42b172",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T08:10:00Z"
+      },
+      {
+        "id": "e3c900fe-7755-4216-a93c-f97452b58fb0",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T18:40:00Z"
+      },
+      {
+        "id": "adfc8191-04fb-44d8-99b4-a4bef6fc425f",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:40:00Z"
+      },
+      {
+        "id": "eb43343d-f7a5-441c-9985-b9e6cdcab8f9",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T12:30:00Z"
+      },
+      {
+        "id": "34151472-8340-4f4c-ab1b-4b6513e1bc42",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T07:00:00Z"
+      },
+      {
+        "id": "b31e4c81-8824-4a44-bdaf-f1185956ca3a",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T06:30:00Z"
+      },
+      {
+        "id": "b431d2ca-48d0-4569-be60-af633a03accf",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T06:10:00Z"
+      },
+      {
+        "id": "ab4c7e73-b37b-4562-9a42-9b410b7c4a81",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T07:40:00Z"
+      },
+      {
+        "id": "b670719d-af19-4250-8638-e727a50aa7b2",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T21:30:00Z"
+      },
+      {
+        "id": "87950633-5289-4971-8dd0-6c6d6e22e15b",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T20:50:00Z"
+      },
+      {
+        "id": "0d7eb304-e6b6-47dc-92cb-d32bbbf36b12",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T18:30:00Z"
+      },
+      {
+        "id": "15d9d48f-28cf-4a43-a5fc-d2d87a21370b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T20:00:00Z",
+        "note": "Updated monthly budget"
+      },
+      {
+        "id": "c9ea4d8f-8c45-43f8-a550-f6e5153eef22",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T21:00:00Z"
+      },
+      {
+        "id": "ec836889-5da9-430e-a8c5-a893e04ab8aa",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T22:00:00Z"
+      },
+      {
+        "id": "e5c0dcf8-3894-4dd4-b099-11c23e2f5b30",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T06:00:00Z"
+      },
+      {
+        "id": "2eb950c9-0fc6-42c8-b2b5-64cb76d70de4",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T20:30:00Z"
+      },
+      {
+        "id": "d9804149-7c6d-49ee-a5d4-0c93f01cacc0",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T06:20:00Z"
+      },
+      {
+        "id": "80187bc9-4a30-463a-8fde-c2e5fb99571c",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T08:30:00Z"
+      },
+      {
+        "id": "b05ad3af-57be-4417-8244-e3d4003b0c00",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T22:40:00Z"
+      },
+      {
+        "id": "0363e251-cbd0-4df1-801c-6ced12a665df",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T20:10:00Z"
+      },
+      {
+        "id": "869ba77b-69dd-4939-a7fa-3941b2a7af3b",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T07:30:00Z"
+      },
+      {
+        "id": "b43f100a-d921-4629-a2c7-9a6a17293467",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T07:10:00Z"
+      },
+      {
+        "id": "66533e32-7461-4dbc-af96-1f9708f7b714",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T20:00:00Z"
+      },
+      {
+        "id": "b3581ad8-699c-4184-859e-1c25728991b6",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T12:10:00Z"
+      },
+      {
+        "id": "66337694-838d-4a9c-9836-62c38736e577",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T06:30:00Z"
+      },
+      {
+        "id": "fedc0872-859d-4730-a337-a71e7233a2a0",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T21:20:00Z"
+      },
+      {
+        "id": "7d17e8ce-4abc-49af-8c67-c2c4eb1d0c32",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T12:20:00Z"
+      },
+      {
+        "id": "606a6742-31b1-4c40-a8b1-1ed658443b22",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T12:00:00Z"
+      },
+      {
+        "id": "1fe76e0b-0259-4f2d-93c3-6a031b90eef0",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T08:30:00Z"
+      },
+      {
+        "id": "244c41eb-34b6-4f90-8f84-c3692c1fefec",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T06:00:00Z"
+      },
+      {
+        "id": "3383fd66-54c3-478c-98d2-e1f41d824717",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T21:40:00Z"
+      },
+      {
+        "id": "171c73b0-c254-437d-ae45-a5ba3f9f248c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T06:40:00Z"
+      },
+      {
+        "id": "712aa59e-d440-4907-b347-d02e6c61fa4b",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T08:50:00Z"
+      },
+      {
+        "id": "c5323d5f-9642-47ad-b8af-c37307893ad7",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T18:00:00Z"
+      },
+      {
+        "id": "9b621dc3-49e2-4153-82f7-09a15d5db51c",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T18:50:00Z"
+      },
+      {
+        "id": "20f4c049-758f-4360-934e-b58e6a6e66de",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T07:40:00Z"
+      },
+      {
+        "id": "8a83ce5f-6899-4f3b-a1c3-855ca37c1e8f",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T06:00:00Z"
+      },
+      {
+        "id": "f9d061f9-722b-42fa-b9db-765353160e1b",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T20:00:00Z"
+      },
+      {
+        "id": "4f06e40c-686f-4e1c-a5af-4e5cdd74510c",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T21:50:00Z"
+      },
+      {
+        "id": "a1be305b-ab66-4263-8a4d-b844949b1f6e",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T18:00:00Z"
+      },
+      {
+        "id": "086b58e3-08a0-478e-ab99-12f7cebd5cf2",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T12:00:00Z"
+      },
+      {
+        "id": "f912b4bc-2854-48fe-b228-dba488d772eb",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:10:00Z"
+      },
+      {
+        "id": "ae44036d-ccb4-47cb-9a4b-a95a4740b0f6",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T21:20:00Z",
+        "note": "Canceled trial subscription"
+      },
+      {
+        "id": "cd4aa7e1-1262-4636-88a7-c73b37c18ef6",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:10:00Z"
+      },
+      {
+        "id": "753da879-10e1-4e47-bfc2-2e3e5d0d29ef",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T06:00:00Z"
+      },
+      {
+        "id": "8cd11c76-0987-4ecc-b095-4a9dd342ce2b",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T12:40:00Z"
+      },
+      {
+        "id": "7e385f43-7e6b-484a-9dc6-06901eff0a71",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T07:30:00Z"
+      },
+      {
+        "id": "574c7479-73ec-49fb-9470-9074ecb56d1b",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T06:50:00Z"
+      },
+      {
+        "id": "0560ef32-fa6b-4693-a897-a5e522cf2a3c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T07:20:00Z"
+      },
+      {
+        "id": "3a65210f-2791-4297-bfca-54e7e4dd08df",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T06:10:00Z"
+      },
+      {
+        "id": "8b39a486-c0c8-4ea5-bbe1-c868c4feef73",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T12:50:00Z"
+      },
+      {
+        "id": "6e33fb37-ab1d-42a3-ab25-6ebd61ad7a3d",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T12:50:00Z"
+      },
+      {
+        "id": "c576829f-1375-44f6-ad68-8b400fa4d567",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T21:30:00Z"
+      },
+      {
+        "id": "e87f3397-d8ac-4606-9ce4-096c8ad26bd7",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T12:20:00Z"
+      },
+      {
+        "id": "50fe25ce-7a7c-409e-bb46-3236992cc663",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T22:40:00Z"
+      },
+      {
+        "id": "43551fda-61e7-46c7-ac21-59a9aa152845",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T06:40:00Z"
+      },
+      {
+        "id": "45522c69-bcd4-4928-b012-9a7976ee1c4b",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T20:30:00Z"
+      },
+      {
+        "id": "71c87e4d-8e1b-4c2e-99af-9aa6badae4f7",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T07:50:00Z"
+      },
+      {
+        "id": "1c45d7d7-589d-430b-8060-2e1dafcf56ef",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T22:50:00Z"
+      },
+      {
+        "id": "7a5037d1-f4e1-4d0f-9473-8c460976bbeb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T22:40:00Z"
+      },
+      {
+        "id": "0c65a39b-065d-4e7f-9e6e-4be8d0794c31",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T08:30:00Z"
+      },
+      {
+        "id": "06f4a9b9-1e94-4a22-81be-d841a9f38a10",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T07:50:00Z"
+      },
+      {
+        "id": "54d091cf-5368-4d80-a6e9-0b4b3e93eeda",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T12:00:00Z"
+      },
+      {
+        "id": "2e42b06e-e0c1-4f0f-8ad6-3d1db8d9a669",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T22:40:00Z"
+      },
+      {
+        "id": "18b472f5-31d8-4e25-8f24-1e8e344af193",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T22:20:00Z"
+      },
+      {
+        "id": "2ca5993f-c415-4c5a-adbc-1fade806f574",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T18:00:00Z"
+      },
+      {
+        "id": "8c1bfb92-40dd-4fe1-b167-58d9b7dc370d",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T20:50:00Z"
+      },
+      {
+        "id": "51a41977-daca-44fd-9099-66f5ed5432f2",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T21:50:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "9cccbfce-9691-4526-84d5-9a3f7a94938c",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T18:40:00Z"
+      },
+      {
+        "id": "2206081b-f80e-45ec-875e-e8347a38dc48",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T18:40:00Z"
+      },
+      {
+        "id": "7951d3b7-ed5a-46c2-ab11-c05f836b710a",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T18:50:00Z"
+      },
+      {
+        "id": "f9445a98-a4d8-47cb-86a1-c00ae7ddd6bb",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T06:30:00Z"
+      },
+      {
+        "id": "fd7fc2b3-07b0-4c62-90a6-cd281d7ead8c",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T20:00:00Z"
+      },
+      {
+        "id": "96c7a975-74da-49b2-a431-12822e240326",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T07:10:00Z"
+      },
+      {
+        "id": "7118fe05-5fea-485f-b871-65db5effc433",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T20:40:00Z"
+      },
+      {
+        "id": "74cd0a93-4c89-4482-8f46-613c21347938",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T21:00:00Z"
+      },
+      {
+        "id": "811280c4-a544-4afe-9c95-dd1a83cb9522",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T08:00:00Z"
+      },
+      {
+        "id": "a2d4288a-5216-4c7c-b686-2df985c5d7f3",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T12:20:00Z"
+      },
+      {
+        "id": "1970f274-53db-4ebe-a65a-4b0c5cc8e215",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T07:30:00Z"
+      },
+      {
+        "id": "314e2776-f957-47b6-8ac5-f0ff8685328e",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T06:00:00Z"
+      },
+      {
+        "id": "faf2879f-2f5a-428a-b26b-ebb0f44895e7",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T20:40:00Z"
+      },
+      {
+        "id": "5b8b1908-5aa3-4538-815c-a9dcf8ae030c",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T22:10:00Z"
+      },
+      {
+        "id": "0690975d-7721-4eaa-8abd-7dd9dcad40d6",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T08:30:00Z"
+      },
+      {
+        "id": "39a0081c-5b59-4f21-9c37-bfb98c6e0dfe",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T21:50:00Z"
+      },
+      {
+        "id": "1f17cb38-5251-4e3e-aae3-9235c7f1d538",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T21:50:00Z"
+      },
+      {
+        "id": "e8d05994-b318-41cc-80b2-96b87ae75179",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T18:00:00Z"
+      },
+      {
+        "id": "1cacc9bf-1c8a-4c7e-90ed-c3617d51230b",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T20:00:00Z"
+      },
+      {
+        "id": "9e09d7ce-04c2-41f3-b6e5-6bee927324bb",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T06:50:00Z",
+        "note": "Nonfiction notes"
+      },
+      {
+        "id": "e05c93ce-9489-420b-869b-83a2ec84ac7e",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T21:30:00Z"
+      },
+      {
+        "id": "b7f51380-7ebc-44e7-aac7-0e8ae5983bd3",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T08:50:00Z"
+      },
+      {
+        "id": "36c88fa8-7836-4e04-bea6-dbb6aaed6d4e",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:10:00Z"
+      },
+      {
+        "id": "748b7e6d-66a1-4ca8-9898-1e09d5399fec",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:10:00Z"
+      },
+      {
+        "id": "ce902ccb-e4c0-4905-88b1-8cce4dde3d11",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T08:40:00Z"
+      },
+      {
+        "id": "9f8a1f86-919f-4333-80df-541d4d720119",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:10:00Z"
+      },
+      {
+        "id": "24279804-2898-4167-a7b0-e608cd07434e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T20:50:00Z"
+      },
+      {
+        "id": "0e971925-c87d-464e-bb31-d826acf1f5a3",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T12:30:00Z"
+      },
+      {
+        "id": "902cb521-82cd-422e-8a8a-84a38aca1926",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T18:40:00Z"
+      },
+      {
+        "id": "8f69f419-dbdb-4e2a-83ab-76d5231debc0",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T07:20:00Z"
+      },
+      {
+        "id": "2b0d6cb7-1bc4-489c-aeb4-ee29af01aa53",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T21:50:00Z"
+      },
+      {
+        "id": "ff2b041b-f216-47cb-9420-9f2f86c7dc4d",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T08:20:00Z"
+      },
+      {
+        "id": "a72178ea-eb80-4094-9d78-fcd6a08c60f2",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T18:00:00Z"
+      },
+      {
+        "id": "1d847817-32e2-44bd-b07e-d1c20e4eb764",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T20:10:00Z"
+      },
+      {
+        "id": "dd126277-8399-4a1a-a9f0-591f793c2e1e",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T21:00:00Z"
+      },
+      {
+        "id": "59f12074-c452-4980-8ca0-f58e424fa2dd",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T22:20:00Z"
+      },
+      {
+        "id": "2a99a35f-3243-42bc-a2b6-5e8f1fdd7cc9",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T22:50:00Z"
+      },
+      {
+        "id": "ee4bad94-110b-4e70-b9d7-269ed9bb133d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T07:50:00Z"
+      },
+      {
+        "id": "41565d12-73d5-43f6-8940-8c480fb263d5",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T22:00:00Z"
+      },
+      {
+        "id": "0d463b80-9f44-4beb-a476-7a707f4a4d69",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T12:30:00Z"
+      },
+      {
+        "id": "713a3091-4ced-4e4f-aaa6-f9243a46bee9",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T22:40:00Z"
+      },
+      {
+        "id": "9f8fb5fe-aded-4eea-88ab-9f4a2933bf46",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T18:30:00Z"
+      },
+      {
+        "id": "ce9efd24-8897-400c-9a0a-878778a4ee23",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T20:20:00Z"
+      },
+      {
+        "id": "05725dc9-87b4-40ec-a6fe-877cf956253e",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T20:10:00Z"
+      },
+      {
+        "id": "2672f667-952e-423d-a3d0-a066e1d0eb9b",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T12:50:00Z"
+      },
+      {
+        "id": "cff5b3e0-a546-4936-b795-3ae35a2ada6d",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T07:20:00Z"
+      },
+      {
+        "id": "11a21851-922a-4f0a-b186-f467403a2d2d",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T18:20:00Z"
+      },
+      {
+        "id": "23b76c04-aecc-4678-9b3d-6a23cc15761d",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T06:00:00Z"
+      },
+      {
+        "id": "cdeafadc-932b-4694-946c-921f1834f21e",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T21:50:00Z"
+      },
+      {
+        "id": "96894a7b-9ff5-431d-a63b-2d91b905941d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T12:20:00Z"
+      },
+      {
+        "id": "d8b155af-4800-4e6a-8136-94434ffe3e5f",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T07:20:00Z"
+      },
+      {
+        "id": "901368b4-72bc-488b-9fa4-195c0ce0071c",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T08:30:00Z"
+      },
+      {
+        "id": "81ab1182-7efa-4678-b1b0-b954c6668dd8",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T06:10:00Z"
+      },
+      {
+        "id": "61de044d-394c-43cc-bdab-36a21bb03e6c",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T20:50:00Z"
+      },
+      {
+        "id": "106b3fb5-8721-4a16-bfc3-c0ce59bc718c",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T06:30:00Z"
+      },
+      {
+        "id": "86226a65-5b56-4271-9576-a295e5fa5deb",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T18:50:00Z"
+      },
+      {
+        "id": "823c5850-fb08-4db2-9dda-99feced5f18e",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T21:20:00Z"
+      },
+      {
+        "id": "560f05fd-b164-4557-8619-08a1dbb40978",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T07:40:00Z"
+      },
+      {
+        "id": "98d323bc-437f-447a-a3d7-21ef4ff9c045",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T07:30:00Z"
+      },
+      {
+        "id": "253f3947-1740-4e01-bf68-ecf29fc60d85",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T06:50:00Z"
+      },
+      {
+        "id": "a0c86635-ccf6-4bb9-b0d8-d7d981498fe7",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T21:50:00Z"
+      },
+      {
+        "id": "c41d8c15-f471-42b0-837c-a098462aec7f",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T21:00:00Z"
+      },
+      {
+        "id": "eb3305d8-b7a6-420d-b4fa-5190c5805513",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T18:20:00Z"
+      },
+      {
+        "id": "fc66f95c-c661-4ad7-836a-1b28e116c9fb",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T20:40:00Z"
+      },
+      {
+        "id": "eacb1343-a348-4cfd-90c0-8271ae1f55f8",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T20:20:00Z"
+      },
+      {
+        "id": "fdd839d4-dcd3-4673-b066-cac3519f3137",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T18:00:00Z"
+      },
+      {
+        "id": "4dd5b858-7251-4e2b-9f94-d9f4abb15de2",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T08:20:00Z"
+      },
+      {
+        "id": "97906b9d-836c-4b2b-bd7a-64461a0f96d1",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T20:50:00Z"
+      },
+      {
+        "id": "0fa6890b-4107-4e7e-b24a-5e3045a3580e",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T12:20:00Z"
+      },
+      {
+        "id": "832ebf56-6380-4445-9792-1d6a912e9181",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T22:30:00Z"
+      },
+      {
+        "id": "a3701106-cd79-4dd8-a4d5-3d032692ba1f",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T21:20:00Z"
+      },
+      {
+        "id": "47b954ad-3c79-410c-9fcb-ebf98cd96452",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T06:50:00Z"
+      },
+      {
+        "id": "023eabee-3155-4e9b-a5d4-f4cc971a28c0",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T12:10:00Z"
+      },
+      {
+        "id": "6c08332d-58b4-406a-b512-e577c15dbd2f",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T18:50:00Z"
+      },
+      {
+        "id": "d0ff53bd-a648-4b90-b686-ce8265ead678",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T06:20:00Z"
+      },
+      {
+        "id": "9e5c45a8-1495-44f0-821b-21a3d2698ffe",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T22:10:00Z"
+      },
+      {
+        "id": "6e5889ae-eb30-41be-b8cf-fdbacb4c8f8b",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T18:20:00Z"
+      },
+      {
+        "id": "c882fa2b-b3ab-4e71-b7ff-d344c816e99d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T18:40:00Z"
+      },
+      {
+        "id": "f5a8c2d6-b7c1-498c-8ea7-bfa85ce7e398",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T22:10:00Z"
+      },
+      {
+        "id": "7fef8f63-5b54-4378-991a-fe4e1bf7c65a",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T21:20:00Z"
+      },
+      {
+        "id": "2308f49f-3ea3-4ef8-a11f-5d9d010dfa2d",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T08:00:00Z"
+      },
+      {
+        "id": "04a9f3a5-83ed-434e-bd4b-29f44442dbd6",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T12:50:00Z"
+      },
+      {
+        "id": "14b07686-5bdc-4915-9edc-234a2358baca",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T20:30:00Z"
+      },
+      {
+        "id": "1bca1f58-5fd6-4315-ae4f-6564014539ad",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T12:50:00Z"
+      },
+      {
+        "id": "7b60405f-acda-4ad1-8cb9-d4392b6c2638",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T20:40:00Z"
+      },
+      {
+        "id": "2e4f49cd-5e31-46a9-895d-482118303b1d",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T22:00:00Z"
+      },
+      {
+        "id": "8032fd9d-9352-4938-b427-d71149c16fb2",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T20:20:00Z"
+      },
+      {
+        "id": "c71a922b-860c-43cb-8685-e77df97e81bb",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T08:00:00Z"
+      },
+      {
+        "id": "28f8eb90-3677-484e-b650-911b91ab674a",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T06:20:00Z"
+      },
+      {
+        "id": "b52c57f5-e419-4d24-bb4b-e93a871c1151",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T22:10:00Z"
+      },
+      {
+        "id": "cec664b8-3159-4b2c-8225-35d60878d3f5",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T08:50:00Z"
+      },
+      {
+        "id": "90c97f54-9f54-4e3c-aed8-090e762eb760",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T07:20:00Z"
+      },
+      {
+        "id": "dff61572-5832-48d5-9cae-23a20ce0c3be",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T12:10:00Z"
+      },
+      {
+        "id": "6702c462-63e4-472d-97b2-f1b906c839eb",
+        "habitId": "545e7898-3286-42fa-a182-3f617f56f553",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T21:30:00Z"
+      },
+      {
+        "id": "b4336654-ab04-4fb9-8710-44b9953a64b4",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T21:00:00Z"
+      },
+      {
+        "id": "73b1cdd1-ca70-4ebc-9a1b-f6d65a6b4134",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T20:00:00Z"
+      },
+      {
+        "id": "50609a82-9dc5-4d21-89b3-bcb5617e5631",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T07:40:00Z"
+      },
+      {
+        "id": "1c0c9c9f-e05f-4927-9b65-75ddb5a7bfb7",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T08:20:00Z"
+      },
+      {
+        "id": "d4a0290b-5a0e-49c1-856b-5e5ce3604501",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T12:00:00Z"
+      },
+      {
+        "id": "d328a914-ed89-43a6-903f-6c493d5c14ac",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T21:50:00Z"
+      },
+      {
+        "id": "1c2c1419-3ff6-463a-a96d-65deebcd6939",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T18:10:00Z"
+      },
+      {
+        "id": "334bcab9-7da9-45ce-a135-ce6b18209a91",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T07:10:00Z"
+      },
+      {
+        "id": "75c6eb00-c784-469b-84ad-9c4a5e411c7e",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T06:20:00Z"
+      },
+      {
+        "id": "fe7ee07d-a001-4c76-9864-0b966286ac0b",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T22:30:00Z"
+      },
+      {
+        "id": "ef75325e-dda9-43a6-8885-e1bc4eff3b0b",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T21:50:00Z"
+      },
+      {
+        "id": "857b1723-b7bb-40fc-bf17-8e28c2992c16",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T22:10:00Z"
+      },
+      {
+        "id": "178a7b94-5305-44d1-b8dd-5b8bb4399d44",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T07:10:00Z"
+      },
+      {
+        "id": "2a838667-621c-407f-96ba-4383e06a05e5",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T08:00:00Z"
+      },
+      {
+        "id": "eb05981f-8a03-43bf-b97b-9773ae85cf42",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T07:00:00Z"
+      },
+      {
+        "id": "82c0c746-48d6-4d08-8d56-fc91a7617bd2",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T21:20:00Z"
+      },
+      {
+        "id": "8968ad42-c0bd-493d-9f8c-3e0ae039b779",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T20:20:00Z"
+      },
+      {
+        "id": "7a2c4624-04aa-4fd5-a15f-f970b936b4b5",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T21:20:00Z"
+      },
+      {
+        "id": "eeceb3f7-fc8c-4141-ae0f-95fefcba64ad",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T18:10:00Z"
+      },
+      {
+        "id": "dd4fc8b7-ca89-498e-b5c4-9594857ffcab",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T06:10:00Z"
+      },
+      {
+        "id": "a3b97310-8488-42a4-9090-9310563c99e4",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T18:10:00Z"
+      },
+      {
+        "id": "8a2b560a-90c1-4c3f-b0f1-773639c3909e",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T06:10:00Z"
+      },
+      {
+        "id": "14c055cd-71e7-4658-8a37-ba47e999cb64",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T21:40:00Z"
+      },
+      {
+        "id": "245d9209-e6e1-41a1-b45d-56a506534e75",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T21:20:00Z"
+      },
+      {
+        "id": "0f8d21d0-e141-4396-ac64-7af88aaa7509",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T18:40:00Z"
+      },
+      {
+        "id": "a22ae9bc-4061-40c1-8afb-5b2a09558803",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T06:30:00Z"
+      },
+      {
+        "id": "ebb857ce-e64d-4e2e-8593-39eb2012ab91",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T18:10:00Z"
+      },
+      {
+        "id": "4ae0ae46-ee23-4864-a4ab-b08335e8268d",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T21:20:00Z"
+      },
+      {
+        "id": "ac7e2f55-e8e2-494d-9f12-f985a2148118",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T12:40:00Z"
+      },
+      {
+        "id": "e897af90-64e0-47e6-a6c5-e7100b1144bf",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T18:50:00Z"
+      },
+      {
+        "id": "6836fbd2-3c63-4034-a756-16134a9a59f7",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T18:50:00Z"
+      },
+      {
+        "id": "4b3c3b3d-0905-4bfb-9201-ec1d5792da8c",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T20:00:00Z"
+      },
+      {
+        "id": "b3c7abec-05c8-48dd-9d36-c786a8a53f1e",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T08:50:00Z"
+      },
+      {
+        "id": "7a9f431a-60a7-4596-b03a-cc95b0d30b87",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T06:10:00Z"
+      },
+      {
+        "id": "eb9c379c-a1c9-40af-b8bc-50617e232c66",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T18:50:00Z"
+      },
+      {
+        "id": "c49e1669-cfc8-4504-872d-31db05b5ff24",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T18:20:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "9478db27-d146-4d92-9053-aa5d6e68e6c7",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T12:00:00Z"
+      },
+      {
+        "id": "138de97f-cd70-44ce-b2b4-31f936f3f956",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T21:00:00Z"
+      },
+      {
+        "id": "649914b6-70a0-43f2-b1a9-8f29507ebdc8",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T22:50:00Z"
+      },
+      {
+        "id": "e1956420-d686-4d96-b92e-769e85c9782b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T18:50:00Z"
+      },
+      {
+        "id": "af6634ba-efcd-4d59-a472-de3ac25af8a9",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T18:00:00Z"
+      },
+      {
+        "id": "3ceb662f-ec30-48d9-ada0-d3332ba99947",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T22:50:00Z"
+      },
+      {
+        "id": "99ca8c5e-64ef-48a2-b929-95513c838503",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T21:20:00Z"
+      },
+      {
+        "id": "c1bfd530-12ee-47f5-a135-1d672f755fba",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T06:00:00Z"
+      },
+      {
+        "id": "4294b480-35e6-44c9-976c-5233cd3d9a0b",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T06:40:00Z"
+      },
+      {
+        "id": "e4717625-3a7a-4b49-8907-7dc46219554d",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T12:40:00Z"
+      },
+      {
+        "id": "12e32e12-831b-4336-a996-96ad511b45ec",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T07:00:00Z"
+      },
+      {
+        "id": "d1b9d106-ebda-49cb-9836-2a9e9fa91830",
+        "habitId": "cf4b14fa-176a-43cf-91ad-2bf7494b1f00",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T07:50:00Z"
+      },
+      {
+        "id": "96ea4a6b-0709-4ea3-9fc2-83dd6ad2c57d",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T08:40:00Z"
+      },
+      {
+        "id": "01ef1b09-3254-4358-b1a5-4fba16b7cec5",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T21:20:00Z"
+      },
+      {
+        "id": "d24c2910-21b8-4fc7-8110-f2918f8bb91e",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T18:50:00Z"
+      },
+      {
+        "id": "de56d97a-0eca-45c3-8014-a4edb945274b",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T07:30:00Z"
+      },
+      {
+        "id": "bf8374f5-519f-4a31-8ce2-6d56369f7f36",
+        "habitId": "6c57fbd2-b610-4c03-bb34-54429456f122",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T22:30:00Z"
+      },
+      {
+        "id": "62558fdc-51e9-4516-a14e-ef8261332d5e",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T08:30:00Z"
+      },
+      {
+        "id": "491df6d4-615a-4cb6-b677-6bccc8bfb6f4",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T12:10:00Z"
+      },
+      {
+        "id": "887e4631-a7e6-4407-be6b-970f76c966fb",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T21:20:00Z"
+      },
+      {
+        "id": "43006949-fb84-48b4-9103-558c2a61781b",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T08:50:00Z"
+      },
+      {
+        "id": "4afb6d11-d288-4410-ab0e-6d496dad04a0",
+        "habitId": "9b480ff8-a3f8-40a6-bcf5-d06f47e82d2b",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T20:30:00Z"
+      },
+      {
+        "id": "416dac14-ff0d-4abe-ab6c-1f652a6becf3",
+        "habitId": "e959f45a-96d3-4371-b1a8-58c5d9d17124",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T07:10:00Z"
+      },
+      {
+        "id": "3c60b980-ab8d-4c08-8e7c-4bd21c5c12ea",
+        "habitId": "010be66a-0553-467e-a698-135588d654dd",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T12:10:00Z"
+      },
+      {
+        "id": "ff6aaf14-3ef2-4c4c-966e-6684e7707780",
+        "habitId": "0d1aa703-b3f5-4871-a19c-e5509575f50a",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T21:50:00Z"
+      },
+      {
+        "id": "c1cdcf8b-a90a-4ac4-a230-1c927a16ffc1",
+        "habitId": "29317158-6b2f-4bdf-aa30-3bdc1e3c94c5",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T18:00:00Z"
+      },
+      {
+        "id": "e58bd0f1-47b0-4eb5-b210-c17aeb757f90",
+        "habitId": "50fa2b60-2f3f-4266-a8c0-f65c9fa75f11",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T07:10:00Z"
+      },
+      {
+        "id": "7c76b7bf-d01f-428f-b4d5-bc7ebfaeeaf0",
+        "habitId": "52bca7d8-afe5-41d2-9fc6-55a71274f08a",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T07:50:00Z"
+      },
+      {
+        "id": "650632c9-e885-45ea-be3e-6e45b723bc58",
+        "habitId": "6f9d1782-92e3-4e2a-b975-b18290b7e6cb",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T18:30:00Z"
+      },
+      {
+        "id": "5c28a55a-7efb-4bbf-9fc7-6f709859c793",
+        "habitId": "c8b78935-74af-47ac-a977-3f83f904a546",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T08:50:00Z"
+      }
+    ],
+    "settings": {
+      "id": "user_settings",
+      "theme": "system",
+      "weekStartsOn": 1,
+      "showStreaks": true,
+      "showCompletionRate": true,
+      "defaultView": "today",
+      "createdAt": "2025-08-15T12:00:00Z",
+      "updatedAt": "2026-02-25T15:30:00Z"
+    }
+  }
+}

--- a/public/sample-data/habitflow-sample-starter.json
+++ b/public/sample-data/habitflow-sample-starter.json
@@ -1,0 +1,687 @@
+{
+  "version": "1.0",
+  "exportedAt": "2026-02-25T15:30:00Z",
+  "app": "HabitFlow",
+  "data": {
+    "habits": [
+      {
+        "id": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "name": "Morning Walk",
+        "icon": "\ud83d\udeb6",
+        "color": "#10b981",
+        "frequency": "daily",
+        "category": "Health",
+        "sortOrder": 0,
+        "isArchived": false,
+        "createdAt": "2025-08-15T12:00:00Z",
+        "updatedAt": "2025-12-13T12:00:00Z",
+        "description": "20-minute walk after coffee",
+        "reminderTime": "07:30"
+      },
+      {
+        "id": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "name": "Read 20 Minutes",
+        "icon": "\ud83d\udcda",
+        "color": "#3b82f6",
+        "frequency": "daily",
+        "category": "Learning",
+        "sortOrder": 1,
+        "isArchived": false,
+        "createdAt": "2025-08-16T12:00:00Z",
+        "updatedAt": "2025-12-14T12:00:00Z",
+        "description": "Read before bed",
+        "reminderTime": "21:00"
+      },
+      {
+        "id": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "name": "Strength Training",
+        "icon": "\ud83c\udfcb\ufe0f",
+        "color": "#ef4444",
+        "frequency": "specific_days",
+        "category": "Fitness",
+        "sortOrder": 2,
+        "isArchived": false,
+        "createdAt": "2025-08-17T12:00:00Z",
+        "updatedAt": "2025-12-15T12:00:00Z",
+        "description": "Mon/Wed/Fri",
+        "reminderTime": "18:00",
+        "targetDays": [
+          1,
+          3,
+          5
+        ]
+      },
+      {
+        "id": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "name": "Meditation",
+        "icon": "\ud83e\uddd8",
+        "color": "#8b5cf6",
+        "frequency": "weekdays",
+        "category": "Mindset",
+        "sortOrder": 3,
+        "isArchived": false,
+        "createdAt": "2025-08-18T12:00:00Z",
+        "updatedAt": "2025-12-16T12:00:00Z",
+        "description": "10 minutes breathing",
+        "reminderTime": "08:00"
+      },
+      {
+        "id": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "name": "Meal Prep",
+        "icon": "\ud83e\udd57",
+        "color": "#14b8a6",
+        "frequency": "weekends",
+        "category": "Health",
+        "sortOrder": 4,
+        "isArchived": false,
+        "createdAt": "2025-08-19T12:00:00Z",
+        "updatedAt": "2025-12-17T12:00:00Z",
+        "description": "Prep lunches for the week",
+        "reminderTime": "11:00"
+      }
+    ],
+    "completions": [
+      {
+        "id": "d0f95f1e-4a82-4e74-9650-141f27245e3d",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T21:45:00Z"
+      },
+      {
+        "id": "d1f6f80e-b9ac-4821-b270-b652b97486de",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-21",
+        "completedAt": "2026-01-21T08:45:00Z"
+      },
+      {
+        "id": "737d3166-0578-4e42-9d9d-0a6ff2a7ded2",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:15:00Z"
+      },
+      {
+        "id": "221a46ae-0491-4d7d-889a-57c5a2b8c2ee",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T22:05:00Z",
+        "note": "Finished a chapter"
+      },
+      {
+        "id": "8e88e2fa-743d-4aac-839c-25e222565f99",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-22",
+        "completedAt": "2026-01-22T06:05:00Z"
+      },
+      {
+        "id": "1a13a896-d67a-4a3c-b2a1-c86219fa67fe",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T21:45:00Z"
+      },
+      {
+        "id": "ba702657-d9b2-4438-a52d-cf7b95a13c42",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-23",
+        "completedAt": "2026-01-23T17:00:00Z"
+      },
+      {
+        "id": "3228f9b0-60d4-407d-92c9-08e70ab460f2",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T08:05:00Z"
+      },
+      {
+        "id": "59c809cb-f7e5-49f0-84c1-1f16e25d0ab9",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T12:05:00Z"
+      },
+      {
+        "id": "6bac5bd3-16cd-4a9b-b1c9-df46a549ce68",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-24",
+        "completedAt": "2026-01-24T17:40:00Z"
+      },
+      {
+        "id": "d784cb88-a56d-400b-b7bc-d176547edfb8",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T08:05:00Z"
+      },
+      {
+        "id": "6783a8e3-5785-4a4b-80e2-ca6ceb68b5d8",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T19:10:00Z"
+      },
+      {
+        "id": "7f04995f-6e59-47a7-92e6-dc7332ef2e0c",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-25",
+        "completedAt": "2026-01-25T22:15:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "05106b34-5196-48a5-9825-fee23e4a7ac2",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T06:40:00Z"
+      },
+      {
+        "id": "3bbdbaf3-9bee-49c1-882b-bf46a9669f89",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T20:10:00Z"
+      },
+      {
+        "id": "dd5b2f37-228c-43d4-bac2-ac388b4e214e",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T08:05:00Z"
+      },
+      {
+        "id": "b494c6e4-1a4e-4a57-b68a-3b5a78c327b0",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-01-26",
+        "completedAt": "2026-01-26T19:45:00Z"
+      },
+      {
+        "id": "0d514af1-78c5-4cdc-bb30-0bb44622efff",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T22:10:00Z"
+      },
+      {
+        "id": "ad70f82f-4607-4b69-9f41-254beeb7ff68",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-27",
+        "completedAt": "2026-01-27T17:15:00Z"
+      },
+      {
+        "id": "b0cc539e-f6aa-4602-931c-01356fd0002f",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T22:10:00Z"
+      },
+      {
+        "id": "5ed2a79b-4a13-4193-8944-328b171868cc",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T08:20:00Z"
+      },
+      {
+        "id": "3b4e1105-2cb4-4798-a9de-6b56621bf1a8",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-01-28",
+        "completedAt": "2026-01-28T21:05:00Z"
+      },
+      {
+        "id": "5026639f-2522-4911-9808-39bb34dd9124",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:05:00Z"
+      },
+      {
+        "id": "b6f57f22-16aa-487a-8170-291fc1b93c1a",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-29",
+        "completedAt": "2026-01-29T21:45:00Z"
+      },
+      {
+        "id": "a33d71e6-3175-4878-9533-ed3a784b6331",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T12:15:00Z"
+      },
+      {
+        "id": "79b55968-89ac-4b1f-acca-15000f3a71ae",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T12:10:00Z"
+      },
+      {
+        "id": "4ff8d621-8198-4fa7-8750-bc917683adab",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T22:45:00Z"
+      },
+      {
+        "id": "6702a28e-87c0-4c9b-97d6-9323dc10cebb",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-01-30",
+        "completedAt": "2026-01-30T21:00:00Z"
+      },
+      {
+        "id": "6f3127c3-33f0-4168-882f-d820e3074179",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T20:30:00Z"
+      },
+      {
+        "id": "7ebd36bb-4001-478f-895f-2c1c2b681f2b",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-01-31",
+        "completedAt": "2026-01-31T12:00:00Z"
+      },
+      {
+        "id": "eddddc0f-6cc5-4096-8388-8802118e41ae",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T12:50:00Z"
+      },
+      {
+        "id": "e0c7defe-f10f-4369-b390-7ad055104f44",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T22:50:00Z"
+      },
+      {
+        "id": "63b4332a-4ebd-43e0-afad-3b0fe72a714a",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-01",
+        "completedAt": "2026-02-01T19:45:00Z"
+      },
+      {
+        "id": "1aa7432d-d1a0-4456-b35e-e8f65793fc9b",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T17:45:00Z"
+      },
+      {
+        "id": "e6b76d3f-f590-4f92-a2d2-c8370d02d1d1",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T07:05:00Z",
+        "note": "Read before bed"
+      },
+      {
+        "id": "0b28c672-a5b6-480a-bf0c-5b1d9476a34c",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T06:20:00Z"
+      },
+      {
+        "id": "a749d6a1-6131-42db-97ae-d79f26066c22",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-02",
+        "completedAt": "2026-02-02T07:45:00Z"
+      },
+      {
+        "id": "9aee1120-1428-44e0-9042-a25a7697e8c4",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T07:45:00Z"
+      },
+      {
+        "id": "65b1b9b9-255c-4e96-9541-a3ca48e781d8",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-03",
+        "completedAt": "2026-02-03T19:20:00Z"
+      },
+      {
+        "id": "42f99000-50d6-4e2b-b02f-481cc6b36d75",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T19:50:00Z"
+      },
+      {
+        "id": "408a6ef1-e3b0-4b5c-af79-8fef749ed948",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T17:30:00Z"
+      },
+      {
+        "id": "b4ebf1a9-d026-4001-8d75-6dc0b3f1f98c",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-04",
+        "completedAt": "2026-02-04T07:45:00Z"
+      },
+      {
+        "id": "7fa14447-4946-4328-90ee-898aad180e5d",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T21:10:00Z"
+      },
+      {
+        "id": "b131fdfb-38e1-44ca-81c5-7b3d72e93efa",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-05",
+        "completedAt": "2026-02-05T22:00:00Z"
+      },
+      {
+        "id": "b1b926b9-b789-4478-a1cd-35efa763ebe4",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-06",
+        "completedAt": "2026-02-06T19:45:00Z"
+      },
+      {
+        "id": "da704dae-3e42-43bf-9c65-6fad7fc50384",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T18:15:00Z"
+      },
+      {
+        "id": "e79f7cfd-857e-4a6d-b48e-25276feccb72",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T18:45:00Z"
+      },
+      {
+        "id": "3718545c-531b-4648-9d74-cff0dd6aa36a",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-07",
+        "completedAt": "2026-02-07T20:50:00Z"
+      },
+      {
+        "id": "ac4682e0-8885-4096-95f0-756d134c2a61",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T06:05:00Z"
+      },
+      {
+        "id": "c983f65e-4ff7-447c-ba37-c2e469595546",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T12:05:00Z"
+      },
+      {
+        "id": "82e3df2a-b6f1-4817-9c4a-73e0579e83fe",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-08",
+        "completedAt": "2026-02-08T07:20:00Z"
+      },
+      {
+        "id": "2c656cae-fa5d-4bbf-9913-16cc19ac1eb4",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T07:40:00Z"
+      },
+      {
+        "id": "6fdaf968-89f4-47a2-839e-a3e9e073a941",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T17:15:00Z"
+      },
+      {
+        "id": "8ac03fbb-9b7f-4945-b819-43cdc83d1cde",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-09",
+        "completedAt": "2026-02-09T20:20:00Z"
+      },
+      {
+        "id": "0db96d18-9b6b-4ffb-b27c-c9675466a786",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T17:40:00Z"
+      },
+      {
+        "id": "b9a4b3f6-2db4-4bf2-b9d3-f7e675d2a7e9",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-10",
+        "completedAt": "2026-02-10T07:20:00Z"
+      },
+      {
+        "id": "38af9224-b0c4-4762-b437-6da8b24c36bc",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T06:00:00Z"
+      },
+      {
+        "id": "d3fbae9c-86a4-4a69-9c4e-d74889aa26b4",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-11",
+        "completedAt": "2026-02-11T06:10:00Z"
+      },
+      {
+        "id": "63700884-65ce-4db1-b780-f82ec84247d2",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T06:45:00Z"
+      },
+      {
+        "id": "3edb441e-f98d-42f7-8ea2-86dd1694e329",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-12",
+        "completedAt": "2026-02-12T08:05:00Z"
+      },
+      {
+        "id": "db9c9705-b477-49ae-aea5-6201d2af6a43",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T19:40:00Z"
+      },
+      {
+        "id": "4cc9ecaa-e26b-46f8-8a11-be52a1fc16bb",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T07:50:00Z"
+      },
+      {
+        "id": "2eeded25-7161-4c75-9f7c-29418bf5ff74",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-13",
+        "completedAt": "2026-02-13T08:15:00Z"
+      },
+      {
+        "id": "79b7f687-d5e3-43bd-8571-0cdaf938346f",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T12:20:00Z"
+      },
+      {
+        "id": "5a2fe68c-b895-4c73-849b-46ac081c89bd",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-14",
+        "completedAt": "2026-02-14T07:15:00Z"
+      },
+      {
+        "id": "daf22540-a352-4196-801f-aa882fd429c6",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T17:30:00Z"
+      },
+      {
+        "id": "2af25764-6cf1-4e4a-9ff6-a09dde1fb7f1",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T19:05:00Z"
+      },
+      {
+        "id": "45a5d43e-4170-41a4-af0a-56492d790957",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-15",
+        "completedAt": "2026-02-15T21:10:00Z"
+      },
+      {
+        "id": "970dc4ed-541d-4021-9f92-4feb504c8a20",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T19:05:00Z"
+      },
+      {
+        "id": "32097f43-a369-45b2-8bae-4625b859231d",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T18:05:00Z"
+      },
+      {
+        "id": "6921bee5-c428-4ec2-9d32-4d3438f51d60",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-16",
+        "completedAt": "2026-02-16T18:45:00Z"
+      },
+      {
+        "id": "1e0ac9d6-c172-46cc-a009-af3d666e11e7",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T07:00:00Z"
+      },
+      {
+        "id": "61bb6335-2104-4195-9c2c-84fed49ecb0a",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T18:20:00Z"
+      },
+      {
+        "id": "27b829f8-8e59-457b-bebf-dc5ae788a87b",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-17",
+        "completedAt": "2026-02-17T12:45:00Z"
+      },
+      {
+        "id": "710bb445-989f-46ef-b9bf-437e22f0765a",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T20:10:00Z"
+      },
+      {
+        "id": "fb32db55-887e-4471-996f-c4a8ddbe7aed",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T07:45:00Z"
+      },
+      {
+        "id": "8d8659de-c36f-4aa5-af3a-91c425ce9328",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T06:45:00Z"
+      },
+      {
+        "id": "a84e400e-d0ed-44e1-be4d-3d2229a7fab5",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-18",
+        "completedAt": "2026-02-18T12:30:00Z"
+      },
+      {
+        "id": "b9c680e7-a118-4a2e-bd00-7cef4bc937fb",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T12:45:00Z"
+      },
+      {
+        "id": "e2ef0c67-a993-4b70-b862-fee175983f79",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T08:05:00Z"
+      },
+      {
+        "id": "6e20990e-365d-4d85-8c8a-0fad592f609e",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-19",
+        "completedAt": "2026-02-19T06:10:00Z"
+      },
+      {
+        "id": "6ba98772-8834-440d-973c-5527d6eb29e8",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T08:40:00Z"
+      },
+      {
+        "id": "54a33e2f-b3b0-4936-bde2-80217ed4d347",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T06:10:00Z"
+      },
+      {
+        "id": "d2d0cb56-b03b-451f-9c33-a7a69f4fd26f",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T18:50:00Z"
+      },
+      {
+        "id": "1d5bbc9f-24db-4e0e-ab6b-aa8e301d6a95",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-20",
+        "completedAt": "2026-02-20T17:15:00Z"
+      },
+      {
+        "id": "5fc60bc6-36a6-4d16-b1da-d6f71743cb8c",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-21",
+        "completedAt": "2026-02-21T07:40:00Z"
+      },
+      {
+        "id": "28e2d861-2d66-40a3-8db3-5837158c8cf0",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T12:00:00Z"
+      },
+      {
+        "id": "e1dd462d-3b60-4dc9-9895-70d165c67b08",
+        "habitId": "7fbd931f-c18a-4eba-8ac2-3f7d30b9246b",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T18:20:00Z"
+      },
+      {
+        "id": "9a37745b-0695-42c8-a86c-696059164e17",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-22",
+        "completedAt": "2026-02-22T20:05:00Z"
+      },
+      {
+        "id": "8bef377c-c39e-43e5-944a-ed7980a87403",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T22:20:00Z"
+      },
+      {
+        "id": "875c78d0-73f7-4047-8b7d-3003bf2666a2",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T06:45:00Z"
+      },
+      {
+        "id": "e3203f3e-e294-4ea5-9531-9e49099e1519",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T21:50:00Z"
+      },
+      {
+        "id": "01e04127-b60e-43a2-9585-44047b147ca2",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-23",
+        "completedAt": "2026-02-23T12:15:00Z"
+      },
+      {
+        "id": "cdb30613-993d-4cd7-ba5b-8fb411c26233",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T19:40:00Z"
+      },
+      {
+        "id": "067ec799-f523-4525-8444-f1934c91e38b",
+        "habitId": "b3aeb084-72a2-46cb-b4f6-ecd7d11a40b6",
+        "date": "2026-02-24",
+        "completedAt": "2026-02-24T08:40:00Z"
+      },
+      {
+        "id": "5869e607-b1fa-4df7-a408-94322a82bd5b",
+        "habitId": "4ffea61d-bc83-4225-9614-4384550912c4",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T08:40:00Z"
+      },
+      {
+        "id": "b752f7b3-c4b5-4f0f-aa79-5f24f2b4a734",
+        "habitId": "a04d9a49-13d9-4fa4-b2cc-3f3b0cb0fbb7",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T07:05:00Z"
+      },
+      {
+        "id": "bcff69c4-e898-4342-aa99-8ebfab12a661",
+        "habitId": "b9d507c7-8bb1-4ce7-a8a0-2afb12a8f97c",
+        "date": "2026-02-25",
+        "completedAt": "2026-02-25T22:30:00Z"
+      }
+    ],
+    "settings": {
+      "id": "user_settings",
+      "theme": "system",
+      "weekStartsOn": 1,
+      "showStreaks": true,
+      "showCompletionRate": true,
+      "defaultView": "today",
+      "createdAt": "2025-08-15T12:00:00Z",
+      "updatedAt": "2026-02-25T15:30:00Z"
+    }
+  }
+}

--- a/scripts/generate-sample-imports.py
+++ b/scripts/generate-sample-imports.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Generate built-in HabitFlow sample import datasets.
+
+Outputs JSON files in public/sample-data/ that match the app import schema.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+TODAY = date(2026, 2, 25)
+OUT_DIR = Path("public/sample-data")
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def uid() -> str:
+    return str(uuid.uuid4())
+
+
+def iso_dt(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def iso_at(day: date, hour: int, minute: int) -> str:
+    return iso_dt(datetime(day.year, day.month, day.day, hour, minute, tzinfo=timezone.utc))
+
+
+def ymd(day: date) -> str:
+    return day.isoformat()
+
+
+def dow_sun0(day: date) -> int:
+    # Python Monday=0..Sunday=6 -> app expects Sunday=0..Saturday=6
+    return (day.weekday() + 1) % 7
+
+
+def scheduled_for(habit: dict[str, Any], day: date) -> bool:
+    freq = habit["frequency"]
+    dow = dow_sun0(day)
+    if freq == "daily":
+        return True
+    if freq == "weekdays":
+        return dow not in (0, 6)
+    if freq == "weekends":
+        return dow in (0, 6)
+    if freq == "specific_days":
+        return dow in habit.get("targetDays", [])
+    if freq == "x_per_week":
+        return True
+    return False
+
+
+@dataclass(frozen=True)
+class HabitTemplate:
+    name: str
+    icon: str
+    color: str
+    frequency: str
+    category: str
+    reminder_time: str | None = None
+    description: str | None = None
+    target_days: list[int] | None = None
+    target_count: int | None = None
+    archived: bool = False
+    start_date: date | None = None
+    end_date: date | None = None
+
+
+STARTER_TEMPLATES = [
+    HabitTemplate("Morning Walk", "🚶", "#10b981", "daily", "Health", "07:30", "20-minute walk after coffee"),
+    HabitTemplate("Read 20 Minutes", "📚", "#3b82f6", "daily", "Learning", "21:00", "Read before bed"),
+    HabitTemplate("Strength Training", "🏋️", "#ef4444", "specific_days", "Fitness", "18:00", "Mon/Wed/Fri", [1, 3, 5]),
+    HabitTemplate("Meditation", "🧘", "#8b5cf6", "weekdays", "Mindset", "08:00", "10 minutes breathing"),
+    HabitTemplate("Meal Prep", "🥗", "#14b8a6", "weekends", "Health", "11:00", "Prep lunches for the week"),
+]
+
+
+POWER_USER_TEMPLATES = [
+    HabitTemplate("Morning Walk", "🚶", "#10b981", "daily", "Health", "07:00", "Outdoor walk"),
+    HabitTemplate("Read 20 Minutes", "📚", "#3b82f6", "daily", "Learning", "21:00", "Reading habit"),
+    HabitTemplate("Meditation", "🧘", "#8b5cf6", "weekdays", "Mindset", "08:00", "Mindfulness"),
+    HabitTemplate("Strength Training", "🏋️", "#ef4444", "specific_days", "Fitness", "18:00", "Mon/Wed/Fri lifts", [1, 3, 5]),
+    HabitTemplate("Stretching", "🧎", "#f97316", "daily", "Mobility", "06:45", "Mobility flow"),
+    HabitTemplate("Meal Prep", "🥗", "#14b8a6", "weekends", "Health", "11:00", "Weekend prep"),
+    HabitTemplate("Practice Guitar", "🎸", "#f59e0b", "x_per_week", "Creative", "20:30", "15 min minimum", target_count=4),
+    HabitTemplate("Language Practice", "🗣️", "#06b6d4", "specific_days", "Learning", "12:30", "Spanish lessons", [0, 2, 4, 6]),
+    HabitTemplate("Journal", "✍️", "#ec4899", "daily", "Mindset", "22:00", "3 lines minimum"),
+    HabitTemplate("Inbox Zero", "📥", "#0ea5e9", "weekdays", "Work", "16:30", "Email cleanup"),
+    HabitTemplate("Budget Check-in", "💸", "#84cc16", "x_per_week", "Admin", "19:00", "Review spending", target_count=2),
+    HabitTemplate("Call Family", "📞", "#a855f7", "specific_days", "Relationships", "17:30", "Sunday call", [0]),
+    HabitTemplate("Deep Work Block", "🧠", "#2563eb", "weekdays", "Work", "09:30", "90-minute focus sprint"),
+    HabitTemplate("Protein Goal", "🥚", "#f43f5e", "daily", "Health", "20:00", "Hit protein target"),
+    HabitTemplate("Drink Water", "💧", "#22c55e", "daily", "Health", "10:00", "Stay hydrated"),
+    HabitTemplate("Sleep Before 11", "😴", "#6366f1", "daily", "Recovery", "22:15", "Wind down routine"),
+    HabitTemplate("Run / Cardio", "🏃", "#0ea5e9", "specific_days", "Fitness", "07:15", "Tue/Thu/Sat cardio", [2, 4, 6]),
+    HabitTemplate("Plan Tomorrow", "🗓️", "#f59e0b", "weekdays", "Planning", "21:30", "Set top 3 tasks"),
+    HabitTemplate("Desk Cleanup", "🧽", "#a3a3a3", "weekdays", "Environment", "17:45", "2-minute reset"),
+    HabitTemplate("Practice Typing", "⌨️", "#38bdf8", "x_per_week", "Learning", "13:30", "Typing drills", target_count=3),
+    HabitTemplate("No Sugar Dessert", "🍰", "#fb7185", "daily", "Nutrition", "20:45", "Avoid sweets"),
+    HabitTemplate("Sunlight Break", "☀️", "#eab308", "weekdays", "Health", "12:00", "Get outside midday"),
+    HabitTemplate("Review Goals", "🎯", "#9333ea", "specific_days", "Planning", "19:30", "Mon/Thu review", [1, 4]),
+    HabitTemplate("Creative Sketch", "✏️", "#f97316", "x_per_week", "Creative", "18:30", "Sketchbook session", target_count=2),
+    HabitTemplate("Cold Shower Challenge", "🧊", "#64748b", "daily", "Challenge", None, "Completed challenge", archived=True, start_date=date(2025, 9, 1), end_date=date(2025, 9, 30)),
+    HabitTemplate("Job Search Applications", "💼", "#059669", "x_per_week", "Career", "14:00", "Send applications", target_count=5, archived=True, start_date=date(2025, 8, 1), end_date=date(2025, 11, 30)),
+]
+
+
+def habit_rate(name: str) -> float:
+    rates = {
+        "Morning Walk": 0.74,
+        "Read 20 Minutes": 0.68,
+        "Meditation": 0.62,
+        "Strength Training": 0.70,
+        "Stretching": 0.72,
+        "Meal Prep": 0.80,
+        "Practice Guitar": 0.58,
+        "Language Practice": 0.66,
+        "Journal": 0.63,
+        "Inbox Zero": 0.55,
+        "Budget Check-in": 0.52,
+        "Call Family": 0.83,
+        "Deep Work Block": 0.61,
+        "Protein Goal": 0.65,
+        "Drink Water": 0.77,
+        "Sleep Before 11": 0.57,
+        "Run / Cardio": 0.64,
+        "Plan Tomorrow": 0.60,
+        "Desk Cleanup": 0.67,
+        "Practice Typing": 0.51,
+        "No Sugar Dessert": 0.54,
+        "Sunlight Break": 0.59,
+        "Review Goals": 0.73,
+        "Creative Sketch": 0.49,
+        "Cold Shower Challenge": 0.87,
+        "Job Search Applications": 0.46,
+    }
+    return rates.get(name, 0.6)
+
+
+def build_habits(templates: list[HabitTemplate], created_base: datetime) -> list[dict[str, Any]]:
+    habits: list[dict[str, Any]] = []
+    for i, t in enumerate(templates):
+        created = created_base + timedelta(days=i)
+        item: dict[str, Any] = {
+            "id": uid(),
+            "name": t.name,
+            "icon": t.icon,
+            "color": t.color,
+            "frequency": t.frequency,
+            "category": t.category,
+            "sortOrder": i,
+            "isArchived": t.archived,
+            "createdAt": iso_dt(created),
+            "updatedAt": iso_dt(created + timedelta(days=120)),
+        }
+        if t.description:
+            item["description"] = t.description
+        if t.reminder_time:
+            item["reminderTime"] = t.reminder_time
+        if t.target_days is not None:
+            item["targetDays"] = t.target_days
+        if t.target_count is not None:
+            item["targetCount"] = t.target_count
+        habits.append(item)
+    return habits
+
+
+def build_completions(
+    habits: list[dict[str, Any]],
+    templates: dict[str, HabitTemplate],
+    start: date,
+    end: date,
+    seed: int,
+) -> list[dict[str, Any]]:
+    rng = random.Random(seed)
+    completions: list[dict[str, Any]] = []
+
+    for habit in habits:
+        template = templates[habit["name"]]
+        d = start
+        bias = 0.0
+        while d <= end:
+            if not scheduled_for(habit, d):
+                d += timedelta(days=1)
+                continue
+
+            if template.start_date and d < template.start_date:
+                d += timedelta(days=1)
+                continue
+            if template.end_date and d > template.end_date:
+                d += timedelta(days=1)
+                continue
+
+            p = habit_rate(habit["name"])
+
+            # Gentle recency improvement
+            if d >= end - timedelta(days=45):
+                p += 0.06
+            elif d <= start + timedelta(days=30):
+                p -= 0.02
+
+            # January slump to make charts interesting
+            if date(2026, 1, 8) <= d <= date(2026, 1, 16):
+                p -= 0.10
+
+            dow = dow_sun0(d)
+            if habit["name"] in {"Practice Guitar", "Creative Sketch"} and dow in (0, 6):
+                p += 0.10
+            if habit["name"] == "Inbox Zero" and dow in (5, 6):
+                p -= 0.15
+            if habit["name"] in {"Journal", "Read 20 Minutes"} and dow in (0, 6):
+                p += 0.03
+
+            p = max(0.10, min(0.96, p + bias))
+            done = rng.random() < p
+
+            if done:
+                hour = rng.choice([6, 7, 8, 12, 17, 18, 19, 20, 21, 22])
+                minute = rng.choice([0, 5, 10, 15, 20, 30, 40, 45, 50])
+                comp: dict[str, Any] = {
+                    "id": uid(),
+                    "habitId": habit["id"],
+                    "date": ymd(d),
+                    "completedAt": iso_at(d, hour, minute),
+                }
+                if habit["name"] in {"Journal", "Read 20 Minutes", "Budget Check-in"} and rng.random() < 0.06:
+                    notes = {
+                        "Journal": ["Good reset today", "Low energy but showed up", "Short entry, still counts"],
+                        "Read 20 Minutes": ["Finished a chapter", "Read before bed", "Nonfiction notes"],
+                        "Budget Check-in": ["Reviewed groceries", "Updated budget categories", "Caught a duplicate charge"],
+                    }
+                    comp["note"] = rng.choice(notes[habit["name"]])
+                completions.append(comp)
+                bias = min(0.03, bias + 0.0025)
+            else:
+                bias = max(-0.02, bias - 0.0035)
+
+            d += timedelta(days=1)
+
+    completions.sort(key=lambda c: (c["date"], c["habitId"]))
+    return completions
+
+
+def make_payload(
+    *,
+    templates: list[HabitTemplate],
+    days: int,
+    seed: int,
+    theme: str = "system",
+    week_starts_on: int = 1,
+) -> dict[str, Any]:
+    now = datetime(2026, 2, 25, 15, 30, tzinfo=timezone.utc)
+    created_base = datetime(2025, 8, 15, 12, 0, tzinfo=timezone.utc)
+    habits = build_habits(templates, created_base)
+    template_map = {t.name: t for t in templates}
+    start = TODAY - timedelta(days=days)
+    completions = build_completions(habits, template_map, start, TODAY, seed)
+
+    return {
+        "version": "1.0",
+        "exportedAt": iso_dt(now),
+        "app": "HabitFlow",
+        "data": {
+            "habits": habits,
+            "completions": completions,
+            "settings": {
+                "id": "user_settings",
+                "theme": theme,
+                "weekStartsOn": week_starts_on,
+                "showStreaks": True,
+                "showCompletionRate": True,
+                "defaultView": "today",
+                "createdAt": iso_dt(created_base),
+                "updatedAt": iso_dt(now),
+            },
+        },
+    }
+
+
+def write_payload(filename: str, payload: dict[str, Any]) -> None:
+    path = OUT_DIR / filename
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"{path}: {len(payload['data']['habits'])} habits, "
+        f"{len(payload['data']['completions'])} completions"
+    )
+
+
+def main() -> None:
+    write_payload(
+        "habitflow-sample-starter.json",
+        make_payload(templates=STARTER_TEMPLATES, days=35, seed=11),
+    )
+    write_payload(
+        "habitflow-sample-power-user.json",
+        make_payload(templates=POWER_USER_TEMPLATES, days=370, seed=29),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,15 +8,23 @@
   --surface-elevated: rgba(255, 255, 255, 0.84);
   --surface-strong: #fffefb;
   --surface-muted: #f4ede2;
+  --surface-paper: #fffdf8;
+  --surface-panel: rgba(255, 252, 246, 0.78);
+  --surface-overlay: rgba(255, 255, 255, 0.52);
+  --surface-tint: rgba(245, 236, 223, 0.72);
   --text-primary: #1f1b16;
   --text-secondary: #554e43;
   --text-muted: #8f8578;
   --border: rgba(64, 50, 31, 0.14);
   --border-subtle: #d9cfbf;
+  --border-strong: rgba(78, 61, 38, 0.2);
   --ring: #2563eb;
   --bg-glow-1: rgba(14, 165, 233, 0.15);
   --bg-glow-2: rgba(245, 158, 11, 0.14);
   --bg-grid: rgba(102, 83, 58, 0.06);
+  --shadow-editorial-sm: 0 8px 20px -16px rgba(37, 29, 18, 0.34);
+  --shadow-editorial-md: 0 18px 34px -22px rgba(37, 29, 18, 0.38);
+  --shadow-editorial-lg: 0 28px 56px -32px rgba(37, 29, 18, 0.46);
 
   /* Accent Colors */
   --accent-blue: #2563eb;
@@ -53,17 +61,25 @@
   --background-alt: #1b1611;
   --surface: rgba(41, 31, 23, 0.58);
   --surface-elevated: rgba(46, 35, 26, 0.78);
-  --surface-strong: #2a2118;
-  --surface-muted: #231b14;
+  --surface-strong: #31261c;
+  --surface-muted: #2a2017;
+  --surface-paper: #2b2219;
+  --surface-panel: rgba(47, 36, 26, 0.82);
+  --surface-overlay: rgba(57, 43, 31, 0.6);
+  --surface-tint: rgba(68, 51, 36, 0.76);
   --text-primary: #f8f2e8;
-  --text-secondary: #d3c6b5;
-  --text-muted: #9b8d7b;
+  --text-secondary: #ddd0bf;
+  --text-muted: #b4a692;
   --border: rgba(255, 235, 209, 0.14);
-  --border-subtle: #433528;
+  --border-subtle: #594535;
+  --border-strong: rgba(255, 235, 209, 0.26);
   --ring: #60a5fa;
   --bg-glow-1: rgba(37, 99, 235, 0.26);
   --bg-glow-2: rgba(217, 119, 6, 0.2);
   --bg-grid: rgba(208, 176, 142, 0.05);
+  --shadow-editorial-sm: 0 10px 22px -16px rgba(0, 0, 0, 0.5);
+  --shadow-editorial-md: 0 22px 40px -24px rgba(0, 0, 0, 0.56);
+  --shadow-editorial-lg: 0 30px 58px -30px rgba(0, 0, 0, 0.62);
   --chart-1: #2dd4bf;
   --chart-2: #60a5fa;
   --chart-3: #c084fc;
@@ -84,11 +100,16 @@
   --color-surface-elevated: var(--surface-elevated);
   --color-surface-strong: var(--surface-strong);
   --color-surface-muted: var(--surface-muted);
+  --color-surface-paper: var(--surface-paper);
+  --color-surface-panel: var(--surface-panel);
+  --color-surface-overlay: var(--surface-overlay);
+  --color-surface-tint: var(--surface-tint);
   --color-text-primary: var(--text-primary);
   --color-text-secondary: var(--text-secondary);
   --color-text-muted: var(--text-muted);
   --color-border: var(--border);
   --color-border-subtle: var(--border-subtle);
+  --color-border-strong: var(--border-strong);
   --color-ring: var(--ring);
 
   --color-accent-blue: var(--accent-blue);
@@ -129,6 +150,7 @@
 body {
   background-color: var(--background);
   background-image:
+    radial-gradient(1200px 760px at 50% 120%, rgba(255, 255, 255, 0.35) 0%, transparent 68%),
     repeating-linear-gradient(
       45deg,
       transparent 0 20px,
@@ -143,6 +165,11 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent-blue) 22%, transparent);
+  color: var(--text-primary);
 }
 
 h1,
@@ -238,6 +265,79 @@ h6 {
 
 .animate-overlay-fade {
   animation: overlay-fade 200ms ease-out;
+}
+
+/* ─── Editorial Surface Helpers ──────────────────────────── */
+.hf-panel {
+  background: var(--surface-panel);
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 88%, white 12%);
+  box-shadow: var(--shadow-editorial-sm);
+  backdrop-filter: blur(20px);
+}
+
+.hf-panel-strong {
+  background: var(--surface-paper);
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 88%, white 12%);
+  box-shadow: var(--shadow-editorial-md);
+}
+
+.hf-panel-muted {
+  background: color-mix(in srgb, var(--surface-tint) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(18px);
+}
+
+.hf-hero {
+  position: relative;
+  background:
+    radial-gradient(600px 240px at 105% -10%, color-mix(in srgb, var(--accent-amber) 15%, transparent), transparent 65%),
+    radial-gradient(680px 260px at -5% -25%, color-mix(in srgb, var(--accent-cyan) 14%, transparent), transparent 70%),
+    var(--surface-paper);
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 85%, white 15%);
+  box-shadow: var(--shadow-editorial-md);
+}
+
+.hf-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.32), transparent 40%),
+    repeating-linear-gradient(
+      135deg,
+      transparent 0 13px,
+      color-mix(in srgb, var(--bg-grid) 70%, transparent) 13px 14px
+    );
+  opacity: 0.65;
+}
+
+.hf-row {
+  background: color-mix(in srgb, var(--surface-overlay) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28);
+  backdrop-filter: blur(18px);
+}
+
+.hf-row:hover {
+  background: color-mix(in srgb, var(--surface-paper) 72%, transparent);
+  border-color: color-mix(in srgb, var(--border-strong) 86%, transparent);
+}
+
+.hf-kicker {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .hf-hero::before {
+    opacity: 0.48;
+  }
 }
 
 /* ─── Cell Fill (Month Grid) ────────────────────────────── */

--- a/src/app/habits/[id]/edit/page.tsx
+++ b/src/app/habits/[id]/edit/page.tsx
@@ -70,7 +70,7 @@ export default function EditHabitPage({
   if (!habit) {
     return (
       <PageContainer>
-        <Header title="Habit not found" eyebrow="Habit Library" />
+        <Header title="Habit not found" eyebrow="Habit Library" accentColor="var(--accent-emerald)" />
         <p className="text-text-secondary text-sm">
           This habit may have been deleted.
         </p>
@@ -80,7 +80,12 @@ export default function EditHabitPage({
 
   return (
     <PageContainer>
-      <Header title="Edit Habit" subtitle={habit.name} eyebrow="Habit Library" />
+      <Header
+        title="Edit Habit"
+        subtitle={habit.name}
+        eyebrow="Habit Library"
+        accentColor="var(--accent-emerald)"
+      />
       <div className="max-w-xl space-y-6">
         <HabitForm
           initialData={habit}
@@ -89,7 +94,7 @@ export default function EditHabitPage({
         />
 
         {!habit.isArchived && (
-          <div className="pt-4 border-t border-border-subtle">
+          <div className="hf-panel-muted rounded-2xl border-0 p-4 pt-4">
             <Button
               variant="destructive"
               onClick={() => setShowArchive(true)}

--- a/src/app/habits/new/page.tsx
+++ b/src/app/habits/new/page.tsx
@@ -44,6 +44,7 @@ export default function NewHabitPage() {
         title="New Habit"
         subtitle="Create a new habit to track"
         eyebrow="Habit Library"
+        accentColor="var(--accent-emerald)"
       />
       <div className="max-w-xl">
         <HabitForm onSubmit={handleSubmit} submitLabel="Create Habit" />

--- a/src/app/habits/page.tsx
+++ b/src/app/habits/page.tsx
@@ -136,6 +136,7 @@ export default function HabitsPage() {
         title="Habits"
         subtitle={`${activeHabits.length} active habit${activeHabits.length !== 1 ? "s" : ""}`}
         eyebrow="Habit Library"
+        accentColor="var(--accent-emerald)"
         actions={
           <Link href="/habits/new">
             <Button size="sm">
@@ -175,7 +176,7 @@ export default function HabitsPage() {
           </div>
 
           {/* Search & Filter */}
-          <div className="rounded-2xl border border-border-subtle bg-surface-elevated/80 p-4 backdrop-blur-xl">
+          <div className="hf-panel rounded-3xl p-4">
             <div className="mb-3 flex items-center gap-2">
               <Badge className="text-[11px]">Filters</Badge>
               <span className="text-xs text-text-muted">Narrow down your habit list</span>
@@ -199,10 +200,15 @@ export default function HabitsPage() {
           </div>
 
           {/* Active Habits */}
-          <div className="rounded-2xl border border-border-subtle bg-surface/70 p-3 sm:p-4">
-            <div className="mb-3 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-text-primary">Active Habits</h2>
-              <span className="text-xs text-text-muted">{filteredHabits.length} shown</span>
+          <div className="hf-panel-strong rounded-3xl p-3 sm:p-4">
+            <div className="mb-3 flex items-center justify-between rounded-2xl border border-border-subtle/70 bg-surface-overlay/60 px-3 py-2">
+              <div>
+                <p className="hf-kicker">Library</p>
+                <h2 className="text-sm font-semibold text-text-primary">Active Habits</h2>
+              </div>
+              <span className="rounded-full border border-border-subtle/80 bg-surface-paper/70 px-2.5 py-1 text-xs text-text-muted">
+                {filteredHabits.length} shown
+              </span>
             </div>
             <div className="space-y-2">
               {filteredHabits.map((habit, idx) => (
@@ -230,11 +236,11 @@ export default function HabitsPage() {
 
           {/* Archived Section */}
           {archivedHabits.length > 0 && (
-            <div className="rounded-2xl border border-border-subtle bg-surface/60 p-4">
+            <div className="hf-panel-muted rounded-2xl p-4">
               <button
                 type="button"
                 onClick={() => setShowArchived(!showArchived)}
-                className="text-sm font-medium text-text-muted hover:text-text-secondary transition-colors"
+                className="rounded-full border border-transparent px-2 py-1 text-sm font-medium text-text-muted transition-colors hover:border-border-subtle hover:bg-surface-paper/50 hover:text-text-secondary"
               >
                 {showArchived ? "Hide" : "Show"} archived ({archivedHabits.length})
               </button>
@@ -271,12 +277,14 @@ interface SummaryCardProps {
 
 function SummaryCard({ icon: Icon, label, value, helper, accent }: SummaryCardProps) {
   return (
-    <div className="rounded-2xl border border-border-subtle bg-surface-strong/80 p-3.5 shadow-sm">
+    <div className="hf-panel-strong rounded-2xl p-3.5">
       <div className="flex items-center justify-between">
-        <p className="text-xs font-medium text-text-secondary">{label}</p>
-        <Icon className="h-4 w-4" style={{ color: accent }} />
+        <p className="text-xs font-medium uppercase tracking-[0.1em] text-text-secondary">{label}</p>
+        <div className="rounded-lg border border-border-subtle/80 bg-surface-tint/70 p-1.5">
+          <Icon className="h-4 w-4" style={{ color: accent }} />
+        </div>
       </div>
-      <p className="mt-1 text-2xl font-semibold text-text-primary">{value}</p>
+      <p className="mt-2 text-2xl font-semibold text-text-primary">{value}</p>
       <p className="text-xs text-text-muted">{helper}</p>
     </div>
   );

--- a/src/app/month/page.tsx
+++ b/src/app/month/page.tsx
@@ -57,10 +57,11 @@ export default function MonthPage() {
         title="Month"
         subtitle={monthLabel}
         eyebrow="Planning View"
+        accentColor="var(--accent-cyan)"
         actions={
           <div className="flex items-center gap-1">
             <Button
-              variant="ghost"
+              variant="secondary"
               size="icon"
               onClick={() => setMonthOffset((o) => o - 1)}
               aria-label="Previous month"
@@ -77,7 +78,7 @@ export default function MonthPage() {
               </Button>
             )}
             <Button
-              variant="ghost"
+              variant="secondary"
               size="icon"
               onClick={() => setMonthOffset((o) => o + 1)}
               aria-label="Next month"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,12 @@ export default function DashboardPage() {
 
   return (
     <PageContainer>
-      <Header title="Today" subtitle={formatted} eyebrow="Daily Focus" />
+      <Header
+        title="Today"
+        subtitle={formatted}
+        eyebrow="Daily Focus"
+        accentColor="var(--accent-blue)"
+      />
       <TodayView
         habits={habits}
         completions={completions}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ export default function SettingsPage() {
         title="Settings"
         subtitle="Customize your experience"
         eyebrow="Preferences"
+        accentColor="var(--accent-amber)"
       />
       <SettingsContent />
     </PageContainer>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -90,6 +90,7 @@ export default function StatsPage() {
         title="Statistics"
         subtitle="Track your progress over time"
         eyebrow="Analytics"
+        accentColor="var(--accent-violet)"
       />
 
       {loading ? (

--- a/src/app/week/page.tsx
+++ b/src/app/week/page.tsx
@@ -53,10 +53,11 @@ export default function WeekPage() {
         title="Week"
         subtitle={weekLabel}
         eyebrow="Planning View"
+        accentColor="var(--accent-emerald)"
         actions={
           <div className="flex items-center gap-1">
             <Button
-              variant="ghost"
+              variant="secondary"
               size="icon"
               onClick={() => setWeekOffset((o) => o - 1)}
               aria-label="Previous week"
@@ -73,7 +74,7 @@ export default function WeekPage() {
               </Button>
             )}
             <Button
-              variant="ghost"
+              variant="secondary"
               size="icon"
               onClick={() => setWeekOffset((o) => o + 1)}
               aria-label="Next week"

--- a/src/components/dashboard/compact-progress-bar.tsx
+++ b/src/components/dashboard/compact-progress-bar.tsx
@@ -13,7 +13,7 @@ export function CompactProgressBar({ completed, total }: CompactProgressBarProps
 
   return (
     <div className="flex items-center gap-4 sm:gap-5">
-      <div className="rounded-2xl border border-border-subtle bg-surface-muted/70 p-1">
+      <div className="rounded-2xl border border-border-subtle bg-surface-paper/75 p-1 shadow-[var(--shadow-editorial-sm)]">
         <DailyProgressRing
           completed={completed}
           total={total}
@@ -30,7 +30,7 @@ export function CompactProgressBar({ completed, total }: CompactProgressBarProps
             {percentage}%
           </span>
         </div>
-        <div className="h-2.5 overflow-hidden rounded-full bg-surface-muted">
+        <div className="h-2.5 overflow-hidden rounded-full border border-border-subtle/70 bg-surface-muted">
           <div
             className="h-full rounded-full bg-accent-blue transition-all duration-500 ease-out"
             style={{ width: `${percentage}%` }}

--- a/src/components/dashboard/month-cell.tsx
+++ b/src/components/dashboard/month-cell.tsx
@@ -39,7 +39,7 @@ export function MonthCell({
 
   if (!scheduled) {
     return (
-      <div className="flex h-8 w-8 items-center justify-center rounded-md bg-surface-muted/20">
+      <div className="flex h-8 w-8 items-center justify-center rounded-md bg-surface-overlay/28">
         <div className="h-1.5 w-1.5 rounded-full bg-text-muted/30" />
       </div>
     );
@@ -60,7 +60,7 @@ export function MonthCell({
       className={cn(
         "h-8 w-8 rounded-md flex items-center justify-center border",
         "transition-all duration-150",
-        completed ? "shadow-sm" : "border-border-subtle/60 hover:border-border-subtle",
+        completed ? "shadow-[var(--shadow-editorial-sm)]" : "border-border-subtle/60 bg-surface-paper/40 hover:border-border-subtle",
         isToday && "ring-1 ring-accent-blue/45 ring-offset-1 ring-offset-background",
         animating && "animate-cell-fill"
       )}

--- a/src/components/dashboard/month-view.tsx
+++ b/src/components/dashboard/month-view.tsx
@@ -49,11 +49,10 @@ export function MonthView({
     <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
       <div
         className={cn(
-          "bg-surface-elevated/90 backdrop-blur-xl border border-border-subtle rounded-2xl",
-          "shadow-sm"
+          "hf-panel rounded-3xl"
         )}
       >
-        <div className="flex flex-wrap items-center gap-3 border-b border-border-subtle/70 px-4 py-3 text-xs text-text-secondary">
+        <div className="flex flex-wrap items-center gap-2 border-b border-border-subtle/70 bg-surface-paper/35 px-4 py-3 text-xs text-text-secondary">
           <LegendChip label="Done" className="bg-accent-blue" />
           <LegendChip label="Scheduled" className="bg-surface-muted border border-border-subtle" />
           <LegendChip label="Future" className="bg-transparent border border-text-muted/45" />
@@ -81,8 +80,8 @@ export function MonthView({
                 className={cn(
                   "flex h-10 flex-col items-center justify-center rounded-md border text-[10px]",
                   isToday
-                    ? "border-accent-blue/40 bg-accent-blue/8 text-accent-blue font-bold"
-                    : "border-border-subtle/60 bg-surface/40 text-text-muted"
+                    ? "border-accent-blue/40 bg-accent-blue/8 text-accent-blue font-bold shadow-[var(--shadow-editorial-sm)]"
+                    : "border-border-subtle/60 bg-surface-paper/40 text-text-muted"
                 )}
               >
                 {dayNum}
@@ -136,7 +135,7 @@ function MonthHabitRow({
         className={cn(
           "flex items-center gap-2 min-h-[40px] px-2 sticky left-0 rounded-md border-l-2",
           "z-10 backdrop-blur-xl",
-          rowIndex % 2 === 0 ? "bg-surface/75" : "bg-surface-muted/35",
+          rowIndex % 2 === 0 ? "bg-surface-paper/72" : "bg-surface-overlay/72",
           !isLast && "border-b border-border-subtle/45"
         )}
         style={{ borderLeftColor: habit.color }}
@@ -156,7 +155,7 @@ function MonthHabitRow({
             key={date}
             className={cn(
               "flex items-center justify-center min-h-[40px] rounded-md",
-              rowIndex % 2 === 0 ? "bg-surface/40" : "bg-surface-muted/24",
+              rowIndex % 2 === 0 ? "bg-surface-paper/30" : "bg-surface-overlay/28",
               date === today && "bg-accent-blue/7",
               !isLast && "border-b border-border-subtle/45"
             )}
@@ -178,7 +177,7 @@ function MonthHabitRow({
 
 function MonthSkeleton({ daysCount }: { daysCount: number }) {
   return (
-    <div className="rounded-2xl bg-surface-elevated border border-border-subtle p-4 space-y-3">
+    <div className="hf-panel rounded-2xl p-4 space-y-3">
       <div className="flex gap-1">
         <Skeleton className="h-8 w-[168px] rounded-lg" />
         {Array.from({ length: Math.min(daysCount, 15) }).map((_, i) => (
@@ -199,7 +198,7 @@ function MonthSkeleton({ daysCount }: { daysCount: number }) {
 
 function LegendChip({ label, className }: { label: string; className: string }) {
   return (
-    <div className="inline-flex items-center gap-1.5">
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-border-subtle/70 bg-surface-paper/50 px-2 py-1">
       <span className={cn("h-2.5 w-2.5 rounded-full", className)} />
       <span>{label}</span>
     </div>

--- a/src/components/dashboard/today-view.tsx
+++ b/src/components/dashboard/today-view.tsx
@@ -82,13 +82,13 @@ export function TodayView({
 
   return (
     <div className="space-y-5">
-      <div className="rounded-3xl border border-border-subtle bg-surface-strong/90 p-4 shadow-sm backdrop-blur-xl sm:p-5">
-        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="hf-hero rounded-3xl p-4 sm:p-5">
+        <div className="relative z-[1] mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">
+            <p className="hf-kicker">
               Today&apos;s Momentum
             </p>
-            <h2 className="mt-1 text-xl font-semibold text-text-primary sm:text-2xl">
+            <h2 className="mt-1 text-xl font-semibold text-text-primary sm:text-3xl">
               {completedCount} of {scheduledCount} habits complete
             </h2>
             <p className="mt-1 text-sm text-text-secondary">
@@ -97,7 +97,7 @@ export function TodayView({
                 : `${remainingCount} left today. Small steps compound quickly.`}
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
             <Badge variant="accent" className="px-3 py-1 text-[11px]">
               {completionRate}% completion
             </Badge>
@@ -109,24 +109,26 @@ export function TodayView({
           </div>
         </div>
 
-        <CompactProgressBar completed={completedCount} total={scheduledCount} />
+        <div className="relative z-[1] rounded-2xl border border-border-subtle/75 bg-surface-overlay/70 p-3 sm:p-4">
+          <CompactProgressBar completed={completedCount} total={scheduledCount} />
 
-        {focusCategories.length > 0 && (
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <span className="text-xs text-text-muted">Focus areas:</span>
-            {focusCategories.map((category) => (
-              <Badge key={category} className="text-[11px]">
-                {category}
-              </Badge>
-            ))}
-          </div>
-        )}
+          {focusCategories.length > 0 && (
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <span className="text-xs text-text-muted">Focus areas:</span>
+              {focusCategories.map((category) => (
+                <Badge key={category} className="text-[11px]">
+                  {category}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Checklist */}
       {scheduledHabits.length > 0 ? (
-        <div className="overflow-hidden rounded-2xl border border-border-subtle bg-surface-elevated/90 backdrop-blur-xl">
-          <div className="flex items-center justify-between border-b border-border-subtle/70 px-4 py-3">
+        <div className="hf-panel overflow-hidden rounded-3xl">
+          <div className="flex items-center justify-between border-b border-border-subtle/70 bg-surface-paper/40 px-4 py-3">
             <div>
               <h3 className="text-sm font-semibold text-text-primary">Today&apos;s Checklist</h3>
               <p className="text-xs text-text-muted">
@@ -135,7 +137,7 @@ export function TodayView({
             </div>
             <Link
               href="/habits"
-              className="inline-flex items-center gap-1 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary"
+              className="inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:border-border-subtle hover:bg-surface-paper/70 hover:text-text-primary"
             >
               Manage
               <ArrowRight className="h-3.5 w-3.5" />
@@ -159,9 +161,9 @@ export function TodayView({
           })}
         </div>
       ) : (
-        <p className="text-center text-sm text-text-muted py-8">
+        <div className="hf-panel rounded-2xl px-4 py-8 text-center text-sm text-text-muted">
           No habits scheduled for today.
-        </p>
+        </div>
       )}
 
       {/* All Complete Message */}
@@ -185,7 +187,7 @@ function ChecklistRow({ habit, completed, streak, onToggle, isLast }: ChecklistR
     <div
       className={cn(
         "group relative flex items-center gap-3 px-4 py-3.5",
-        "transition-colors duration-150 hover:bg-surface/55",
+        "transition-all duration-150 hover:bg-surface-paper/40",
         !isLast && "border-b border-border-subtle/50"
       )}
     >
@@ -203,7 +205,7 @@ function ChecklistRow({ habit, completed, streak, onToggle, isLast }: ChecklistR
 
       <Link
         href={`/habits/${habit.id}`}
-        className="flex-1 min-w-0 flex items-center gap-2"
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-lg pr-1"
       >
         <span className="text-base shrink-0">{habit.icon}</span>
         <span

--- a/src/components/dashboard/week-cell.tsx
+++ b/src/components/dashboard/week-cell.tsx
@@ -24,14 +24,14 @@ export function WeekCell({
   const wrapperClass = cn(
     "flex min-h-[52px] items-center justify-center rounded-xl border transition-colors duration-150",
     isToday
-      ? "border-accent-blue/35 bg-accent-blue/8"
+      ? "border-accent-blue/35 bg-accent-blue/8 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]"
       : "border-transparent"
   );
 
   if (isFuture) {
     return (
       <div
-        className={cn(wrapperClass, "bg-surface-muted/35")}
+        className={cn(wrapperClass, "bg-surface-overlay/32")}
       >
         {scheduled ? (
           <div
@@ -47,7 +47,7 @@ export function WeekCell({
 
   if (!scheduled) {
     return (
-      <div className={cn(wrapperClass, "bg-surface-muted/25")}>
+      <div className={cn(wrapperClass, "bg-surface-overlay/24")}>
         <Minus className="h-4 w-4 text-text-muted/45" />
       </div>
     );
@@ -55,7 +55,7 @@ export function WeekCell({
 
   return (
     <div
-      className={cn(wrapperClass, "bg-surface/45")}
+      className={cn(wrapperClass, "bg-surface-paper/38")}
       style={{
         backgroundColor: completed ? `${color}1c` : undefined,
       }}

--- a/src/components/dashboard/week-view.tsx
+++ b/src/components/dashboard/week-view.tsx
@@ -64,11 +64,10 @@ export function WeekView({
     <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
       <div
         className={cn(
-          "bg-surface-elevated/90 backdrop-blur-xl border border-border-subtle rounded-2xl",
-          "shadow-sm"
+          "hf-panel rounded-3xl"
         )}
       >
-        <div className="flex flex-wrap items-center gap-3 border-b border-border-subtle/70 px-4 py-3 text-xs text-text-secondary">
+        <div className="flex flex-wrap items-center gap-2 border-b border-border-subtle/70 bg-surface-paper/35 px-4 py-3 text-xs text-text-secondary">
           <LegendItem label="Completed" colorClass="bg-accent-blue" />
           <LegendItem label="Scheduled" colorClass="bg-surface-muted border border-border-subtle" />
           <LegendItem label="Future" colorClass="bg-transparent border border-text-muted/45" />
@@ -94,8 +93,8 @@ export function WeekView({
                 className={cn(
                   "flex h-14 flex-col items-center justify-center rounded-xl border text-center",
                   isToday
-                    ? "border-accent-blue/35 bg-accent-blue/10"
-                    : "border-border-subtle/65 bg-surface/45"
+                    ? "border-accent-blue/35 bg-accent-blue/10 shadow-[var(--shadow-editorial-sm)]"
+                    : "border-border-subtle/65 bg-surface-paper/45"
                 )}
               >
                 <span className="text-[10px] font-semibold text-text-muted uppercase">
@@ -159,8 +158,8 @@ function HabitRow({
         className={cn(
           "flex items-center gap-2.5 min-h-[52px] px-2.5 sticky left-0 rounded-lg border-l-2",
           "z-10 backdrop-blur-xl transition-colors duration-150",
-          rowIndex % 2 === 0 ? "bg-surface/75" : "bg-surface-muted/40",
-          "hover:bg-surface-strong",
+          rowIndex % 2 === 0 ? "bg-surface-paper/70" : "bg-surface-overlay/70",
+          "hover:bg-surface-paper",
           !isLast && "border-b border-border-subtle/50"
         )}
         style={{ borderLeftColor: habit.color }}
@@ -181,7 +180,7 @@ function HabitRow({
             key={date}
             className={cn(
               "rounded-lg",
-              rowIndex % 2 === 0 ? "bg-surface/45" : "bg-surface-muted/30",
+              rowIndex % 2 === 0 ? "bg-surface-paper/35" : "bg-surface-overlay/35",
               !isLast && "border-b border-border-subtle/45"
             )}
           >
@@ -202,7 +201,7 @@ function HabitRow({
 
 function LegendItem({ label, colorClass }: { label: string; colorClass: string }) {
   return (
-    <div className="inline-flex items-center gap-1.5">
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-border-subtle/70 bg-surface-paper/50 px-2 py-1">
       <span className={cn("h-2.5 w-2.5 rounded-full", colorClass)} />
       <span>{label}</span>
     </div>

--- a/src/components/habits/completion-toggle.tsx
+++ b/src/components/habits/completion-toggle.tsx
@@ -35,14 +35,14 @@ export function CompletionToggle({
       type="button"
       onClick={handleClick}
       className={cn(
-        "rounded-full flex items-center justify-center shrink-0",
-        "transition-all duration-200 border-2",
+        "flex shrink-0 items-center justify-center rounded-full",
+        "transition-all duration-200 border-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]",
         sizeClass,
         animating && "animate-completion-bounce"
       )}
       style={{
         borderColor: completed ? color : "var(--border-subtle)",
-        backgroundColor: completed ? color : "transparent",
+        backgroundColor: completed ? color : "var(--surface-paper)",
       }}
       aria-label={completed ? "Mark as incomplete" : "Mark as complete"}
       aria-pressed={completed}

--- a/src/components/habits/habit-calendar-heatmap.tsx
+++ b/src/components/habits/habit-calendar-heatmap.tsx
@@ -7,7 +7,7 @@ import {
   format,
   parseISO,
 } from "date-fns";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { isHabitScheduledForDate } from "@/lib/date-utils";
 import type { Habit, HabitCompletion } from "@/types";
@@ -80,9 +80,10 @@ export function HabitCalendarHeatmap({
     <Card>
       <CardHeader>
         <CardTitle>Activity</CardTitle>
+        <CardDescription>Last 26 weeks of scheduled vs completed activity</CardDescription>
       </CardHeader>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto rounded-2xl border border-border-subtle/70 bg-surface-overlay/45 p-3">
         {/* Month labels */}
         <div className="flex ml-8 mb-1">
           {monthLabels.map(({ col, label }, i) => {
@@ -121,7 +122,7 @@ export function HabitCalendarHeatmap({
                   <div
                     key={cell.date}
                     className={cn(
-                      "h-[10px] w-[10px] rounded-[2px]",
+                      "h-[10px] w-[10px] rounded-[3px]",
                       cell.status === "future" && "bg-transparent",
                       cell.status === "unscheduled" && "bg-border-subtle/30",
                       cell.status === "scheduled" && "bg-border-subtle",
@@ -140,7 +141,7 @@ export function HabitCalendarHeatmap({
         </div>
 
         {/* Legend */}
-        <div className="flex items-center gap-3 mt-3 text-[10px] text-text-muted">
+        <div className="mt-3 flex items-center gap-3 text-[10px] text-text-muted">
           <div className="flex items-center gap-1">
             <div className="h-[10px] w-[10px] rounded-[2px] bg-border-subtle/30" />
             <span>Not scheduled</span>

--- a/src/components/habits/habit-detail-header.tsx
+++ b/src/components/habits/habit-detail-header.tsx
@@ -13,11 +13,11 @@ interface HabitDetailHeaderProps {
 
 export function HabitDetailHeader({ habit }: HabitDetailHeaderProps) {
   return (
-    <div>
+    <div className="hf-hero rounded-3xl p-5">
       {/* Back link */}
       <Link
         href="/habits"
-        className="inline-flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors mb-4"
+        className="relative z-[1] mb-4 inline-flex items-center gap-1 rounded-full border border-transparent px-2 py-1 text-sm text-text-secondary transition-colors hover:border-border-subtle hover:bg-surface-paper/70 hover:text-text-primary"
       >
         <ChevronLeft className="h-4 w-4" />
         Back
@@ -25,13 +25,15 @@ export function HabitDetailHeader({ habit }: HabitDetailHeaderProps) {
 
       {/* Color accent bar */}
       <div
-        className="h-1.5 rounded-full w-16 mb-4"
+        className="relative z-[1] mb-4 h-1.5 w-16 rounded-full"
         style={{ backgroundColor: habit.color }}
       />
 
-      <div className="flex items-start justify-between gap-4">
+      <div className="relative z-[1] flex items-start justify-between gap-4">
         <div className="flex items-start gap-3 min-w-0">
-          <span className="text-3xl shrink-0">{habit.icon}</span>
+          <span className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-border-subtle bg-surface-paper text-3xl shadow-[var(--shadow-editorial-sm)]">
+            {habit.icon}
+          </span>
           <div className="min-w-0">
             <h2 className="text-xl font-bold text-text-primary truncate">
               {habit.name}

--- a/src/components/habits/habit-form.tsx
+++ b/src/components/habits/habit-form.tsx
@@ -110,8 +110,9 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
   return (
     <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
       {/* Name */}
-      <Card>
+      <Card variant="elevated">
         <div className="space-y-2" data-error={errors.name ? "" : undefined}>
+          <p className="hf-kicker">Essentials</p>
           <Label htmlFor="name">Name *</Label>
           <Input
             id="name"
@@ -144,9 +145,10 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
       {/* Icon */}
       <Card>
         <div className="space-y-2" data-error={errors.icon ? "" : undefined}>
+          <p className="hf-kicker">Identity</p>
           <Label>Icon</Label>
           <div className="flex items-center gap-4 mb-3">
-            <div className="h-14 w-14 rounded-xl bg-surface-elevated border border-border-subtle flex items-center justify-center text-3xl">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border-subtle bg-surface-paper text-3xl shadow-[var(--shadow-editorial-sm)]">
               {icon}
             </div>
             <span className="text-sm text-text-secondary">
@@ -163,17 +165,19 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
       {/* Color */}
       <Card>
         <div className="space-y-2">
+          <p className="hf-kicker">Color</p>
           <Label>Color</Label>
           <ColorPicker value={color} onChange={setColor} />
         </div>
       </Card>
 
       {/* Frequency */}
-      <Card>
+      <Card variant="elevated">
         <div
           className="space-y-2"
           data-error={errors.targetDays || errors.targetCount ? "" : undefined}
         >
+          <p className="hf-kicker">Schedule</p>
           <Label>Frequency *</Label>
           <FrequencySelector
             frequency={frequency}
@@ -195,6 +199,7 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
       {/* Reminder Time */}
       <Card>
         <div className="space-y-2">
+          <p className="hf-kicker">Reminder</p>
           <Label htmlFor="reminderTime">Reminder Time</Label>
           <Input
             id="reminderTime"
@@ -209,6 +214,7 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
       {/* Category */}
       <Card>
         <div className="space-y-2">
+          <p className="hf-kicker">Organization</p>
           <Label htmlFor="category">Category</Label>
           <Input
             id="category"
@@ -222,7 +228,7 @@ export function HabitForm({ initialData, onSubmit, submitLabel }: HabitFormProps
       </Card>
 
       {/* Actions */}
-      <div className="flex gap-3 pt-2">
+      <div className="hf-panel rounded-2xl flex gap-3 p-3">
         <Button
           type="button"
           variant="ghost"

--- a/src/components/habits/habit-list-item.tsx
+++ b/src/components/habits/habit-list-item.tsx
@@ -46,9 +46,8 @@ export function HabitListItem({
     <>
       <div
         className={cn(
-          "group relative rounded-2xl border px-4 py-3",
-          "bg-surface backdrop-blur-xl transition-all duration-200",
-          "border-border hover:border-border-subtle hover:bg-surface-elevated"
+          "hf-row group relative rounded-2xl px-4 py-3",
+          "transition-all duration-200 hover:-translate-y-0.5"
         )}
       >
         <span
@@ -59,8 +58,8 @@ export function HabitListItem({
 
         <div className="flex items-center gap-3 pl-1">
           <div
-            className="h-10 w-10 rounded-xl flex items-center justify-center text-xl shrink-0 border border-border-subtle"
-            style={{ backgroundColor: `${habit.color}15` }}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border-subtle bg-surface-paper text-xl shadow-[var(--shadow-editorial-sm)]"
+            style={{ boxShadow: `inset 0 0 0 1px ${habit.color}20, var(--shadow-editorial-sm)` }}
           >
             {habit.icon}
           </div>
@@ -91,7 +90,7 @@ export function HabitListItem({
 
           <DropdownMenu>
             <DropdownMenuTrigger
-              className="p-2 rounded-lg text-text-muted hover:text-text-primary hover:bg-surface-muted transition-colors"
+              className="rounded-xl border border-transparent p-2 text-text-muted transition-colors hover:border-border-subtle hover:bg-surface-paper/70 hover:text-text-primary"
               aria-label="Actions"
             >
               <MoreVertical className="h-4 w-4" />

--- a/src/components/habits/habit-recent-history.tsx
+++ b/src/components/habits/habit-recent-history.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { parseISO, format, subDays, isToday, isYesterday } from "date-fns";
 import { Check, Circle, Minus } from "lucide-react";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { isHabitScheduledForDate } from "@/lib/date-utils";
 import type { Habit, HabitCompletion } from "@/types";
@@ -49,13 +49,14 @@ export function HabitRecentHistory({
     <Card>
       <CardHeader>
         <CardTitle>Recent History</CardTitle>
+        <CardDescription>Last {DAYS_TO_SHOW} days for this habit</CardDescription>
       </CardHeader>
 
-      <div className="space-y-0 divide-y divide-border-subtle">
+      <div className="space-y-2">
         {days.map(({ dateStr, scheduled, completion }) => (
           <div
             key={dateStr}
-            className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            className="hf-row flex items-center gap-3 rounded-xl px-3 py-2.5"
           >
             {/* Status icon */}
             {!scheduled ? (

--- a/src/components/habits/habit-stats-grid.tsx
+++ b/src/components/habits/habit-stats-grid.tsx
@@ -20,15 +20,20 @@ interface StatItemProps {
 
 function StatItem({ icon: Icon, label, value, color }: StatItemProps) {
   return (
-    <Card className="flex flex-col items-center text-center py-4">
-      <div
-        className="h-10 w-10 rounded-xl flex items-center justify-center mb-2"
-        style={{ backgroundColor: `${color}15` }}
-      >
-        <Icon className="h-5 w-5" style={{ color }} />
+    <Card className="relative overflow-hidden py-4">
+      <div className="absolute inset-x-0 top-0 h-1" style={{ backgroundColor: color, opacity: 0.7 }} />
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-10 w-10 items-center justify-center rounded-xl border border-border-subtle"
+          style={{ backgroundColor: `${color}14` }}
+        >
+          <Icon className="h-5 w-5" style={{ color }} />
+        </div>
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">{label}</div>
+          <div className="mt-1 text-2xl font-bold text-text-primary">{value}</div>
+        </div>
       </div>
-      <div className="text-xl font-bold text-text-primary">{value}</div>
-      <div className="text-xs text-text-muted">{label}</div>
     </Card>
   );
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -45,10 +45,19 @@ export function AppShell({ children }: AppShellProps) {
 
       <div
         aria-hidden
-        className="pointer-events-none fixed inset-x-0 top-0 z-10 h-20 bg-gradient-to-b from-background-alt/65 to-transparent lg:left-64"
+        className="pointer-events-none fixed inset-0 z-0"
+      >
+        <div className="absolute left-[20%] top-[-6rem] h-64 w-64 rounded-full bg-accent-cyan/10 blur-3xl" />
+        <div className="absolute right-[8%] top-10 h-56 w-56 rounded-full bg-accent-amber/10 blur-3xl" />
+        <div className="absolute bottom-[8%] left-[35%] h-72 w-72 rounded-full bg-accent-blue/7 blur-3xl" />
+      </div>
+
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-x-0 top-0 z-10 h-24 bg-gradient-to-b from-background-alt/70 via-background-alt/30 to-transparent lg:left-64"
       />
 
-      <main id="main-content" className="relative pb-24 lg:pl-64 lg:pb-0">
+      <main id="main-content" className="relative z-10 pb-32 lg:pl-64 lg:pb-0">
         {children}
       </main>
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -8,22 +8,33 @@ export interface HeaderProps extends React.HTMLAttributes<HTMLElement> {
   subtitle?: string;
   actions?: React.ReactNode;
   eyebrow?: string;
+  accentColor?: string;
 }
 
 const Header = forwardRef<HTMLElement, HeaderProps>(
-  ({ className, title, subtitle, actions, eyebrow = "HabitFlow", ...props }, ref) => {
+  (
+    { className, title, subtitle, actions, eyebrow = "HabitFlow", accentColor = "var(--accent-blue)", ...props },
+    ref
+  ) => {
     return (
       <header
         ref={ref}
         className={cn("mb-6 sm:mb-8", className)}
         {...props}
       >
-        <div className="rounded-2xl border border-border-subtle/80 bg-surface/70 p-4 shadow-sm backdrop-blur-xl sm:p-5">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div className="min-w-0">
-              <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
-                {eyebrow}
-              </p>
+        <div className="hf-hero relative overflow-hidden rounded-3xl p-4 sm:p-5">
+          <div className="relative z-[1] flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 pl-3 sm:pl-4">
+              <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-border-subtle/80 bg-surface-paper/80 px-2.5 py-1">
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: accentColor }}
+                />
+                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">
+                  {eyebrow}
+                </p>
+              </div>
               <h1 className="text-3xl sm:text-4xl font-semibold leading-tight text-text-primary">
                 {title}
               </h1>
@@ -34,11 +45,20 @@ const Header = forwardRef<HTMLElement, HeaderProps>(
               )}
             </div>
             {actions && (
-              <div className="flex items-center gap-2 self-start rounded-xl border border-border-subtle bg-surface-strong/85 p-1.5 shadow-sm">
+              <div className="hf-row flex items-center gap-2 self-start rounded-2xl p-1.5">
                 {actions}
               </div>
             )}
           </div>
+          <div
+            aria-hidden
+            className="relative z-[1] mt-4 h-px rounded-full bg-gradient-to-r from-border-strong via-border-subtle/80 to-transparent"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute bottom-5 left-4 top-5 w-[3px] rounded-full opacity-80 sm:left-5"
+            style={{ backgroundColor: accentColor }}
+          />
         </div>
       </header>
     );

--- a/src/components/layout/nav-bar.tsx
+++ b/src/components/layout/nav-bar.tsx
@@ -51,20 +51,20 @@ export function Sidebar() {
   return (
     <aside
       aria-label="Main navigation"
-      className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-border/80 bg-surface/85 backdrop-blur-2xl lg:flex"
+      className="fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-border/70 bg-surface-overlay/85 backdrop-blur-2xl lg:flex"
     >
       <div className="px-4 pb-2 pt-4">
         <Link
           href="/"
-          className="block rounded-2xl border border-border-subtle bg-surface-strong/90 p-4 shadow-sm transition-colors duration-200 hover:bg-surface-strong"
+          className="hf-panel-strong block rounded-2xl p-4 transition-transform duration-200 hover:-translate-y-0.5"
         >
           <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-accent-blue text-sm font-bold text-white">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/30 bg-accent-blue text-sm font-bold text-white shadow-[0_10px_20px_-14px_var(--accent-blue)]">
               HF
             </div>
             <div className="min-w-0">
               <p className="truncate text-base font-semibold text-text-primary">HabitFlow</p>
-              <p className="text-xs text-text-muted">Build momentum every day</p>
+              <p className="text-xs text-text-muted">Warm editorial mode</p>
             </div>
           </div>
         </Link>
@@ -84,8 +84,8 @@ export function Sidebar() {
                 "group relative flex items-center gap-3 rounded-xl border px-3 py-2.5 text-sm font-medium",
                 "transition-all duration-200",
                 active
-                  ? "border-border-subtle bg-surface-strong text-text-primary shadow-sm"
-                  : "border-transparent text-text-secondary hover:border-border hover:bg-surface-muted/70 hover:text-text-primary"
+                  ? "border-border-subtle bg-surface-paper text-text-primary shadow-[var(--shadow-editorial-sm)]"
+                  : "border-transparent text-text-secondary hover:border-border hover:bg-surface-tint/70 hover:text-text-primary"
               )}
             >
               <span
@@ -99,7 +99,7 @@ export function Sidebar() {
               <span
                 className={cn(
                   "flex h-8 w-8 items-center justify-center rounded-lg transition-colors duration-200",
-                  active ? "animate-nav-pop bg-surface-muted" : "group-hover:bg-surface-muted"
+                  active ? "animate-nav-pop bg-surface-tint/80" : "group-hover:bg-surface-tint/80"
                 )}
               >
                 <Icon className="h-4 w-4" style={active ? { color: item.accent } : undefined} />
@@ -115,7 +115,7 @@ export function Sidebar() {
           href="/habits/new"
           className={cn(
             "flex w-full items-center justify-center gap-2 rounded-xl px-3 py-2.5",
-            "bg-accent-blue text-sm font-medium text-white shadow-[0_14px_30px_-20px_var(--accent-blue)]",
+            "border border-white/20 bg-accent-blue text-sm font-medium text-white shadow-[0_16px_28px_-18px_var(--accent-blue)]",
             "transition-all duration-200 hover:-translate-y-0.5 hover:brightness-110"
           )}
         >
@@ -153,17 +153,17 @@ export function BottomNav() {
                 href={item.href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "group relative flex h-full min-w-[54px] flex-col items-center justify-center gap-1 rounded-xl px-1 text-[10px] font-medium",
+                  "group relative flex h-full min-w-[54px] flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-medium",
                   "transition-all duration-200",
                   active
-                    ? "text-text-primary"
-                    : "text-text-muted hover:text-text-secondary"
+                    ? "bg-surface-paper/90 text-text-primary shadow-[var(--shadow-editorial-sm)]"
+                    : "text-text-secondary/85 hover:text-text-primary"
                 )}
               >
                 <span
                   aria-hidden
                   className={cn(
-                    "absolute left-2 right-2 top-0 h-0.5 rounded-full transition-opacity duration-200",
+                    "absolute left-2 right-2 top-1 h-0.5 rounded-full transition-opacity duration-200",
                     active ? "opacity-100" : "opacity-0"
                   )}
                   style={{ backgroundColor: item.accent }}
@@ -171,12 +171,12 @@ export function BottomNav() {
                 <span
                   className={cn(
                     "flex h-8 w-8 items-center justify-center rounded-lg transition-all duration-200",
-                    active ? "animate-nav-pop bg-surface-muted shadow-sm" : "group-hover:bg-surface"
+                    active ? "animate-nav-pop bg-surface-tint/75 shadow-sm" : "group-hover:bg-surface"
                   )}
                 >
                   <Icon className="h-4 w-4" style={active ? { color: item.accent } : undefined} />
                 </span>
-                <span className={cn("leading-none", active && "-translate-y-0.5")}>{item.label}</span>
+                <span className={cn("leading-none tracking-[-0.01em]", active && "-translate-y-0.5")}>{item.label}</span>
               </Link>
             );
           })}

--- a/src/components/layout/page-container.tsx
+++ b/src/components/layout/page-container.tsx
@@ -11,7 +11,8 @@ const PageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
       <div
         ref={ref}
         className={cn(
-          "mx-auto w-full max-w-[1240px] px-4 py-5 sm:px-6 sm:py-8 lg:px-10 lg:py-10",
+          "mx-auto w-full max-w-[1260px] px-4 py-5 sm:px-6 sm:py-8 lg:px-10 lg:py-10",
+          "relative",
           className
         )}
         {...props}

--- a/src/components/settings/about-section.tsx
+++ b/src/components/settings/about-section.tsx
@@ -4,7 +4,7 @@ const APP_VERSION = "1.0.0";
 
 export function AboutSection() {
   return (
-    <div className="space-y-3 text-sm">
+    <div className="space-y-3 rounded-2xl border border-border-subtle/70 bg-surface-overlay/45 p-4 text-sm">
       <div className="flex items-center gap-2">
         <span className="font-semibold text-text-primary">HabitFlow</span>
         <span className="text-text-muted">v{APP_VERSION}</span>

--- a/src/components/settings/data-management.tsx
+++ b/src/components/settings/data-management.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Download, Upload, Trash2 } from "lucide-react";
+import { Download, Upload, Trash2, Sprout, Layers3, Rocket } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,6 +24,30 @@ import {
 
 const CLEAR_CONFIRM_WORD = "DELETE";
 
+const SAMPLE_IMPORTS = [
+  {
+    id: "starter",
+    label: "Starter Sample",
+    description: "5 habits and ~30 days of history",
+    href: "/sample-data/habitflow-sample-starter.json",
+    icon: Sprout,
+  },
+  {
+    id: "standard",
+    label: "Standard Sample",
+    description: "13 habits and ~5 months of history",
+    href: "/sample-data/habitflow-sample-standard.json",
+    icon: Layers3,
+  },
+  {
+    id: "power",
+    label: "Power User Sample",
+    description: "26 habits and ~1 year of history",
+    href: "/sample-data/habitflow-sample-power-user.json",
+    icon: Rocket,
+  },
+] as const;
+
 export function DataManagement() {
   const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -31,8 +55,19 @@ export function DataManagement() {
     habits: number;
     completions: number;
     data: Parameters<typeof applyImport>[0];
+    sourceLabel?: string;
   } | null>(null);
   const [clearOpen, setClearOpen] = useState(false);
+  const [loadingSampleId, setLoadingSampleId] = useState<string | null>(null);
+
+  function openImportPreview(data: Parameters<typeof applyImport>[0], sourceLabel?: string) {
+    setImportPreview({
+      habits: data.data.habits.length,
+      completions: data.data.completions.length,
+      data,
+      sourceLabel,
+    });
+  }
 
   async function handleExport() {
     try {
@@ -60,13 +95,33 @@ export function DataManagement() {
         return;
       }
 
-      setImportPreview({
-        habits: result.data!.data.habits.length,
-        completions: result.data!.data.completions.length,
-        data: result.data!,
-      });
+      openImportPreview(result.data!);
     } catch {
       toast("Could not read file. Make sure it's valid JSON.", "error");
+    }
+  }
+
+  async function handleLoadSample(sample: (typeof SAMPLE_IMPORTS)[number]) {
+    setLoadingSampleId(sample.id);
+    try {
+      const response = await fetch(sample.href, { cache: "no-store" });
+      if (!response.ok) {
+        toast(`Failed to load sample (${response.status})`, "error");
+        return;
+      }
+
+      const raw = await response.json();
+      const result = validateImportData(raw);
+      if (!result.valid) {
+        toast(`Invalid sample: ${result.errors?.[0] ?? "Unknown error"}`, "error");
+        return;
+      }
+
+      openImportPreview(result.data!, sample.label);
+    } catch {
+      toast("Could not load sample data", "error");
+    } finally {
+      setLoadingSampleId(null);
     }
   }
 
@@ -77,7 +132,7 @@ export function DataManagement() {
       await applyImport(importPreview.data);
       toast("Data imported successfully");
       setImportPreview(null);
-      window.location.reload();
+      window.location.href = "/";
     } catch {
       toast("Failed to import data", "error");
     }
@@ -96,27 +151,23 @@ export function DataManagement() {
   return (
     <>
       <div className="space-y-3">
-        <Button variant="secondary" className="w-full justify-start gap-3" onClick={handleExport}>
-          <Download className="h-4 w-4" />
-          Export Data
-        </Button>
+        <div className="rounded-2xl border border-border-subtle/70 bg-surface-overlay/45 p-2">
+          <Button variant="secondary" className="w-full justify-start gap-3" onClick={handleExport}>
+            <Download className="h-4 w-4" />
+            Export Data
+          </Button>
+        </div>
 
-        <Button
-          variant="secondary"
-          className="w-full justify-start gap-3"
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Upload className="h-4 w-4" />
-          Import Data
-        </Button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          className="hidden"
-          onChange={handleFileSelected}
-        />
-
+        <div className="rounded-2xl border border-border-subtle/70 bg-surface-overlay/45 p-2">
+          <Button
+            variant="secondary"
+            className="w-full justify-start gap-3"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="h-4 w-4" />
+            Import Data
+          </Button>
+        </div>
         <Button
           variant="ghost"
           className="w-full justify-start gap-3 text-error hover:text-error hover:bg-error/10"
@@ -125,15 +176,76 @@ export function DataManagement() {
           <Trash2 className="h-4 w-4" />
           Clear All Data
         </Button>
+        <p className="text-xs text-text-muted">
+          Export a backup before importing or clearing data.
+        </p>
+
+        <div className="rounded-2xl border border-border-subtle/70 bg-surface-overlay/35 p-3">
+          <div className="mb-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">
+              Load Sample Data
+            </p>
+            <p className="mt-1 text-xs text-text-muted">
+              Quickly explore the app with prebuilt habits and completion history.
+            </p>
+            <p className="mt-1 text-xs text-text-muted">
+              After loading sample data, you&apos;ll be returned to Home.
+            </p>
+          </div>
+          <div className="space-y-2">
+            {SAMPLE_IMPORTS.map((sample) => {
+              const Icon = sample.icon;
+              const loading = loadingSampleId === sample.id;
+              return (
+                <div
+                  key={sample.id}
+                  className="rounded-xl border border-border-subtle/60 bg-surface-paper/40 p-2"
+                >
+                  <Button
+                    variant="secondary"
+                    className="h-auto w-full justify-start gap-3 px-3 py-2"
+                    onClick={() => handleLoadSample(sample)}
+                    disabled={Boolean(loadingSampleId)}
+                  >
+                    <span className="rounded-lg border border-border-subtle/70 bg-surface-overlay/60 p-1.5">
+                      <Icon className="h-3.5 w-3.5" />
+                    </span>
+                    <span className="min-w-0 text-left">
+                      <span className="block text-sm">{loading ? "Loading..." : sample.label}</span>
+                      <span className="block text-xs font-normal text-text-muted">
+                        {sample.description}
+                      </span>
+                    </span>
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          className="hidden"
+          onChange={handleFileSelected}
+        />
       </div>
 
       {/* Import preview dialog */}
       <Dialog open={importPreview !== null} onOpenChange={() => setImportPreview(null)}>
         <DialogContent onClose={() => setImportPreview(null)}>
           <DialogHeader>
-            <DialogTitle>Import Data</DialogTitle>
+            <DialogTitle>{importPreview?.sourceLabel ? "Load Sample Data" : "Import Data"}</DialogTitle>
             <DialogDescription>
-              This will replace all existing data with {importPreview?.habits} habit
+              {importPreview?.sourceLabel ? (
+                <>
+                  This will load <strong>{importPreview.sourceLabel}</strong> and replace your
+                  current data.
+                </>
+              ) : (
+                <>This will replace all existing data with </>
+              )}{" "}
+              It includes {importPreview?.habits} habit
               {importPreview?.habits !== 1 ? "s" : ""} and{" "}
               {importPreview?.completions} completion
               {importPreview?.completions !== 1 ? "s" : ""}.
@@ -144,7 +256,7 @@ export function DataManagement() {
               Cancel
             </Button>
             <Button variant="primary" onClick={handleConfirmImport}>
-              Replace &amp; Import
+              {importPreview?.sourceLabel ? "Replace & Load Sample" : "Replace & Import"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -18,8 +18,11 @@ const VIEW_OPTIONS = [
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-2xl bg-surface-elevated backdrop-blur-xl border border-border p-5 space-y-4">
-      <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+    <section className="hf-panel rounded-3xl p-5 space-y-4">
+      <div className="border-b border-border-subtle/70 pb-3">
+        <p className="hf-kicker">Settings</p>
+        <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+      </div>
       {children}
     </section>
   );
@@ -35,7 +38,7 @@ function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className="flex items-center justify-between gap-4 rounded-2xl border border-border-subtle/60 bg-surface-overlay/45 px-3 py-2.5">
       <div className="min-w-0">
         <p className="text-sm font-medium text-text-primary">{label}</p>
         {description && (
@@ -106,7 +109,7 @@ export function SettingsContent() {
           label="Default view"
           description="Choose which view to show on launch"
         >
-          <div className="flex gap-1" role="radiogroup" aria-label="Default view">
+          <div className="hf-panel-muted flex gap-1 rounded-2xl p-1" role="radiogroup" aria-label="Default view">
             {VIEW_OPTIONS.map(({ value, label }) => {
               const active = settings.defaultView === value;
               return (
@@ -118,8 +121,8 @@ export function SettingsContent() {
                   className={cn(
                     "rounded-xl px-3 py-1.5 text-sm font-medium transition-colors duration-150",
                     active
-                      ? "bg-accent-blue/10 text-accent-blue"
-                      : "text-text-secondary hover:bg-surface-elevated hover:text-text-primary"
+                      ? "border border-accent-blue/20 bg-accent-blue/10 text-accent-blue shadow-[var(--shadow-editorial-sm)]"
+                      : "border border-transparent text-text-secondary hover:bg-surface-paper/70 hover:text-text-primary"
                   )}
                 >
                   {label}

--- a/src/components/settings/theme-toggle.tsx
+++ b/src/components/settings/theme-toggle.tsx
@@ -37,8 +37,8 @@ export function ThemeToggle({ theme, onChange, className }: ThemeToggleProps) {
               "flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium",
               "transition-colors duration-150",
               active
-                ? "bg-accent-blue/10 text-accent-blue"
-                : "text-text-secondary hover:bg-surface-elevated hover:text-text-primary"
+                ? "border border-accent-blue/20 bg-accent-blue/10 text-accent-blue shadow-[var(--shadow-editorial-sm)]"
+                : "border border-transparent text-text-secondary hover:bg-surface-tint/70 hover:text-text-primary"
             )}
           >
             <Icon className="h-4 w-4" />

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -27,17 +27,17 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center text-center py-16 px-4",
+        "hf-panel-strong mx-auto flex w-full max-w-3xl flex-col items-center justify-center rounded-3xl px-4 py-10 text-center sm:py-16",
         className
       )}
     >
       {Icon && (
-        <div className="mb-6 rounded-2xl bg-surface p-4 border border-border-subtle">
-          <Icon className="h-10 w-10 text-text-muted" />
+        <div className="mb-5 rounded-2xl border border-border-subtle bg-surface-tint/80 p-3 shadow-[var(--shadow-editorial-sm)] sm:mb-6 sm:p-4">
+          <Icon className="h-8 w-8 text-text-muted sm:h-10 sm:w-10" />
         </div>
       )}
-      <h3 className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
-      <p className="text-sm text-text-secondary max-w-xs mb-6">{description}</p>
+      <h3 className="mb-2 text-lg font-semibold text-text-primary">{title}</h3>
+      <p className="mb-5 max-w-xs text-sm text-text-secondary sm:mb-6">{description}</p>
       {actionLabel && actionHref && (
         <Link href={actionHref}>
           <Button>
@@ -80,7 +80,7 @@ export function NoStatsEmpty() {
 
 export function AllCompleteMessage() {
   return (
-    <div className="text-center py-8 animate-fade-in">
+    <div className="hf-panel-strong animate-fade-in rounded-3xl py-8 text-center">
       <div className="text-4xl mb-3">🎉</div>
       <h3 className="text-lg font-semibold text-text-primary mb-1">
         All done for today!

--- a/src/components/stats/aggregate-heatmap.tsx
+++ b/src/components/stats/aggregate-heatmap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import type { AggregateHeatmapData } from "@/lib/stats-utils";
 
 interface AggregateHeatmapProps {
@@ -29,11 +29,12 @@ export function AggregateHeatmap({ data, today }: AggregateHeatmapProps) {
     <Card>
       <CardHeader>
         <CardTitle>Activity</CardTitle>
+        <CardDescription>52-week completion intensity across all habits</CardDescription>
       </CardHeader>
 
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto rounded-2xl border border-border-subtle/70 bg-surface-overlay/45 p-3">
         {/* Month labels */}
-        <div className="flex ml-8 mb-1">
+        <div className="mb-1 ml-8 flex">
           {monthLabels.map(({ col, label }, i) => {
             const nextCol = monthLabels[i + 1]?.col ?? WEEKS;
             const span = nextCol - col;
@@ -69,7 +70,7 @@ export function AggregateHeatmap({ data, today }: AggregateHeatmapProps) {
                 {col.map((cell) => (
                   <div
                     key={cell.date}
-                    className="h-[10px] w-[10px] rounded-[2px]"
+                    className="h-[10px] w-[10px] rounded-[3px]"
                     style={{
                       backgroundColor:
                         cell.date > today
@@ -86,7 +87,7 @@ export function AggregateHeatmap({ data, today }: AggregateHeatmapProps) {
         </div>
 
         {/* Legend */}
-        <div className="flex items-center gap-2 mt-3 text-[10px] text-text-muted">
+        <div className="mt-3 flex items-center gap-2 text-[10px] text-text-muted">
           <span>Less</span>
           {[0, 0.25, 0.5, 0.75, 1].map((ratio, i) => (
             <div

--- a/src/components/stats/category-breakdown.tsx
+++ b/src/components/stats/category-breakdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import type { CategoryBreakdownEntry } from "@/lib/stats-utils";
 
 interface CategoryBreakdownProps {
@@ -14,6 +14,7 @@ export function CategoryBreakdown({ data }: CategoryBreakdownProps) {
       <Card>
         <CardHeader>
           <CardTitle>Categories</CardTitle>
+          <CardDescription>Habit mix and completion performance by category</CardDescription>
         </CardHeader>
         <p className="text-sm text-text-muted">
           No active habits to categorize.
@@ -26,10 +27,11 @@ export function CategoryBreakdown({ data }: CategoryBreakdownProps) {
     <Card>
       <CardHeader>
         <CardTitle>Categories</CardTitle>
+        <CardDescription>Habit mix and completion performance by category</CardDescription>
       </CardHeader>
 
-      <div className="flex flex-col sm:flex-row items-center gap-4">
-        <div className="h-48 w-48 shrink-0">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+        <div className="h-48 w-48 shrink-0 rounded-2xl border border-border-subtle/70 bg-surface-paper/45 p-2">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -51,9 +53,10 @@ export function CategoryBreakdown({ data }: CategoryBreakdownProps) {
                 contentStyle={{
                   backgroundColor: "var(--surface-elevated)",
                   border: "1px solid var(--border)",
-                  borderRadius: "12px",
-                  fontSize: "12px",
-                }}
+                    borderRadius: "12px",
+                    fontSize: "12px",
+                    boxShadow: "var(--shadow-editorial-md)",
+                  }}
                 formatter={(value: number | undefined, name: string | undefined) => [
                   `${value ?? 0} habit${value !== 1 ? "s" : ""}`,
                   name ?? "",
@@ -64,9 +67,12 @@ export function CategoryBreakdown({ data }: CategoryBreakdownProps) {
         </div>
 
         {/* Legend */}
-        <div className="flex flex-col gap-2 min-w-0">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
           {data.map((entry) => (
-            <div key={entry.category} className="flex items-center gap-2">
+            <div
+              key={entry.category}
+              className="flex items-center gap-2 rounded-xl border border-border-subtle/70 bg-surface-overlay/50 px-2.5 py-2"
+            >
               <div
                 className="h-3 w-3 rounded-full shrink-0"
                 style={{ backgroundColor: entry.color }}

--- a/src/components/stats/completion-trend-chart.tsx
+++ b/src/components/stats/completion-trend-chart.tsx
@@ -7,8 +7,9 @@ import {
   YAxis,
   ResponsiveContainer,
   Tooltip,
+  CartesianGrid,
 } from "recharts";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import type { DailyCompletionEntry } from "@/lib/stats-utils";
 
 interface CompletionTrendChartProps {
@@ -30,6 +31,7 @@ export function CompletionTrendChart({ data }: CompletionTrendChartProps) {
     <Card>
       <CardHeader>
         <CardTitle>Daily Completions</CardTitle>
+        <CardDescription>Completion volume across the selected date range</CardDescription>
       </CardHeader>
 
       <div className="h-64">
@@ -38,6 +40,7 @@ export function CompletionTrendChart({ data }: CompletionTrendChartProps) {
             data={data}
             margin={{ top: 4, right: 4, bottom: 0, left: -20 }}
           >
+            <CartesianGrid vertical={false} stroke="var(--border-subtle)" strokeDasharray="3 4" />
             <defs>
               <linearGradient id="trendFill" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.3} />
@@ -65,6 +68,7 @@ export function CompletionTrendChart({ data }: CompletionTrendChartProps) {
                 border: "1px solid var(--border)",
                 borderRadius: "12px",
                 fontSize: "12px",
+                boxShadow: "var(--shadow-editorial-md)",
               }}
               labelFormatter={(d) => String(d)}
             />
@@ -72,7 +76,7 @@ export function CompletionTrendChart({ data }: CompletionTrendChartProps) {
               type="monotone"
               dataKey="count"
               stroke="var(--chart-2)"
-              strokeWidth={2}
+              strokeWidth={2.5}
               fill="url(#trendFill)"
             />
           </AreaChart>

--- a/src/components/stats/habit-leaderboard.tsx
+++ b/src/components/stats/habit-leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Flame } from "lucide-react";
@@ -22,6 +22,7 @@ export function HabitLeaderboard({ entries, loading }: HabitLeaderboardProps) {
       <Card>
         <CardHeader>
           <CardTitle>Leaderboard</CardTitle>
+          <CardDescription>Top habits ranked by completion rate in this range</CardDescription>
         </CardHeader>
         <div className="space-y-3">
           {Array.from({ length: 5 }).map((_, i) => (
@@ -39,20 +40,21 @@ export function HabitLeaderboard({ entries, loading }: HabitLeaderboardProps) {
     <Card>
       <CardHeader>
         <CardTitle>Leaderboard</CardTitle>
+        <CardDescription>Top habits ranked by completion rate in this range</CardDescription>
       </CardHeader>
 
       {entries.length === 0 ? (
         <p className="text-sm text-text-muted">No habits to rank yet.</p>
       ) : (
         <>
-          <div className="divide-y divide-border-subtle">
+          <div className="space-y-2">
             {visible.map((entry, index) => (
               <div
                 key={entry.habit.id}
-                className="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
+                className="hf-row flex items-center gap-3 rounded-xl px-3 py-3"
               >
                 {/* Rank */}
-                <span className="text-sm font-semibold text-text-muted w-6 text-right shrink-0">
+                <span className="w-6 shrink-0 text-right text-sm font-semibold text-text-muted">
                   {index + 1}
                 </span>
 
@@ -65,7 +67,7 @@ export function HabitLeaderboard({ entries, loading }: HabitLeaderboardProps) {
                 </div>
 
                 {/* Progress bar */}
-                <div className="w-20 sm:w-28 h-2 rounded-full bg-border-subtle shrink-0">
+                <div className="h-2 w-20 shrink-0 rounded-full bg-border-subtle sm:w-28">
                   <div
                     className="h-full rounded-full transition-all"
                     style={{
@@ -81,7 +83,7 @@ export function HabitLeaderboard({ entries, loading }: HabitLeaderboardProps) {
                 </span>
 
                 {/* Streak */}
-                <div className="flex items-center gap-0.5 shrink-0">
+                <div className="flex shrink-0 items-center gap-0.5 rounded-full border border-border-subtle/70 bg-surface-paper/50 px-2 py-0.5">
                   <Flame className="h-3.5 w-3.5" style={{ color: "var(--chart-4)" }} />
                   <span className="text-xs text-text-muted">
                     {entry.currentStreak}

--- a/src/components/stats/overall-stats-row.tsx
+++ b/src/components/stats/overall-stats-row.tsx
@@ -19,15 +19,24 @@ interface StatCardProps {
 
 function StatCard({ icon: Icon, label, value, accent }: StatCardProps) {
   return (
-    <Card className="flex flex-col items-center text-center py-4">
+    <Card className="relative overflow-hidden py-4">
       <div
-        className="h-10 w-10 rounded-xl flex items-center justify-center mb-2 border border-border-subtle"
-        style={{ backgroundColor: "var(--surface-muted)" }}
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-1"
+        style={{ backgroundColor: accent, opacity: 0.7 }}
+      />
+      <div className="flex items-start gap-3">
+      <div
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border-subtle"
+        style={{ backgroundColor: "var(--surface-tint)" }}
       >
         <Icon className="h-5 w-5" style={{ color: accent }} />
       </div>
-      <div className="text-xl font-bold text-text-primary">{value}</div>
-      <div className="text-xs text-text-muted">{label}</div>
+      <div className="min-w-0">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">{label}</div>
+        <div className="mt-1 text-2xl font-bold text-text-primary">{value}</div>
+      </div>
+      </div>
     </Card>
   );
 }

--- a/src/components/stats/stats-date-range.tsx
+++ b/src/components/stats/stats-date-range.tsx
@@ -16,7 +16,11 @@ export function StatsDateRange({
   onSelect,
 }: StatsDateRangeProps) {
   return (
-    <div className="flex gap-2 flex-wrap">
+    <div className="hf-panel rounded-2xl p-2">
+      <div className="mb-2 px-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-muted">
+        Time Range
+      </div>
+      <div className="flex flex-wrap gap-2">
       {presets.map((preset) => (
         <Button
           key={preset.value}
@@ -31,6 +35,7 @@ export function StatsDateRange({
           {preset.label}
         </Button>
       ))}
+      </div>
     </div>
   );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -10,11 +10,11 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: "bg-surface-muted text-text-secondary border border-border-subtle",
-  success: "bg-success/12 text-success border border-success/30",
-  warning: "bg-warning/12 text-warning border border-warning/30",
-  error: "bg-error/12 text-error border border-error/30",
-  accent: "bg-accent-blue/12 text-accent-blue border border-accent-blue/30",
+  default: "bg-surface-tint/70 text-text-secondary border border-border-subtle",
+  success: "bg-success/10 text-success border border-success/25",
+  warning: "bg-warning/10 text-warning border border-warning/25",
+  error: "bg-error/10 text-error border border-error/25",
+  accent: "bg-accent-blue/10 text-accent-blue border border-accent-blue/25",
 };
 
 const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
@@ -23,7 +23,7 @@ const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
       <span
         ref={ref}
         className={cn(
-          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.22)]",
           variantStyles[variant],
           className
         )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,15 +14,15 @@ export interface ButtonProps
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    "bg-accent-blue text-white hover:brightness-110 shadow-[0_10px_24px_-16px_var(--accent-blue)]",
+    "border border-white/20 bg-accent-blue text-white hover:brightness-110 shadow-[0_14px_26px_-16px_var(--accent-blue)]",
   secondary:
-    "bg-surface-strong text-text-primary hover:bg-surface-elevated border border-border-subtle shadow-sm",
+    "bg-surface-paper text-text-primary hover:bg-surface-strong border border-border-subtle shadow-[var(--shadow-editorial-sm)]",
   ghost:
-    "text-text-secondary hover:bg-surface-muted hover:text-text-primary",
+    "text-text-secondary hover:bg-surface-tint/70 hover:text-text-primary",
   destructive:
-    "bg-error text-white hover:brightness-110 shadow-[0_10px_24px_-16px_var(--error)]",
+    "border border-white/15 bg-error text-white hover:brightness-110 shadow-[0_12px_24px_-16px_var(--error)]",
   outline:
-    "border border-border-subtle text-text-primary hover:bg-surface-muted",
+    "border border-border-subtle text-text-primary bg-surface-overlay/60 hover:bg-surface-tint/70",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -11,11 +11,11 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const variantStyles: Record<CardVariant, string> = {
   default:
-    "bg-surface backdrop-blur-2xl border border-border shadow-[0_20px_38px_-30px_rgba(20,16,10,0.55)]",
+    "bg-surface-panel backdrop-blur-2xl border border-border-subtle shadow-[var(--shadow-editorial-sm)]",
   elevated:
-    "bg-surface-strong backdrop-blur-2xl border border-border-subtle shadow-[0_22px_44px_-30px_rgba(20,16,10,0.65)]",
+    "bg-surface-paper backdrop-blur-2xl border border-border-subtle shadow-[var(--shadow-editorial-md)]",
   interactive:
-    "bg-surface backdrop-blur-2xl border border-border shadow-[0_20px_38px_-30px_rgba(20,16,10,0.55)] hover:-translate-y-0.5 hover:border-border-subtle hover:shadow-[0_24px_46px_-28px_rgba(20,16,10,0.72)] transition-all duration-200 cursor-pointer",
+    "bg-surface-panel backdrop-blur-2xl border border-border-subtle shadow-[var(--shadow-editorial-sm)] hover:-translate-y-0.5 hover:border-border-strong hover:shadow-[var(--shadow-editorial-md)] transition-all duration-200 cursor-pointer",
 };
 
 const Card = forwardRef<HTMLDivElement, CardProps>(
@@ -36,7 +36,7 @@ const CardHeader = forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("mb-4", className)} {...props} />
+  <div ref={ref} className={cn("mb-4 border-b border-border-subtle/70 pb-3", className)} {...props} />
 ));
 
 CardHeader.displayName = "CardHeader";
@@ -60,7 +60,7 @@ const CardDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-text-secondary mt-1", className)}
+    className={cn("mt-1 text-sm text-text-secondary", className)}
     {...props}
   />
 ));

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ function Dialog({ open, onOpenChange, children }: DialogProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
         ref={overlayRef}
-        className="fixed inset-0 bg-black/50 animate-overlay-fade"
+        className="fixed inset-0 bg-black/40 backdrop-blur-[2px] animate-overlay-fade"
         onClick={() => onOpenChange(false)}
         aria-hidden="true"
       />
@@ -59,8 +59,8 @@ const DialogContent = forwardRef<
   <div
     ref={ref}
     className={cn(
-      "w-full max-w-lg mx-4 rounded-2xl p-6",
-      "bg-surface-elevated backdrop-blur-xl border border-border shadow-xl",
+      "mx-4 w-full max-w-lg rounded-3xl p-6",
+      "bg-surface-paper/96 backdrop-blur-xl border border-border-subtle shadow-[var(--shadow-editorial-lg)]",
       className
     )}
     {...props}
@@ -68,7 +68,7 @@ const DialogContent = forwardRef<
     {onClose && (
       <button
         onClick={onClose}
-        className="absolute right-4 top-4 rounded-lg p-1 text-text-muted hover:text-text-primary transition-colors"
+        className="absolute right-4 top-4 rounded-xl border border-border-subtle/70 bg-surface-overlay/80 p-1.5 text-text-muted transition-colors hover:text-text-primary"
         aria-label="Close"
       >
         <X className="h-4 w-4" />
@@ -84,7 +84,7 @@ const DialogHeader = forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("mb-4", className)} {...props} />
+  <div ref={ref} className={cn("mb-4 border-b border-border-subtle/70 pb-3", className)} {...props} />
 ));
 
 DialogHeader.displayName = "DialogHeader";
@@ -121,7 +121,7 @@ const DialogFooter = forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("mt-6 flex justify-end gap-3", className)}
+    className={cn("mt-6 flex justify-end gap-3 border-t border-border-subtle/70 pt-4", className)}
     {...props}
   />
 ));

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -114,7 +114,7 @@ const DropdownMenuContent = forwardRef<HTMLDivElement, DropdownMenuContentProps>
         role="menu"
         className={cn(
           "absolute z-50 mt-1 min-w-[160px] overflow-hidden rounded-xl",
-          "bg-surface-strong backdrop-blur-2xl border border-border-subtle shadow-[0_18px_34px_-20px_rgba(20,16,10,0.7)]",
+          "bg-surface-paper/96 backdrop-blur-2xl border border-border-subtle shadow-[var(--shadow-editorial-lg)]",
           "p-1 animate-fade-in",
           align === "start" && "left-0",
           align === "center" && "left-1/2 -translate-x-1/2",
@@ -151,8 +151,8 @@ const DropdownMenuItem = forwardRef<HTMLButtonElement, DropdownMenuItemProps>(
           "flex w-full items-center rounded-lg px-2 py-1.5 text-sm",
           "transition-colors duration-150 outline-none",
           destructive
-            ? "text-error hover:bg-error/10"
-            : "text-text-primary hover:bg-surface-muted",
+            ? "text-error hover:bg-error/8"
+            : "text-text-primary hover:bg-surface-tint/75",
           className
         )}
         {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,10 +12,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-xl border border-border bg-surface-strong px-3 py-2 shadow-sm",
+          "flex h-10 w-full rounded-xl border border-border-subtle bg-surface-paper px-3 py-2 shadow-[var(--shadow-editorial-sm)]",
           "text-sm text-text-primary placeholder:text-text-muted",
           "transition-all duration-150",
-          "focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring",
+          "focus:outline-none focus:ring-2 focus:ring-ring/70 focus:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -23,7 +23,7 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
           "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full",
           "border-2 border-transparent transition-colors duration-200",
           "disabled:cursor-not-allowed disabled:opacity-50",
-          checked ? "bg-accent-blue" : "bg-border-subtle",
+          checked ? "bg-accent-emerald shadow-[0_10px_18px_-14px_var(--accent-emerald)]" : "bg-border-subtle",
           className
         )}
         {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,10 +12,10 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          "flex min-h-[80px] w-full rounded-lg border border-border-subtle bg-surface px-3 py-2",
+          "flex min-h-[80px] w-full resize-none rounded-xl border border-border-subtle bg-surface-paper px-3 py-2 shadow-[var(--shadow-editorial-sm)]",
           "text-sm text-text-primary placeholder:text-text-muted",
-          "transition-colors duration-150 resize-none",
-          "focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent",
+          "transition-colors duration-150",
+          "focus:outline-none focus:ring-2 focus:ring-ring/70 focus:border-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}


### PR DESCRIPTION
## Summary
- implement the Warm Editorial visual redesign across shared UI, navigation, and core routes
- add built-in sample data loaders in Settings (starter/standard/power user)
- generate and ship public sample datasets, plus a generator script
- fix post-import navigation to return users to Home and improve dark/mobile visual QA polish

## Validation
- npm run type-check
