### PR TITLE
feat(ui): add micro-animations and interaction polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "habitflow",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -350,3 +350,190 @@ h6 {
 .animate-cell-fill {
   animation: cell-fill 200ms ease-out;
 }
+
+/* ─── Staggered List Fade-In ────────────────────────────── */
+@keyframes stagger-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-stagger-in {
+  opacity: 0;
+  animation: stagger-in 300ms ease-out forwards;
+}
+
+/* ─── Shimmer Skeleton ──────────────────────────────────── */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--border-subtle) 25%,
+    color-mix(in srgb, var(--border-subtle) 60%, white 40%) 50%,
+    var(--border-subtle) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+}
+
+.dark .animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--border-subtle) 25%,
+    color-mix(in srgb, var(--border-subtle) 70%, var(--surface-elevated) 30%) 50%,
+    var(--border-subtle) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.8s ease-in-out infinite;
+}
+
+/* ─── Completion Ripple ─────────────────────────────────── */
+@keyframes completion-ripple {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 var(--ripple-color, rgba(37, 99, 235, 0.4));
+  }
+  50% {
+    transform: scale(1.15);
+    box-shadow: 0 0 0 8px var(--ripple-color, rgba(37, 99, 235, 0));
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 10px transparent;
+  }
+}
+
+.animate-completion-ripple {
+  animation: completion-ripple 400ms ease-out;
+}
+
+/* ─── Progress Ring Entry ───────────────────────────────── */
+@keyframes ring-draw {
+  from {
+    stroke-dashoffset: var(--ring-circumference);
+  }
+  to {
+    stroke-dashoffset: var(--ring-target-offset);
+  }
+}
+
+.animate-ring-draw {
+  animation: ring-draw 800ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/* ─── Confetti Particle ─────────────────────────────────── */
+@keyframes confetti-fall {
+  0% {
+    transform: translateY(0) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(120px) rotate(var(--confetti-rotation, 360deg)) scale(0);
+    opacity: 0;
+  }
+}
+
+@keyframes confetti-burst {
+  0% {
+    transform: translate(0, 0) scale(0);
+    opacity: 1;
+  }
+  20% {
+    transform: translate(var(--confetti-x), var(--confetti-y)) scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--confetti-x), calc(var(--confetti-y) + 60px)) scale(0);
+    opacity: 0;
+  }
+}
+
+/* ─── Animated Mesh Gradient Background ─────────────────── */
+@keyframes mesh-drift {
+  0%, 100% {
+    background-position: 0% 50%, 100% 50%, 50% 0%;
+  }
+  33% {
+    background-position: 100% 25%, 0% 75%, 75% 100%;
+  }
+  66% {
+    background-position: 50% 100%, 50% 0%, 0% 50%;
+  }
+}
+
+body {
+  --progress-warmth: 0;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: calc(0.06 + var(--progress-warmth, 0) * 0.08);
+  background:
+    radial-gradient(ellipse 600px 400px at 20% 30%, var(--bg-glow-1), transparent),
+    radial-gradient(ellipse 500px 350px at 80% 70%, var(--bg-glow-2), transparent),
+    radial-gradient(ellipse 450px 300px at 50% 50%, color-mix(in srgb, var(--accent-emerald) 12%, transparent), transparent);
+  animation: mesh-drift 30s ease-in-out infinite;
+  transition: opacity 2s ease;
+}
+
+/* ─── Streak Flame Flicker ──────────────────────────────── */
+@keyframes flame-flicker {
+  0%, 100% {
+    transform: scaleY(1) scaleX(1);
+    filter: brightness(1);
+  }
+  25% {
+    transform: scaleY(1.08) scaleX(0.95);
+    filter: brightness(1.1);
+  }
+  50% {
+    transform: scaleY(0.94) scaleX(1.04);
+    filter: brightness(0.95);
+  }
+  75% {
+    transform: scaleY(1.05) scaleX(0.97);
+    filter: brightness(1.05);
+  }
+}
+
+.animate-flame-flicker {
+  animation: flame-flicker 1.2s ease-in-out infinite;
+  transform-origin: bottom center;
+}
+
+/* ─── Celebration Glow Pulse ────────────────────────────── */
+@keyframes glow-pulse {
+  0% {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.02);
+  }
+}
+
+.animate-glow-pulse {
+  animation: glow-pulse 1.2s ease-out;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { PageContainer } from "@/components/layout/page-container";
 import { Header } from "@/components/layout/header";
 import { TodayView } from "@/components/dashboard/today-view";
@@ -53,6 +53,17 @@ export default function DashboardPage() {
   );
 
   useKeyboardShortcuts(digitShortcuts);
+
+  // Drive the ambient background warmth based on daily completion progress
+  const completedCount = scheduledHabits.filter((h) => isCompleted(h.id)).length;
+  const progressWarmth = scheduledHabits.length > 0
+    ? completedCount / scheduledHabits.length
+    : 0;
+
+  useEffect(() => {
+    document.body.style.setProperty("--progress-warmth", String(progressWarmth));
+    return () => { document.body.style.removeProperty("--progress-warmth"); };
+  }, [progressWarmth]);
 
   return (
     <PageContainer>

--- a/src/components/dashboard/daily-progress-ring.tsx
+++ b/src/components/dashboard/daily-progress-ring.tsx
@@ -14,10 +14,9 @@ export function DailyProgressRing({
   className,
 }: DailyProgressRingProps) {
   const percentage = total > 0 ? (completed / total) * 100 : 0;
-  // Radius tuned to the 120x120 viewBox with strokeWidth=8
   const RING_RADIUS = 54;
   const circumference = 2 * Math.PI * RING_RADIUS;
-  const strokeDashoffset = circumference - (percentage / 100) * circumference;
+  const targetOffset = circumference - (percentage / 100) * circumference;
 
   return (
     <div className={cn("relative inline-flex items-center justify-center", className)}>
@@ -31,7 +30,7 @@ export function DailyProgressRing({
           stroke="var(--border-subtle)"
           strokeWidth="8"
         />
-        {/* Progress ring */}
+        {/* Progress ring — animates from 0 on mount */}
         <circle
           cx="60"
           cy="60"
@@ -41,8 +40,12 @@ export function DailyProgressRing({
           strokeWidth="8"
           strokeLinecap="round"
           strokeDasharray={circumference}
-          strokeDashoffset={strokeDashoffset}
-          className="transition-all duration-500 ease-out"
+          strokeDashoffset={targetOffset}
+          className="animate-ring-draw"
+          style={{
+            "--ring-circumference": circumference,
+            "--ring-target-offset": targetOffset,
+          } as React.CSSProperties}
         />
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center">

--- a/src/components/dashboard/today-view.tsx
+++ b/src/components/dashboard/today-view.tsx
@@ -156,6 +156,7 @@ export function TodayView({
                 streak={showStreaks ? streak : 0}
                 onToggle={() => onToggle(habit.id)}
                 isLast={isLast}
+                index={idx}
               />
             );
           })}
@@ -178,18 +179,21 @@ interface ChecklistRowProps {
   streak: number;
   onToggle: () => void;
   isLast: boolean;
+  index: number;
 }
 
 const MIN_STREAK_DISPLAY = 2;
+const STAGGER_DELAY_MS = 40;
 
-function ChecklistRow({ habit, completed, streak, onToggle, isLast }: ChecklistRowProps) {
+function ChecklistRow({ habit, completed, streak, onToggle, isLast, index }: ChecklistRowProps) {
   return (
     <div
       className={cn(
-        "group relative flex items-center gap-3 px-4 py-3.5",
+        "group relative flex items-center gap-3 px-4 py-3.5 animate-stagger-in",
         "transition-all duration-150 hover:bg-surface-paper/40",
         !isLast && "border-b border-border-subtle/50"
       )}
+      style={{ animationDelay: `${index * STAGGER_DELAY_MS}ms` }}
     >
       <span
         aria-hidden
@@ -227,7 +231,7 @@ function ChecklistRow({ habit, completed, streak, onToggle, isLast }: ChecklistR
 
       {streak >= MIN_STREAK_DISPLAY && (
         <div className="flex items-center gap-1 rounded-full bg-surface-muted px-2 py-1 text-xs font-medium text-accent-amber shrink-0">
-          <Flame className="h-3.5 w-3.5" />
+          <Flame className="h-3.5 w-3.5 animate-flame-flicker" />
           <span>{streak}</span>
         </div>
       )}

--- a/src/components/habits/completion-toggle.tsx
+++ b/src/components/habits/completion-toggle.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { COMPLETION_ANIMATION_MS } from "@/lib/constants";
+
 import { Check } from "lucide-react";
 
 interface CompletionToggleProps {
@@ -23,7 +23,7 @@ export function CompletionToggle({
   const handleClick = () => {
     if (!completed) {
       setAnimating(true);
-      setTimeout(() => setAnimating(false), COMPLETION_ANIMATION_MS);
+      setTimeout(() => setAnimating(false), 400);
     }
     onToggle();
   };
@@ -39,12 +39,13 @@ export function CompletionToggle({
         "flex shrink-0 items-center justify-center rounded-full",
         "transition-all duration-200 border-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]",
         sizeClass,
-        animating && "animate-completion-bounce"
+        animating && "animate-completion-ripple"
       )}
       style={{
         borderColor: completed ? color : "var(--border-subtle)",
         backgroundColor: completed ? color : "var(--surface-paper)",
-      }}
+        "--ripple-color": `color-mix(in srgb, ${color} 40%, transparent)`,
+      } as React.CSSProperties}
       aria-label={completed ? "Mark as incomplete" : "Mark as complete"}
       aria-pressed={completed}
     >

--- a/src/components/shared/AnimatedCounter.tsx
+++ b/src/components/shared/AnimatedCounter.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore, useCallback } from "react";
+
+interface AnimatedCounterProps {
+  value: number;
+  duration?: number;
+  suffix?: string;
+  className?: string;
+}
+
+/**
+ * Animates a number from 0 to target value on mount.
+ * Uses requestAnimationFrame as an external store to satisfy
+ * the react-hooks/set-state-in-effect lint rule.
+ */
+export function AnimatedCounter({
+  value,
+  duration = 600,
+  suffix = "",
+  className,
+}: AnimatedCounterProps) {
+  const displayRef = useRef(0);
+  const rafRef = useRef<number>(undefined);
+  const startTimeRef = useRef<number>(undefined);
+  const listenersRef = useRef(new Set<() => void>());
+
+  const notify = useCallback(() => {
+    for (const listener of listenersRef.current) listener();
+  }, []);
+
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener);
+    return () => { listenersRef.current.delete(listener); };
+  }, []);
+
+  const getSnapshot = useCallback(() => displayRef.current, []);
+
+  const display = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    if (value === 0) {
+      displayRef.current = 0;
+      notify();
+      return;
+    }
+
+    startTimeRef.current = undefined;
+
+    const animate = (timestamp: number) => {
+      if (!startTimeRef.current) startTimeRef.current = timestamp;
+      const elapsed = timestamp - startTimeRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // Ease-out cubic for a satisfying deceleration
+      const eased = 1 - Math.pow(1 - progress, 3);
+      displayRef.current = Math.round(eased * value);
+      notify();
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [value, duration, notify]);
+
+  return (
+    <span className={className}>
+      {display}
+      {suffix}
+    </span>
+  );
+}

--- a/src/components/shared/Confetti.tsx
+++ b/src/components/shared/Confetti.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface ConfettiProps {
+  active: boolean;
+  particleCount?: number;
+}
+
+interface Particle {
+  id: number;
+  x: string;
+  y: string;
+  color: string;
+  rotation: string;
+  delay: string;
+  size: number;
+}
+
+const COLORS = [
+  "var(--accent-amber)",
+  "var(--accent-rose)",
+  "var(--accent-cyan)",
+  "var(--accent-violet)",
+  "var(--accent-emerald)",
+  "var(--accent-blue)",
+  "var(--accent-pink)",
+  "var(--accent-orange)",
+];
+
+const DURATION_MS = 1400;
+
+function generateParticles(count: number): Particle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const angle = (i / count) * Math.PI * 2;
+    const spread = 40 + Math.random() * 60;
+    return {
+      id: i,
+      x: `${Math.cos(angle) * spread}px`,
+      y: `${Math.sin(angle) * spread - 20}px`,
+      color: COLORS[i % COLORS.length],
+      rotation: `${Math.random() * 720 - 360}deg`,
+      delay: `${Math.random() * 150}ms`,
+      size: 4 + Math.random() * 4,
+    };
+  });
+}
+
+/**
+ * CSS-only confetti burst. When `active` is true, renders particles
+ * that animate outward and fade via CSS animations.
+ * Parent controls lifecycle — mount/unmount this component to replay.
+ */
+export function Confetti({ active, particleCount = 24 }: ConfettiProps) {
+  const particles = useMemo(() => generateParticles(particleCount), [particleCount]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden"
+    >
+      <div className="absolute left-1/2 top-1/2">
+        {particles.map((p) => (
+          <span
+            key={p.id}
+            className="absolute rounded-sm"
+            style={{
+              width: p.size,
+              height: p.size,
+              backgroundColor: p.color,
+              "--confetti-x": p.x,
+              "--confetti-y": p.y,
+              "--confetti-rotation": p.rotation,
+              animation: `confetti-burst ${DURATION_MS}ms ease-out forwards`,
+              animationDelay: p.delay,
+              opacity: 0,
+            } as React.CSSProperties}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Plus, BarChart3, CalendarCheck } from "lucide-react";
+import { Confetti } from "@/components/shared/Confetti";
 
 interface EmptyStateProps {
   icon?: React.ComponentType<{ className?: string }>;
@@ -27,7 +28,7 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "hf-panel-strong mx-auto flex w-full max-w-3xl flex-col items-center justify-center rounded-3xl px-4 py-10 text-center sm:py-16",
+        "hf-panel-strong mx-auto flex w-full max-w-3xl flex-col items-center justify-center rounded-3xl px-4 py-10 text-center sm:py-16 animate-fade-in",
         className
       )}
     >
@@ -80,14 +81,18 @@ export function NoStatsEmpty() {
 
 export function AllCompleteMessage() {
   return (
-    <div className="hf-panel-strong animate-fade-in rounded-3xl py-8 text-center">
-      <div className="text-4xl mb-3">🎉</div>
-      <h3 className="text-lg font-semibold text-text-primary mb-1">
-        All done for today!
-      </h3>
-      <p className="text-sm text-text-secondary">
-        Great job staying consistent. See you tomorrow!
-      </p>
+    <div className="hf-panel-strong relative animate-fade-in overflow-hidden rounded-3xl py-8 text-center">
+      <Confetti active />
+      <div className="animate-glow-pulse pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-b from-accent-amber/10 via-transparent to-transparent" />
+      <div className="relative z-[1]">
+        <div className="text-4xl mb-3">🎉</div>
+        <h3 className="text-lg font-semibold text-text-primary mb-1">
+          All done for today!
+        </h3>
+        <p className="text-sm text-text-secondary">
+          Great job staying consistent. See you tomorrow!
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/stats/overall-stats-row.tsx
+++ b/src/components/stats/overall-stats-row.tsx
@@ -3,6 +3,7 @@
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Activity, TrendingUp, Flame, Hash } from "lucide-react";
+import { AnimatedCounter } from "@/components/shared/AnimatedCounter";
 import type { OverallStatsResult } from "@/lib/stats-utils";
 
 interface OverallStatsRowProps {
@@ -13,13 +14,20 @@ interface OverallStatsRowProps {
 interface StatCardProps {
   icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
   label: string;
-  value: string | number;
+  value: number;
+  suffix?: string;
   accent: string;
+  index: number;
 }
 
-function StatCard({ icon: Icon, label, value, accent }: StatCardProps) {
+const STAGGER_DELAY_MS = 60;
+
+function StatCard({ icon: Icon, label, value, suffix, accent, index }: StatCardProps) {
   return (
-    <Card className="relative overflow-hidden py-4">
+    <Card
+      className="relative overflow-hidden py-4 animate-stagger-in"
+      style={{ animationDelay: `${index * STAGGER_DELAY_MS}ms` }}
+    >
       <div
         aria-hidden
         className="absolute inset-x-0 top-0 h-1"
@@ -34,7 +42,9 @@ function StatCard({ icon: Icon, label, value, accent }: StatCardProps) {
       </div>
       <div className="min-w-0">
         <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">{label}</div>
-        <div className="mt-1 text-2xl font-bold text-text-primary">{value}</div>
+        <div className="mt-1 text-2xl font-bold text-text-primary">
+          <AnimatedCounter value={value} suffix={suffix} />
+        </div>
       </div>
       </div>
     </Card>
@@ -59,24 +69,29 @@ export function OverallStatsRow({ stats, loading }: OverallStatsRowProps) {
         label="Active Habits"
         value={stats.totalActiveHabits}
         accent="var(--chart-1)"
+        index={0}
       />
       <StatCard
         icon={TrendingUp}
         label="Completion Rate"
-        value={`${stats.overallCompletionRate}%`}
+        value={stats.overallCompletionRate}
+        suffix="%"
         accent="var(--chart-2)"
+        index={1}
       />
       <StatCard
         icon={Flame}
         label="Best Streak"
         value={stats.bestCurrentStreak}
         accent="var(--chart-4)"
+        index={2}
       />
       <StatCard
         icon={Hash}
         label="Total Completions"
         value={stats.totalCompletions}
         accent="var(--chart-3)"
+        index={3}
       />
     </div>
   );

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -8,7 +8,7 @@ function Skeleton({ className, ...props }: SkeletonProps) {
   return (
     <div
       className={cn(
-        "animate-pulse rounded-lg bg-border-subtle",
+        "animate-shimmer rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Add staggered list entry animations, animated stat counters (AnimatedCounter component), and progress ring draw animation
- Add CSS-only confetti burst on all-complete state and completion ripple effect on habit toggles
- Add flame flicker animation on streak badges, shimmer skeleton loading, and ambient background warmth tied to daily progress
- Bump version from 1.0.0 to 1.1.0

## Test plan
- [ ] Verify habit checklist rows animate in with stagger delay on page load
- [ ] Verify progress ring animates from 0 to current progress on mount
- [ ] Complete all habits for today and confirm confetti burst appears
- [ ] Toggle a habit complete and confirm ripple animation on the checkbox
- [ ] Check stats page — counters should animate up from 0
- [ ] Verify skeleton loading states use shimmer instead of pulse
- [ ] Confirm dark mode renders all animations correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)